### PR TITLE
Fix utils.which for symlinks with python <3.8 on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ docs/_build
 wiki/out
 LATEST_CHANGELOG.md
 __pycache__
+.vscode
+

--- a/src/rez/utils/which.py
+++ b/src/rez/utils/which.py
@@ -72,8 +72,14 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None, env=None):
             # Account for cmd possibly being a symlink. A symlink can be an
             # executable on windows without an extension. If it is, see if its
             # target's extension matches any of the expected path extensions.
-            #
             realfile = os.path.realpath(os.path.join(normdir, cmd)).lower()
+
+            # On windows and python < 3.8
+            # os.path.realpath leaves symlink and junctions unchanged
+            # https://docs.python.org/3/library/os.path.html#os.path.realpath
+            if os.path.islink(realfile):
+                realfile = os.readlink(realfile).lower()
+
             if any(realfile.endswith(x) for x in pathext):
                 files = [cmd]
             else:


### PR DESCRIPTION
# Problem

The implementation of `which` relies on `os.path.realpath` working on windows symlinks and junctions.
As stated in python documentation, this is the case only for python >=3.8
https://docs.python.org/3/library/os.path.html#os.path.realpath

A symlink is letft unchanged, but instead it can be read:
```py
>>> sys.version  # <3.8
'3.7.11 (tags/v3.7.11:9da28d2b342, Aug 10 2021, 15:34:44) [MSC v.1916 64 bit (AMD64)]'
>>> os.path.islink(path)
True
>>> path == os.path.realpath(path)  # Unchanged :'(
True
>>> path == os.readlink(path)
False
```

# Solution

This patch implements a fallback mechanism to read the link if it was not resolved.
