### PR TITLE
allow benchmarking workflow to write to master

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -84,6 +84,12 @@ jobs:
           ref: master
           path: src
 
+          # This is a PAT from an Admin user. We do this in order to be able to write to a
+          # protected branch (master) from this workflow.
+          # See https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/14
+          #
+          token: "${{ secrets.GH_ACTION_TOKEN }}"
+
       # Note failing due to
       # https://github.com/actions/virtual-environments/issues/675
       #


### PR DESCRIPTION
Fixes #1328
See https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/14
Signed-off-by: ajohns <nerdvegas@gmail.com>