### PR TITLE
working with embedded python scanning rezplugins

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -319,6 +319,8 @@ class RezPluginManager(object):
             else:
                 try:
                     module_path = os.path.join(importer.path, name)
+                # Ignore execution failures due to missing `importer.path`,
+                # when rez is packaged as a single application via Pyinstaller or PyOxidizer.
                 except AttributeError:
                     continue
                 init_path = os.path.join(module_path, "rezplugins", "__init__.py")

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -317,7 +317,10 @@ class RezPluginManager(object):
                     module_path = os.path.join(importer.archive, name)
 
             else:
-                module_path = os.path.join(importer.path, name)
+                try:
+                    module_path = os.path.join(importer.path, name)
+                except AttributeError:
+                    continue
                 init_path = os.path.join(module_path, "rezplugins", "__init__.py")
                 if not os.path.isfile(init_path):
                     continue


### PR DESCRIPTION
This PR wants to improve working with embedded python scanning rez-plugins,
allow us to use [Pyinstaller ](https://github.com/pyinstaller/pyinstaller) and [PyOxidizer](https://github.com/indygreg/PyOxidizer) to make rez as a single application to deploy.

Below is a demo 
[rez-2.111.3.zip](https://github.com/AcademySoftwareFoundation/rez/files/9335504/rez-2.111.3.zip)
