### PR TITLE
ResolvedContext.get_resolved_package() should return None for failure

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -438,7 +438,7 @@ class ResolvedContext(object):
         """Returns a `Variant` object or None if the package is not in the
         resolve.
         """
-        pkgs = [x for x in self._resolved_packages if x.name == name]
+        pkgs = [x for x in (self._resolved_packages or []) if x.name == name]
         return pkgs[0] if pkgs else None
 
     def copy(self):


### PR DESCRIPTION
Otherwise for `rez-pip --python-version 1.2.3 -i pandas` with non-existent python version, the following stacktrace will happen:
```
Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\user\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\user\rez\Scripts\rez\rez-pip.exe\__main__.py", line 7, in <module>
  File "c:\users\user\rez\lib\site-packages\rez\cli\_entry_points.py", line 183, in run_rez_pip
    return run("pip")
  File "c:\users\user\rez\lib\site-packages\rez\cli\_main.py", line 191, in run
    returncode = run_cmd()
  File "c:\users\user\rez\lib\site-packages\rez\cli\_main.py", line 183, in run_cmd
    return func(opts, opts.parser, extra_arg_groups)
  File "c:\users\user\rez\lib\site-packages\rez\cli\pip.py", line 73, in command
    extra_args=opts.extra)
  File "c:\users\user\rez\lib\site-packages\rez\pip.py", line 264, in pip_install_package
    py_exe, context = find_pip(pip_version, python_version)
  File "c:\users\user\rez\lib\site-packages\rez\pip.py", line 95, in find_pip
    python_version, pip_version=version
  File "c:\users\user\rez\lib\site-packages\rez\pip.py", line 203, in find_pip_from_context
    py_exe = find_python_in_context(context)
  File "c:\users\user\rez\lib\site-packages\rez\pip.py", line 142, in find_python_in_context
    python_package = context.get_resolved_package("python")
  File "c:\users\user\rez\lib\site-packages\rez\resolved_context.py", line 441, in get_resolved_package
    pkgs = [x for x in self._resolved_packages if x.name == name]
TypeError: 'NoneType' object is not iterable
```