### PR TITLE
Use forward slashes in PowerShell

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -243,10 +243,8 @@ class PowerShellBase(Shell):
         return result
 
     def normalize_path(self, path):
-        if platform_.name == "windows":
-            return to_windows_path(path)
-        else:
-            return path
+        # CMake requires forward slashes and powershell handles them fine
+        return path.replace('\\\\', '/').repace('\\', '/')
 
     def _saferefenv(self, key):
         pass

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -244,7 +244,7 @@ class PowerShellBase(Shell):
 
     def normalize_path(self, path):
         # CMake requires forward slashes and powershell handles them fine
-        return path.replace('\\\\', '/').repace('\\', '/')
+        return path.replace('\\\\', '/').replace('\\', '/')
 
     def _saferefenv(self, key):
         pass


### PR DESCRIPTION
PowerShell consumes forward slashes in path names just fine. CMake occasionally barfs on backslashes. Therefore this PR just uses forward slashes for pwsh and everything is happy.