### PR TITLE
integrate the entry for location mismatch error

### DIFF
--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -4,6 +4,7 @@
 
 from rez.utils.resources import ResourcePool, ResourceHandle
 from rez.utils.data_utils import cached_property
+from rez.utils.filesystem import compare_locaton
 from rez.plugin_managers import plugin_manager
 from rez.config import config
 from rez.exceptions import ResourceError
@@ -428,10 +429,8 @@ class PackageRepository(object):
 
         variables["repository_type"] = self.name()
 
-        if variables.get("location", self.location) != self.location:
-            raise ResourceError("location mismatch - requested %r, repository "
-                                "location is %r" % (variables["location"],
-                                                    self.location))
+        compare_locaton(variables.get("location", self.location), self.location)
+
         variables["location"] = self.location
 
         resource_cls = self.pool.get_resource_class(resource_key)
@@ -474,11 +473,7 @@ class PackageRepository(object):
                                     % (resource_handle.variables["repository_type"],
                                        self.name()))
 
-            if resource_handle.variables.get("location") != self.location:
-                raise ResourceError("location mismatch - requested %r, "
-                                    "repository location is %r "
-                                    % (resource_handle.variables["location"],
-                                       self.location))
+            compare_locaton(resource_handle.variables.get("location"), self.location)
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -4,7 +4,7 @@
 
 from rez.utils.resources import ResourcePool, ResourceHandle
 from rez.utils.data_utils import cached_property
-from rez.utils.filesystem import compare_locaton
+from rez.utils.filesystem import compare_location
 from rez.plugin_managers import plugin_manager
 from rez.config import config
 from rez.exceptions import ResourceError
@@ -429,7 +429,7 @@ class PackageRepository(object):
 
         variables["repository_type"] = self.name()
 
-        compare_locaton(variables.get("location", self.location), self.location)
+        compare_location(variables.get("location", self.location), self.location)
 
         variables["location"] = self.location
 
@@ -473,7 +473,7 @@ class PackageRepository(object):
                                     % (resource_handle.variables["repository_type"],
                                        self.name()))
 
-            compare_locaton(resource_handle.variables.get("location"), self.location)
+            compare_location(resource_handle.variables.get("location"), self.location)
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -699,7 +699,7 @@ def windows_long_path(dos_path):
 
     return path
 
-def compare_locaton(loc1, loc2):
+def compare_location(loc1, loc2):
     # It appears that sometimes, the handle location can differ to the
     # repo location even though they are the same path (different
     # mounts). We account for that here.

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -699,6 +699,7 @@ def windows_long_path(dos_path):
 
     return path
 
+
 def compare_location(loc1, loc2):
     # It appears that sometimes, the handle location can differ to the
     # repo location even though they are the same path (different
@@ -716,4 +717,3 @@ def compare_location(loc1, loc2):
         raise ResourceError("location mismatch - requested %r, "
                             "repository location is %r "
                             % (loc1, loc2))
-    

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -26,6 +26,7 @@ import uuid
 
 from rez.vendor.six import six
 from rez.utils.platform_ import platform_
+from rez.exceptions import ResourceError
 
 
 is_windows = platform.system() == "Windows"
@@ -697,3 +698,22 @@ def windows_long_path(dos_path):
         path = "\\\\?\\" + path
 
     return path
+
+def compare_locaton(loc1, loc2):
+    # It appears that sometimes, the handle location can differ to the
+    # repo location even though they are the same path (different
+    # mounts). We account for that here.
+    #
+    # https://github.com/nerdvegas/rez/pull/957
+    if not platform_.has_case_sensitive_filesystem:
+        loc1 = loc1.lower()
+        loc2 = loc2.lower()
+
+    if loc1 != loc2:
+        loc1 = canonical_path(loc1, platform_)
+
+    if loc1 != loc2:
+        raise ResourceError("location mismatch - requested %r, "
+                            "repository location is %r "
+                            % (loc1, loc2))
+    

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -28,7 +28,7 @@ from rez.utils.resources import cached_property
 from rez.utils.logging_ import print_warning, print_info
 from rez.utils.memcached import memcached, pool_memcached_connections
 from rez.utils.filesystem import make_path_writable, \
-    canonical_path, is_subdirectory
+    canonical_path, is_subdirectory, compare_locaton
 from rez.utils.platform_ import platform_
 from rez.utils.yaml import load_yaml
 from rez.config import config
@@ -815,19 +815,7 @@ class FileSystemPackageRepository(PackageRepository):
                                     "repository_type is %r"
                                     % (repository_type, self.name()))
 
-            # It appears that sometimes, the handle location can differ to the
-            # repo location even though they are the same path (different
-            # mounts). We account for that here.
-            #
-            # https://github.com/nerdvegas/rez/pull/957
-            #
-            if location != self.location:
-                location = canonical_path(location, platform_)
-
-            if location != self.location:
-                raise ResourceError("location mismatch - requested %r, "
-                                    "repository location is %r "
-                                    % (location, self.location))
+            compare_locaton(location, self.location)
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -28,7 +28,7 @@ from rez.utils.resources import cached_property
 from rez.utils.logging_ import print_warning, print_info
 from rez.utils.memcached import memcached, pool_memcached_connections
 from rez.utils.filesystem import make_path_writable, \
-    canonical_path, is_subdirectory, compare_locaton
+    canonical_path, is_subdirectory, compare_location
 from rez.utils.platform_ import platform_
 from rez.utils.yaml import load_yaml
 from rez.config import config
@@ -815,7 +815,7 @@ class FileSystemPackageRepository(PackageRepository):
                                     "repository_type is %r"
                                     % (repository_type, self.name()))
 
-            compare_locaton(location, self.location)
+            compare_location(location, self.location)
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self


### PR DESCRIPTION
os.path.realpath and pathlib.resolve() have different behavior in py3.7 and py3.7+

In python-3.7, os.path.realpath(path) return the drive location like `l:\opt\rez\2.103.4\platform-windows`
But in python-3.8, it will return the unc path like `\\\\studio-dfs\\studio\\...`

I still came across with location mismatched error in some `net use` drive in py3.8 and py3.9 and found out that the location mismatch error in rez.package_repository was not fixed

```
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\utils\data_utils.py", line 566, in func
     value = getattr(self.wrapped, key, None)
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\utils\data_utils.py", line 260, in __get__
     result = self.func(instance)
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\package_resources.py", line 374, in root
     return self._root()
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\package_resources.py", line 511, in _root
     if self.base is None:
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\utils\data_utils.py", line 566, in func
     value = getattr(self.wrapped, key, None)
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\package_resources.py", line 535, in wrapped
     return self.parent
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\utils\data_utils.py", line 260, in __get__
     result = self.func(instance)
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rezplugins\package_repository\filesystem.py", line 285, in parent
     package = self._repository.get_resource(
   File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\package_repository.py", line 453, in get_resource
     handle = self.make_resource_handle(resource_key, **variables)
  File "l:\opt\rez\2.103.4\platform-windows\python-3.9\lib\site-packages\rez\package_repository.py", line 431, in make_resource_handle
    raise ResourceError("location mismatch - requested %r, repository "
rez.exceptions.ResourceError: location mismatch - requested 'l:\\apps\\studio\\prod', repository location is '\\\\studio-dfs\\studio\\apps\\studio\\prod'
```