### PR TITLE
rez-pip fine grained control.

### DIFF
--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -58,8 +58,7 @@ def command(opts, parser, extra_arg_groups=None):
                 installed_variants.update(installed)
             if skipped is not None:
                 skipped_variants.update(skipped)
-        except Exception exc:
-            print exc, exc.__name__, type(exc).__name__
+        except:
             failed_variants.add(package)
     # print summary
     #

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -23,6 +23,10 @@ def setup_parser(parser, completions=False):
         help="install as released package; if not set, package is installed "
         "locally only")
     parser.add_argument(
+        "--variant", dest="variant",
+        help="Specify the variant requirements for package "
+        " default=platform,arch,os")
+    parser.add_argument(
         "PACKAGE",
         help="package to install or archive/url to install from")
 
@@ -43,7 +47,8 @@ def command(opts, parser, extra_arg_groups=None):
         opts.PACKAGE,
         pip_version=opts.pip_ver,
         python_version=opts.py_ver,
-        release=opts.release)
+        release=opts.release,
+        default_variant=opts.variant)
 
     # print summary
     #

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -231,6 +231,8 @@ config_schema = Schema({
     "memcached_uri":                                OptionalStrList,
     "local_packages_path":                          Str,
     "release_packages_path":                        Str,
+    "release_python_packages_path":                 OptionalStr,
+    "pip_default_variant":                          StrList,
     "dot_image_format":                             Str,
     "build_directory":                              Str,
     "documentation_url":                            Str,

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -231,7 +231,7 @@ config_schema = Schema({
     "memcached_uri":                                OptionalStrList,
     "local_packages_path":                          Str,
     "release_packages_path":                        Str,
-    "release_python_packages_path":                 OptionalStr,
+    "release_pip_packages_path":                    OptionalStr,
     "pip_default_variant":                          StrList,
     "dot_image_format":                             Str,
     "build_directory":                              Str,

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -248,7 +248,8 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
            "--install-option=--install-lib=%s" % destpath,
            "--install-option=--install-scripts=%s" % binpath,
            "--install-option=--install-headers=%s" % incpath,
-           "--install-option=--install-data=%s" % datapath]
+           "--install-option=--install-data=%s" % datapath,
+           "--ignore-installed"]
 
     if mode == InstallMode.no_deps:
         cmd.append("--no-deps")

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -216,7 +216,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
     #
     packages_path = config.local_packages_path
     if release:
-        packages_path = config.get("release_python_packages_path", config.release_packages_path)
+        packages_path = config.get("release_pip_packages_path", config.release_packages_path)
 
     if not os.path.exists(packages_path):
         print_warning("Package path does not exist: %s" % packages_path)

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -56,7 +56,7 @@ release_packages_path = "~/.rez/packages/int"
 
 # The path that Rez will deploy python packages to when rez-pip --release is used.
 # If this is not set release_packages_path will be used.
-release_python_packages_path = "~/.rez/packages/python"
+release_pip_packages_path = "~/.rez/packages/python"
 
 # Where temporary files go. Defaults to appropriate path depending on your
 # system - for example, *nix distributions will probably set this to "/tmp". It

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -41,9 +41,10 @@ import os
 # The package search path. Rez uses this to find packages. A package with the
 # same name and version in an earlier path takes precedence.
 packages_path = [
-    "~/packages",           # locally installed pkgs, not yet deployed
-    "~/.rez/packages/int",  # internally developed pkgs, deployed
-    "~/.rez/packages/ext",  # external (3rd party) pkgs, such as houdini, boost
+    "~/packages",             # locally installed pkgs, not yet deployed
+    "~/.rez/packages/int",    # internally developed pkgs, deployed
+    "~/.rez/packages/ext",    # external (3rd party) pkgs, such as houdini, boost
+    "~/.rez/packages/python", # external python pkgs, released with rez-pip
 ]
 
 # The path that Rez will locally install packages to when rez-build is used
@@ -52,6 +53,10 @@ local_packages_path = "~/packages"
 # The path that Rez will deploy packages to when rez-release is used. For
 # production use, you will probably want to change this to a site-wide location.
 release_packages_path = "~/.rez/packages/int"
+
+# The path that Rez will deploy python packages to when rez-pip --release is used.
+# If this is not set release_packages_path will be used.
+release_python_packages_path = "~/.rez/packages/python"
 
 # Where temporary files go. Defaults to appropriate path depending on your
 # system - for example, *nix distributions will probably set this to "/tmp". It
@@ -466,6 +471,10 @@ set_prompt = True
 # false.
 prefix_prompt = True
 
+###############################################################################
+# Pip
+###############################################################################
+pip_default_variant=["platform","arch","os"]
 
 ###############################################################################
 # Misc


### PR DESCRIPTION
## This pull request adds some fine grained control to rez-pip.

Added flags to rez-pip cli command.
 --variant
Example usage:

```
'rez-pip -r --variant platform,arch,os ...' would result in default behavior:
variants = [['platform-linux', 'arch-x86_64', 'os-CentOS-6.6', 'python-2.5']]

'rez-pip -r --variant platform ...' would result in:
variants = [['platform-linux', 'python-2.5']]

To get even more control we could do something like:
'rez-pip -r --variant platform,os-CentOS-6 ...' would result in:
variants = [['platform-linux', 'os-CentOS-6', 'python-2.5']]
```

---

Added config options:

```
release_python_packages_path = "~/.rez/packages/python" # default location for released python packages
pip_default_variant=["platform","arch","os"] # default variant requirements for rez-pip installed packages
```

Python-MAJOR.MINOR will always be added to the variant.
if release_python_packages_path is not set it will fall back on release_packages_path.

---

Added check to make sure release_python_packages_path is both existing and writable.
