### PR TITLE
fix accidental skip of fail in benchmarking ci

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -107,9 +107,11 @@ jobs:
 
       - name: Git commit and push
         run: |
-          git add --all
-          git commit \
-            -m "Generated from GitHub "${{ github.workflow }}" Workflow" \
-            && git push origin master \
-            || echo "Nothing new to commit"
+          if [[ "$(git status --porcelain)" == "" ]]; then
+            echo "Nothing new to commit"
+          else
+            git add --all
+            git commit -m "Generated from GitHub "${{ github.workflow }}" Workflow"
+            git push origin master
+          fi
         working-directory: src


### PR DESCRIPTION
partially addresses #1328 - note that I still expect a fail (for user permissions reasons), but the fail should no longer be silent.
Signed-off-by: ajohns <nerdvegas@gmail.com>