### PR TITLE
1279 add support for 3rd party prompt implementations in pwsh powershell

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -105,8 +105,11 @@ class PowerShellBase(Shell):
         return cls.syspaths
 
     def _bind_interactive_rez(self):
+        curr_prompt = os.getenv("REZ_CURRENT_PROMPT", "")
         if config.set_prompt and self.settings.prompt:
-            self._addline('Function prompt {"%s"}' % self.settings.prompt)
+            self.setenv("REZ_CURRENT_PROMPT", str(curr_prompt + self.settings.prompt))
+            if not self.settings.set_prompt_as_env:
+                self._addline('Function prompt {"%s"}' % str(curr_prompt + self.settings.prompt))
 
     def _additional_commands(self, executor):
         # Make .py launch within shell without extension.

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -5,6 +5,7 @@
 import os
 import re
 from subprocess import PIPE
+from io import open
 
 from rez.config import config
 from rez.vendor.six import six

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -191,7 +191,7 @@ class PowerShellBase(Shell):
                                    "rez-shell.%s" % self.file_extension())
 
         with open(target_file, 'w', encoding='utf-8') as f:
-            f.write(code)
+            f.write(u"%s" % code)
 
         cmd = []
         if pre_command:

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -189,7 +189,7 @@ class PowerShellBase(Shell):
         target_file = os.path.join(tmpdir,
                                    "rez-shell.%s" % self.file_extension())
 
-        with open(target_file, 'w') as f:
+        with open(target_file, 'w', encoding='utf-8') as f:
             f.write(code)
 
         cmd = []

--- a/src/rezplugins/shell/rezconfig
+++ b/src/rezplugins/shell/rezconfig
@@ -20,7 +20,9 @@ cmd:
 powershell:
     prompt: '> $ '
     additional_pathext: ['.PY']
+    set_prompt_as_env: false
 
 pwsh:
     prompt: '> $ '
     additional_pathext: ['.PY']
+    set_prompt_as_env: false

--- a/src/rezplugins/shell/rezconfig
+++ b/src/rezplugins/shell/rezconfig
@@ -18,11 +18,11 @@ cmd:
     additional_pathext: ['.PY']
 
 powershell:
-    prompt: '> $ '
+    prompt: '>'
     additional_pathext: ['.PY']
     set_prompt_as_env: false
 
 pwsh:
-    prompt: '> $ '
+    prompt: '>'
     additional_pathext: ['.PY']
     set_prompt_as_env: false


### PR DESCRIPTION
This PR adds support for setting of nested prompt decorators and for 3rd party prompts by adding an option to only set the prompt as an environment variable so it can be used in 3rd party prompts.

To support unicode setups (as in unicode prompt decoration) i also had to add unicode support to the powershell_base write operation in spawn_shell.

I also changed the default for the prompt in Powershell as the old default is really weird when using it repeated for nested shells.

Behavior for nested shells with new defaults:
![image](https://user-images.githubusercontent.com/243828/162642008-da4c3d99-c52f-4378-9143-e357b91fef30.png)

Example with custom unicode setup in oh-my-posh:
![image](https://user-images.githubusercontent.com/243828/162642037-ecf4d0d8-3d09-428f-9b77-60128e9dacd9.png)

It can even do Beer emojis ❤️ 
![image](https://user-images.githubusercontent.com/243828/162642061-8ea777db-af4c-48b3-b537-50d244f5fafd.png)

Fixes #1279 
