### PR TITLE
Replace nerdvegas with aswf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,18 +51,18 @@
 -  remove references to nerdvegas in comments [\#1312](https://github.com/AcademySoftwareFoundation/rez/pull/1312) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.109.0 (2022-04-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.109.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.108.0...2.109.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.109.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.108.0...2.109.0)
 
 **Merged pull requests:**
 
-- Feature/1256 add git bash shell plugin [\#1280](https://github.com/nerdvegas/rez/pull/1280) ([nerdvegas](https://github.com/nerdvegas))
+- Feature/1256 add git bash shell plugin [\#1280](https://github.com/AcademySoftwareFoundation/rez/pull/1280) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add git-bash shell plugin [\#1256](https://github.com/nerdvegas/rez/issues/1256)
+- add git-bash shell plugin [\#1256](https://github.com/AcademySoftwareFoundation/rez/issues/1256)
 
 ## 2.108.0 (2022-04-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.108.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.107.0...2.108.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.108.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.107.0...2.108.0)
 
 **Notes**
 
@@ -77,268 +77,268 @@ Please be aware of this change in behavior in case it affects you.
 
 **Merged pull requests:**
 
-- Feature/1269 formalize paths in package commands [\#1273](https://github.com/nerdvegas/rez/pull/1273) ([nerdvegas](https://github.com/nerdvegas))
+- Feature/1269 formalize paths in package commands [\#1273](https://github.com/AcademySoftwareFoundation/rez/pull/1273) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- formalize paths in package commands [\#1269](https://github.com/nerdvegas/rez/issues/1269)
+- formalize paths in package commands [\#1269](https://github.com/AcademySoftwareFoundation/rez/issues/1269)
 
 ## 2.107.0 (2022-04-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.107.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.106.0...2.107.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.107.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.106.0...2.107.0)
 
 **Merged pull requests:**
 
-- Feature/1271 improve shell parameterization in tests [\#1272](https://github.com/nerdvegas/rez/pull/1272) ([nerdvegas](https://github.com/nerdvegas))
+- Feature/1271 improve shell parameterization in tests [\#1272](https://github.com/AcademySoftwareFoundation/rez/pull/1272) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- improve shell parameterization in tests [\#1271](https://github.com/nerdvegas/rez/issues/1271)
+- improve shell parameterization in tests [\#1271](https://github.com/AcademySoftwareFoundation/rez/issues/1271)
 
 ## 2.106.0 (2022-03-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.106.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.105.0...2.106.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.106.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.105.0...2.106.0)
 
 **Merged pull requests:**
 
-- added package fam removal func, and tests [\#1252](https://github.com/nerdvegas/rez/pull/1252) ([nerdvegas](https://github.com/nerdvegas))
+- added package fam removal func, and tests [\#1252](https://github.com/AcademySoftwareFoundation/rez/pull/1252) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add ability to delete package family [\#1248](https://github.com/nerdvegas/rez/issues/1248)
+- add ability to delete package family [\#1248](https://github.com/AcademySoftwareFoundation/rez/issues/1248)
 
 ## 2.105.0 (2022-03-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.105.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.10...2.105.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.105.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.10...2.105.0)
 
 **Merged pull requests:**
 
-- add package filter tests, fix 1237 [\#1238](https://github.com/nerdvegas/rez/pull/1238) ([nerdvegas](https://github.com/nerdvegas))
+- add package filter tests, fix 1237 [\#1238](https://github.com/AcademySoftwareFoundation/rez/pull/1238) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-test breaks with packages that do not have a timestamp attribute [\#1237](https://github.com/nerdvegas/rez/issues/1237)
+- rez-test breaks with packages that do not have a timestamp attribute [\#1237](https://github.com/AcademySoftwareFoundation/rez/issues/1237)
 
 ## 2.104.10 (2022-03-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.10) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.9...2.104.10)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.10) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.9...2.104.10)
 
 **Merged pull requests:**
 
-- fix: make cmake install directives whitespace friendly [\#1244](https://github.com/nerdvegas/rez/pull/1244) ([maxnbk](https://github.com/maxnbk))
+- fix: make cmake install directives whitespace friendly [\#1244](https://github.com/AcademySoftwareFoundation/rez/pull/1244) ([maxnbk](https://github.com/maxnbk))
 
 **Closed issues:**
 
-- rez_install_files with LOCAL_SYMLINK fails when an input file has whitespaces in its name [\#553](https://github.com/nerdvegas/rez/issues/553)
+- rez_install_files with LOCAL_SYMLINK fails when an input file has whitespaces in its name [\#553](https://github.com/AcademySoftwareFoundation/rez/issues/553)
 
 ## 2.104.9 (2022-03-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.9) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.8...2.104.9)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.9) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.8...2.104.9)
 
 **Merged pull requests:**
 
-- Implement #1196 [\#1199](https://github.com/nerdvegas/rez/pull/1199) ([instinct-vfx](https://github.com/instinct-vfx))
+- Implement #1196 [\#1199](https://github.com/AcademySoftwareFoundation/rez/pull/1199) ([instinct-vfx](https://github.com/instinct-vfx))
 
 **Closed issues:**
 
-- Switch `get_syspaths` from `REG` to `Get-ItemProperty` in Powershell shell plugins [\#1196](https://github.com/nerdvegas/rez/issues/1196)
+- Switch `get_syspaths` from `REG` to `Get-ItemProperty` in Powershell shell plugins [\#1196](https://github.com/AcademySoftwareFoundation/rez/issues/1196)
 
 ## 2.104.8 (2022-03-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.8) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.7...2.104.8)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.8) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.7...2.104.8)
 
 **Merged pull requests:**
 
-- Re-enable py3 workflow in windows.yaml [\#1232](https://github.com/nerdvegas/rez/pull/1232) ([instinct-vfx](https://github.com/instinct-vfx))
-- fix: address zsh install message displaying wrong completion script [\#1235](https://github.com/nerdvegas/rez/pull/1235) ([maxnbk](https://github.com/maxnbk))
-- Explicit fail when python executable is not found [\#1236](https://github.com/nerdvegas/rez/pull/1236) ([aboellinger](https://github.com/aboellinger))
+- Re-enable py3 workflow in windows.yaml [\#1232](https://github.com/AcademySoftwareFoundation/rez/pull/1232) ([instinct-vfx](https://github.com/instinct-vfx))
+- fix: address zsh install message displaying wrong completion script [\#1235](https://github.com/AcademySoftwareFoundation/rez/pull/1235) ([maxnbk](https://github.com/maxnbk))
+- Explicit fail when python executable is not found [\#1236](https://github.com/AcademySoftwareFoundation/rez/pull/1236) ([aboellinger](https://github.com/aboellinger))
 
 **Closed issues:**
 
-- Typo on install message [\#1186](https://github.com/nerdvegas/rez/issues/1186)
+- Typo on install message [\#1186](https://github.com/AcademySoftwareFoundation/rez/issues/1186)
 
 ## 2.104.7 (2022-02-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.7) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.6...2.104.7)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.7) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.6...2.104.7)
 
 **Merged pull requests:**
 
-- fixed logic fail in wiki workflow [\#1220](https://github.com/nerdvegas/rez/pull/1220) ([nerdvegas](https://github.com/nerdvegas))
+- fixed logic fail in wiki workflow [\#1220](https://github.com/AcademySoftwareFoundation/rez/pull/1220) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- fix wiki regression in v2.104.6 [\#1219](https://github.com/nerdvegas/rez/issues/1219)
+- fix wiki regression in v2.104.6 [\#1219](https://github.com/AcademySoftwareFoundation/rez/issues/1219)
 
 ## 2.104.6 (2022-02-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.6) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.5...2.104.6)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.6) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.5...2.104.6)
 
 **Merged pull requests:**
 
-- Issue 1214 spdx enforce [\#1215](https://github.com/nerdvegas/rez/pull/1215) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1214 spdx enforce [\#1215](https://github.com/AcademySoftwareFoundation/rez/pull/1215) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add workflow to enforce copyright [\#1214](https://github.com/nerdvegas/rez/issues/1214)
+- add workflow to enforce copyright [\#1214](https://github.com/AcademySoftwareFoundation/rez/issues/1214)
 
 ## 2.104.5 (2022-02-15)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.5) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.4...2.104.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.4...2.104.5)
 
 **Merged pull requests:**
 
-- switched to SPDX copyright notices [\#1213](https://github.com/nerdvegas/rez/pull/1213) ([nerdvegas](https://github.com/nerdvegas))
+- switched to SPDX copyright notices [\#1213](https://github.com/AcademySoftwareFoundation/rez/pull/1213) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- replace copyrights with SPDX form [\#1201](https://github.com/nerdvegas/rez/issues/1201)
+- replace copyrights with SPDX form [\#1201](https://github.com/AcademySoftwareFoundation/rez/issues/1201)
 
 ## 2.104.4 (2022-02-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.3...2.104.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.3...2.104.4)
 
 **Merged pull requests:**
 
-- remove nerdvegas refs in wiki [\#1212](https://github.com/nerdvegas/rez/pull/1212) ([nerdvegas](https://github.com/nerdvegas))
+- remove nerdvegas refs in wiki [\#1212](https://github.com/AcademySoftwareFoundation/rez/pull/1212) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.104.3 (2022-02-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.2...2.104.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.2...2.104.3)
 
 **Merged pull requests:**
 
-- fixed wiki bugs [\#1211](https://github.com/nerdvegas/rez/pull/1211) ([nerdvegas](https://github.com/nerdvegas))
+- fixed wiki bugs [\#1211](https://github.com/AcademySoftwareFoundation/rez/pull/1211) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- fix nuked wiki [\#1210](https://github.com/nerdvegas/rez/issues/1210)
+- fix nuked wiki [\#1210](https://github.com/AcademySoftwareFoundation/rez/issues/1210)
 
 ## 2.104.2 (2022-02-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.1...2.104.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.1...2.104.2)
 
 **Merged pull requests:**
 
-- Issue 1206 wiki gpl rm [\#1207](https://github.com/nerdvegas/rez/pull/1207) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1206 wiki gpl rm [\#1207](https://github.com/AcademySoftwareFoundation/rez/pull/1207) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- remove GPL3 code from update-wiki.py [\#1206](https://github.com/nerdvegas/rez/issues/1206)
+- remove GPL3 code from update-wiki.py [\#1206](https://github.com/AcademySoftwareFoundation/rez/issues/1206)
 
 ## 2.104.1 (2022-02-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.104.0...2.104.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.104.0...2.104.1)
 
 **Merged pull requests:**
 
-- Fix aliases in windows powershell/pwsh [\#1192](https://github.com/nerdvegas/rez/pull/1192) ([koaleksa](https://github.com/koaleksa))
+- Fix aliases in windows powershell/pwsh [\#1192](https://github.com/AcademySoftwareFoundation/rez/pull/1192) ([koaleksa](https://github.com/koaleksa))
 
 **Closed issues:**
 
-- Aliases broken on windows when using powershell [\#1191](https://github.com/nerdvegas/rez/issues/1191)
+- Aliases broken on windows when using powershell [\#1191](https://github.com/AcademySoftwareFoundation/rez/issues/1191)
 
 ## 2.104.0 (2022-02-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.104.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.103.4...2.104.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.104.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.103.4...2.104.0)
 
 **Merged pull requests:**
 
-- windows CI upgrade [\#1185](https://github.com/nerdvegas/rez/pull/1185) ([nerdvegas](https://github.com/nerdvegas))
+- windows CI upgrade [\#1185](https://github.com/AcademySoftwareFoundation/rez/pull/1185) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- windows gh actions issue [\#1181](https://github.com/nerdvegas/rez/issues/1181)
+- windows gh actions issue [\#1181](https://github.com/AcademySoftwareFoundation/rez/issues/1181)
 
 ## 2.103.4 (2021-12-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.103.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.103.3...2.103.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.103.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.103.3...2.103.4)
 
 **Merged pull requests:**
 
-- reimplement which [\#1182](https://github.com/nerdvegas/rez/pull/1182) ([nerdvegas](https://github.com/nerdvegas))
+- reimplement which [\#1182](https://github.com/AcademySoftwareFoundation/rez/pull/1182) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Whichcraft not caring about executable symlinks on windows that do not have the extension of an executable [\#1178](https://github.com/nerdvegas/rez/issues/1178)
+- Whichcraft not caring about executable symlinks on windows that do not have the extension of an executable [\#1178](https://github.com/AcademySoftwareFoundation/rez/issues/1178)
 
 ## 2.103.3 (2021-12-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.103.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.103.2...2.103.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.103.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.103.2...2.103.3)
 
 **Merged pull requests:**
 
-- removed sortedcontainers vendored lib [\#1180](https://github.com/nerdvegas/rez/pull/1180) ([nerdvegas](https://github.com/nerdvegas))
+- removed sortedcontainers vendored lib [\#1180](https://github.com/AcademySoftwareFoundation/rez/pull/1180) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.103.2 (2021-12-15)
-[Source](https://github.com/nerdvegas/rez/tree/2.103.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.103.1...2.103.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.103.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.103.1...2.103.2)
 
 **Merged pull requests:**
 
-- Uses Set-Item rather than $Env: to configure powershell environment variables. [\#1176](https://github.com/nerdvegas/rez/pull/1176) ([hutchinson](https://github.com/hutchinson))
+- Uses Set-Item rather than $Env: to configure powershell environment variables. [\#1176](https://github.com/AcademySoftwareFoundation/rez/pull/1176) ([hutchinson](https://github.com/hutchinson))
 
 **Closed issues:**
 
-- Environment variables containing brackets break powershell shell [\#1175](https://github.com/nerdvegas/rez/issues/1175)
+- Environment variables containing brackets break powershell shell [\#1175](https://github.com/AcademySoftwareFoundation/rez/issues/1175)
 
 ## 2.103.1 (2021-12-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.103.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.103.0...2.103.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.103.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.103.0...2.103.1)
 
 **Merged pull requests:**
 
-- fix pwsh shell not exiting with correct error code [\#1174](https://github.com/nerdvegas/rez/pull/1174) ([nerdvegas](https://github.com/nerdvegas))
+- fix pwsh shell not exiting with correct error code [\#1174](https://github.com/AcademySoftwareFoundation/rez/pull/1174) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Build passes when build_command fails while using powershell as default_shell on windows [\#1099](https://github.com/nerdvegas/rez/issues/1099)
+- Build passes when build_command fails while using powershell as default_shell on windows [\#1099](https://github.com/AcademySoftwareFoundation/rez/issues/1099)
 
 ## 2.103.0 (2021-12-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.103.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.102.1...2.103.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.103.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.102.1...2.103.0)
 
 **Merged pull requests:**
 
-- fix 'NoneType' object has no attribute 'conflicts_with' [\#1173](https://github.com/nerdvegas/rez/pull/1173) ([nerdvegas](https://github.com/nerdvegas))
+- fix 'NoneType' object has no attribute 'conflicts_with' [\#1173](https://github.com/AcademySoftwareFoundation/rez/pull/1173) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- AttributeError: 'NoneType' object has no attribute 'conflicts_with' when rez-env a package [\#1150](https://github.com/nerdvegas/rez/issues/1150)
+- AttributeError: 'NoneType' object has no attribute 'conflicts_with' when rez-env a package [\#1150](https://github.com/AcademySoftwareFoundation/rez/issues/1150)
 
 ## 2.102.1 (2021-12-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.102.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.102.0...2.102.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.102.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.102.0...2.102.1)
 
 **Merged pull requests:**
 
-- rez-pip fix for packages with underscores in name [\#1172](https://github.com/nerdvegas/rez/pull/1172) ([nerdvegas](https://github.com/nerdvegas))
+- rez-pip fix for packages with underscores in name [\#1172](https://github.com/AcademySoftwareFoundation/rez/pull/1172) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-pip error with inconsistency between underscores and dashes [\#1159](https://github.com/nerdvegas/rez/issues/1159)
+- rez-pip error with inconsistency between underscores and dashes [\#1159](https://github.com/AcademySoftwareFoundation/rez/issues/1159)
 
 ## 2.102.0 (2021-12-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.102.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.101.0...2.102.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.102.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.101.0...2.102.0)
 
 **Merged pull requests:**
 
-- Update sortedcontainers for Python 3.10 compatibility [\#1169](https://github.com/nerdvegas/rez/pull/1169) ([stilllman](https://github.com/stilllman))
+- Update sortedcontainers for Python 3.10 compatibility [\#1169](https://github.com/AcademySoftwareFoundation/rez/pull/1169) ([stilllman](https://github.com/stilllman))
 
 **Closed issues:**
 
-- Incompatibility with Python 3.10 [\#1168](https://github.com/nerdvegas/rez/issues/1168)
+- Incompatibility with Python 3.10 [\#1168](https://github.com/AcademySoftwareFoundation/rez/issues/1168)
 
 ## 2.101.0 (2021-12-09)
-[Source](https://github.com/nerdvegas/rez/tree/2.101.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.100.2...2.101.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.101.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.100.2...2.101.0)
 
 **Merged pull requests:**
 
-- benchmarking updates [\#1171](https://github.com/nerdvegas/rez/pull/1171) ([nerdvegas](https://github.com/nerdvegas))
+- benchmarking updates [\#1171](https://github.com/AcademySoftwareFoundation/rez/pull/1171) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.100.2 (2021-12-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.100.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.100.1...2.100.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.100.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.100.1...2.100.2)
 
 **Merged pull requests:**
 
-- sonarcloud flagged bugs (4) [\#1167](https://github.com/nerdvegas/rez/pull/1167) ([nerdvegas](https://github.com/nerdvegas))
+- sonarcloud flagged bugs (4) [\#1167](https://github.com/AcademySoftwareFoundation/rez/pull/1167) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- fix 4 sonarcloud-flagged bugs [\#1166](https://github.com/nerdvegas/rez/issues/1166)
+- fix 4 sonarcloud-flagged bugs [\#1166](https://github.com/AcademySoftwareFoundation/rez/issues/1166)
 
 ## 2.100.1 (2021-12-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.100.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.100.0...2.100.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.100.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.100.0...2.100.1)
 
 **Merged pull requests:**
 
-- remove use of tempfile.mktemp [\#1165](https://github.com/nerdvegas/rez/pull/1165) ([nerdvegas](https://github.com/nerdvegas))
+- remove use of tempfile.mktemp [\#1165](https://github.com/AcademySoftwareFoundation/rez/pull/1165) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- (sonarcloud) vulnerability [\#1164](https://github.com/nerdvegas/rez/issues/1164)
+- (sonarcloud) vulnerability [\#1164](https://github.com/AcademySoftwareFoundation/rez/issues/1164)
 
 ## 2.100.0 (2021-11-20)
-[Source](https://github.com/nerdvegas/rez/tree/2.100.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.98.3...2.100.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.100.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.98.3...2.100.0)
 
 **Notes**
 
@@ -347,274 +347,274 @@ More: https://www.apache.org/licenses/LICENSE-2.0
 
 **Merged pull requests:**
 
-- Issue 1119 license change [\#1158](https://github.com/nerdvegas/rez/pull/1158) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1119 license change [\#1158](https://github.com/AcademySoftwareFoundation/rez/pull/1158) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Rez License Change: LGPLv3 to Apache2.0 [\#1119](https://github.com/nerdvegas/rez/issues/1119)
+- Rez License Change: LGPLv3 to Apache2.0 [\#1119](https://github.com/AcademySoftwareFoundation/rez/issues/1119)
 
 ## 2.98.3 (2021-11-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.98.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.98.2...2.98.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.98.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.98.2...2.98.3)
 
 **Merged pull requests:**
 
-- modified whichcraft for rez [\#1157](https://github.com/nerdvegas/rez/pull/1157) ([nerdvegas](https://github.com/nerdvegas))
+- modified whichcraft for rez [\#1157](https://github.com/AcademySoftwareFoundation/rez/pull/1157) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-pip not working ? [\#904](https://github.com/nerdvegas/rez/issues/904)
-- NoneType Error When Using `rez pip` on Windows [\#1024](https://github.com/nerdvegas/rez/issues/1024)
+- rez-pip not working ? [\#904](https://github.com/AcademySoftwareFoundation/rez/issues/904)
+- NoneType Error When Using `rez pip` on Windows [\#1024](https://github.com/AcademySoftwareFoundation/rez/issues/1024)
 
 ## 2.98.2 (2021-11-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.98.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.98.1...2.98.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.98.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.98.1...2.98.2)
 
 Added unmodified whichcraft vendored lib.
 See:
 * https://github.com/cookiecutter/whichcraft/blob/master/whichcraft.py
-* https://github.com/nerdvegas/rez/pull/1155
+* https://github.com/AcademySoftwareFoundation/rez/pull/1155
 
 ## 2.98.1 (2021-11-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.98.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.98.0...2.98.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.98.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.98.0...2.98.1)
 
 **Merged pull requests:**
 
-- Issue 1119 code removal [\#1151](https://github.com/nerdvegas/rez/pull/1151) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1119 code removal [\#1151](https://github.com/AcademySoftwareFoundation/rez/pull/1151) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.98.0 (2021-11-02)
-[Source](https://github.com/nerdvegas/rez/tree/2.98.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.97.0...2.98.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.98.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.97.0...2.98.0)
 
 **Merged pull requests:**
 
-- Fix pika connector [\#1145](https://github.com/nerdvegas/rez/pull/1145) ([davidlatwe](https://github.com/davidlatwe))
-- Issue 1148 pika conn name [\#1149](https://github.com/nerdvegas/rez/pull/1149) ([nerdvegas](https://github.com/nerdvegas))
+- Fix pika connector [\#1145](https://github.com/AcademySoftwareFoundation/rez/pull/1145) ([davidlatwe](https://github.com/davidlatwe))
+- Issue 1148 pika conn name [\#1149](https://github.com/AcademySoftwareFoundation/rez/pull/1149) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Pika could not take port from `context_tracking_host` [\#1144](https://github.com/nerdvegas/rez/issues/1144)
-- name amqp connection [\#1148](https://github.com/nerdvegas/rez/issues/1148)
+- Pika could not take port from `context_tracking_host` [\#1144](https://github.com/AcademySoftwareFoundation/rez/issues/1144)
+- name amqp connection [\#1148](https://github.com/AcademySoftwareFoundation/rez/issues/1148)
 
 ## 2.97.0 (2021-10-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.97.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.96.0...2.97.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.97.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.96.0...2.97.0)
 
 **Merged pull requests:**
 
-- Improve rex env binding [\#1138](https://github.com/nerdvegas/rez/pull/1138) ([davidlatwe](https://github.com/davidlatwe))
+- Improve rex env binding [\#1138](https://github.com/AcademySoftwareFoundation/rez/pull/1138) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.96.0 (2021-10-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.96.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.95.3...2.96.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.96.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.95.3...2.96.0)
 
 **Merged pull requests:**
 
-- pika [\#1140](https://github.com/nerdvegas/rez/pull/1140) ([nerdvegas](https://github.com/nerdvegas))
+- pika [\#1140](https://github.com/AcademySoftwareFoundation/rez/pull/1140) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.95.3 (2021-10-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.95.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.95.2...2.95.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.95.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.95.2...2.95.3)
 
 **Merged pull requests:**
 
-- fix regression in v2.94.0 wrt windows string escape on rxt command [\#1139](https://github.com/nerdvegas/rez/pull/1139) ([nerdvegas](https://github.com/nerdvegas))
+- fix regression in v2.94.0 wrt windows string escape on rxt command [\#1139](https://github.com/AcademySoftwareFoundation/rez/pull/1139) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
--  (double-dash) removes double quotes on Windows [\#1133](https://github.com/nerdvegas/rez/issues/1133)
+-  (double-dash) removes double quotes on Windows [\#1133](https://github.com/AcademySoftwareFoundation/rez/issues/1133)
 
 ## 2.95.2 (2021-10-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.95.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.95.1...2.95.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.95.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.95.1...2.95.2)
 
 **Merged pull requests:**
 
-- powershell quoted command fix [\#1130](https://github.com/nerdvegas/rez/pull/1130) ([nerdvegas](https://github.com/nerdvegas))
-- CLI: display detailed version info with --version [\#1134](https://github.com/nerdvegas/rez/pull/1134) ([davidlatwe](https://github.com/davidlatwe))
+- powershell quoted command fix [\#1130](https://github.com/AcademySoftwareFoundation/rez/pull/1130) ([nerdvegas](https://github.com/nerdvegas))
+- CLI: display detailed version info with --version [\#1134](https://github.com/AcademySoftwareFoundation/rez/pull/1134) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- Rez pip fails to execute in Windows after 2.94.0 [\#1120](https://github.com/nerdvegas/rez/issues/1120)
+- Rez pip fails to execute in Windows after 2.94.0 [\#1120](https://github.com/AcademySoftwareFoundation/rez/issues/1120)
 
 ## 2.95.1 (2021-10-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.95.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.95.0...2.95.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.95.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.95.0...2.95.1)
 
 **Merged pull requests:**
 
-- Better shell specific testing [\#1136](https://github.com/nerdvegas/rez/pull/1136) ([davidlatwe](https://github.com/davidlatwe))
+- Better shell specific testing [\#1136](https://github.com/AcademySoftwareFoundation/rez/pull/1136) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- rez-env output test is not testing on specified shell [\#1135](https://github.com/nerdvegas/rez/issues/1135)
+- rez-env output test is not testing on specified shell [\#1135](https://github.com/AcademySoftwareFoundation/rez/issues/1135)
 
 ## 2.95.0 (2021-09-21)
-[Source](https://github.com/nerdvegas/rez/tree/2.95.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.94.0...2.95.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.95.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.94.0...2.95.0)
 
 **Merged pull requests:**
 
-- Fix  fileno() error in Maya2022 [\#1124](https://github.com/nerdvegas/rez/pull/1124) ([yanshil](https://github.com/yanshil))
-- copy dist-info to python subdur in rez-pip [\#1128](https://github.com/nerdvegas/rez/pull/1128) ([nerdvegas](https://github.com/nerdvegas))
+- Fix  fileno() error in Maya2022 [\#1124](https://github.com/AcademySoftwareFoundation/rez/pull/1124) ([yanshil](https://github.com/yanshil))
+- copy dist-info to python subdur in rez-pip [\#1128](https://github.com/AcademySoftwareFoundation/rez/pull/1128) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-pip installs dist-info dir to root, causes probs with some pkgs [\#892](https://github.com/nerdvegas/rez/issues/892)
+- rez-pip installs dist-info dir to root, causes probs with some pkgs [\#892](https://github.com/AcademySoftwareFoundation/rez/issues/892)
 
 ## 2.94.0 (2021-08-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.94.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.93.3...2.94.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.94.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.93.3...2.94.0)
 
 **Merged pull requests:**
 
-- quoting fix [\#1115](https://github.com/nerdvegas/rez/pull/1115) ([nerdvegas](https://github.com/nerdvegas))
+- quoting fix [\#1115](https://github.com/AcademySoftwareFoundation/rez/pull/1115) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- bug in command quoting [\#1114](https://github.com/nerdvegas/rez/issues/1114)
+- bug in command quoting [\#1114](https://github.com/AcademySoftwareFoundation/rez/issues/1114)
 
 ## 2.93.3 (2021-08-05)
-[Source](https://github.com/nerdvegas/rez/tree/2.93.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.93.2...2.93.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.93.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.93.2...2.93.3)
 
 **Merged pull requests:**
 
-- fixed always-0 exitcode in pytest-based selftest [\#1118](https://github.com/nerdvegas/rez/pull/1118) ([nerdvegas](https://github.com/nerdvegas))
+- fixed always-0 exitcode in pytest-based selftest [\#1118](https://github.com/AcademySoftwareFoundation/rez/pull/1118) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- failed tests in pytest-enabled rez-selftest are not getting picked up [\#1117](https://github.com/nerdvegas/rez/issues/1117)
+- failed tests in pytest-enabled rez-selftest are not getting picked up [\#1117](https://github.com/AcademySoftwareFoundation/rez/issues/1117)
 
 ## 2.93.2 (2021-08-03)
-[Source](https://github.com/nerdvegas/rez/tree/2.93.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.93.1...2.93.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.93.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.93.1...2.93.2)
 
 **Merged pull requests:**
 
-- Prevent alias (windows function) to store all arguments in one string instead of an array of strings [\#1101](https://github.com/nerdvegas/rez/pull/1101) ([aguiot](https://github.com/aguiot))
+- Prevent alias (windows function) to store all arguments in one string instead of an array of strings [\#1101](https://github.com/AcademySoftwareFoundation/rez/pull/1101) ([aguiot](https://github.com/aguiot))
 
 ## 2.93.1 (2021-08-03)
-[Source](https://github.com/nerdvegas/rez/tree/2.93.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.93.0...2.93.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.93.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.93.0...2.93.1)
 
 **Merged pull requests:**
 
-- handling archived lib when scanning rezplugins (fix #1108) [\#1109](https://github.com/nerdvegas/rez/pull/1109) ([davidlatwe](https://github.com/davidlatwe))
+- handling archived lib when scanning rezplugins (fix #1108) [\#1109](https://github.com/AcademySoftwareFoundation/rez/pull/1109) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- PluginManager.rezplugins_module_paths breaks with zipped Python [\#1108](https://github.com/nerdvegas/rez/issues/1108)
+- PluginManager.rezplugins_module_paths breaks with zipped Python [\#1108](https://github.com/AcademySoftwareFoundation/rez/issues/1108)
 
 ## 2.93.0 (2021-07-13)
-[Source](https://github.com/nerdvegas/rez/tree/2.93.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.92.0...2.93.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.93.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.92.0...2.93.0)
 
 **Merged pull requests:**
 
-- added minimal cli test [\#1106](https://github.com/nerdvegas/rez/pull/1106) ([nerdvegas](https://github.com/nerdvegas))
+- added minimal cli test [\#1106](https://github.com/AcademySoftwareFoundation/rez/pull/1106) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.92.0 (2021-07-13)
-[Source](https://github.com/nerdvegas/rez/tree/2.92.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.91.0...2.92.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.92.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.91.0...2.92.0)
 
 **Merged pull requests:**
 
-- PR: Ensure that "ViewGraphButton" menu instance is not garbage collected. [\#1103](https://github.com/nerdvegas/rez/pull/1103) ([KelSolaar](https://github.com/KelSolaar))
-- Remove the -s flag to rez-pip because "pip search" is decommissioned [\#1105](https://github.com/nerdvegas/rez/pull/1105) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- PR: Ensure that "ViewGraphButton" menu instance is not garbage collected. [\#1103](https://github.com/AcademySoftwareFoundation/rez/pull/1103) ([KelSolaar](https://github.com/KelSolaar))
+- Remove the -s flag to rez-pip because "pip search" is decommissioned [\#1105](https://github.com/AcademySoftwareFoundation/rez/pull/1105) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
 
 **Closed issues:**
 
-- Deprecate rez-pip -s flag because pip-search is disabled and will likely not return [\#1104](https://github.com/nerdvegas/rez/issues/1104)
+- Deprecate rez-pip -s flag because pip-search is disabled and will likely not return [\#1104](https://github.com/AcademySoftwareFoundation/rez/issues/1104)
 
 ## 2.91.0 (2021-06-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.91.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.90.3...2.91.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.91.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.90.3...2.91.0)
 
 **Merged pull requests:**
 
-- added env-var to disable cofig reads from ~/.rezconfig.py [\#1098](https://github.com/nerdvegas/rez/pull/1098) ([nerdvegas](https://github.com/nerdvegas))
+- added env-var to disable cofig reads from ~/.rezconfig.py [\#1098](https://github.com/AcademySoftwareFoundation/rez/pull/1098) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- config selftest can fail [\#1097](https://github.com/nerdvegas/rez/issues/1097)
+- config selftest can fail [\#1097](https://github.com/AcademySoftwareFoundation/rez/issues/1097)
 
 ## 2.90.3 (2021-06-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.90.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.90.2...2.90.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.90.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.90.2...2.90.3)
 
 **Merged pull requests:**
 
-- fixed missing __ne__ op in resource handle [\#1096](https://github.com/nerdvegas/rez/pull/1096) ([nerdvegas](https://github.com/nerdvegas))
+- fixed missing __ne__ op in resource handle [\#1096](https://github.com/AcademySoftwareFoundation/rez/pull/1096) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- regression: rez-test Could not resolve to variant [\#1095](https://github.com/nerdvegas/rez/issues/1095)
+- regression: rez-test Could not resolve to variant [\#1095](https://github.com/AcademySoftwareFoundation/rez/issues/1095)
 
 ## 2.90.2 (2021-06-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.90.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.90.1...2.90.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.90.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.90.1...2.90.2)
 
 **Merged pull requests:**
 
-- Allow trailing comma in Legacy Metadata [\#1092](https://github.com/nerdvegas/rez/pull/1092) ([bfloch](https://github.com/bfloch))
+- Allow trailing comma in Legacy Metadata [\#1092](https://github.com/AcademySoftwareFoundation/rez/pull/1092) ([bfloch](https://github.com/bfloch))
 
 ## 2.90.1 (2021-06-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.90.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.90.0...2.90.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.90.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.90.0...2.90.1)
 
 **Merged pull requests:**
 
-- Avoid hidden folder/files as it introduces problems on certain fileystems [\#1088](https://github.com/nerdvegas/rez/pull/1088) ([bfloch](https://github.com/bfloch))
+- Avoid hidden folder/files as it introduces problems on certain fileystems [\#1088](https://github.com/AcademySoftwareFoundation/rez/pull/1088) ([bfloch](https://github.com/bfloch))
 
 ## 2.90.0 (2021-06-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.90.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.89.1...2.90.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.90.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.89.1...2.90.0)
 
 **Merged pull requests:**
 
-- Extension plugins [\#1040](https://github.com/nerdvegas/rez/pull/1040) ([davidlatwe](https://github.com/davidlatwe))
+- Extension plugins [\#1040](https://github.com/AcademySoftwareFoundation/rez/pull/1040) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.89.1 (2021-06-02)
-[Source](https://github.com/nerdvegas/rez/tree/2.89.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.89.0...2.89.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.89.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.89.0...2.89.1)
 
 **Merged pull requests:**
 
-- disable memcache when ignoring hidden pkgs [\#1090](https://github.com/nerdvegas/rez/pull/1090) ([nerdvegas](https://github.com/nerdvegas))
+- disable memcache when ignoring hidden pkgs [\#1090](https://github.com/AcademySoftwareFoundation/rez/pull/1090) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-rm --ignored-since faulty in combo with memcached enabled [\#1089](https://github.com/nerdvegas/rez/issues/1089)
+- rez-rm --ignored-since faulty in combo with memcached enabled [\#1089](https://github.com/AcademySoftwareFoundation/rez/issues/1089)
 
 ## 2.89.0 (2021-06-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.89.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.88.4...2.89.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.89.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.88.4...2.89.0)
 
 **Merged pull requests:**
 
-- Improve context resolve failure info [\#1083](https://github.com/nerdvegas/rez/pull/1083) ([davidlatwe](https://github.com/davidlatwe))
+- Improve context resolve failure info [\#1083](https://github.com/AcademySoftwareFoundation/rez/pull/1083) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.88.4 (2021-06-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.88.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.88.3...2.88.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.88.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.88.3...2.88.4)
 
 **Merged pull requests:**
 
-- Fix conflict fail graph #865 [\#1087](https://github.com/nerdvegas/rez/pull/1087) ([davidlatwe](https://github.com/davidlatwe))
+- Fix conflict fail graph #865 [\#1087](https://github.com/AcademySoftwareFoundation/rez/pull/1087) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- fail-graph not showing true root of the conflict [\#865](https://github.com/nerdvegas/rez/issues/865)
+- fail-graph not showing true root of the conflict [\#865](https://github.com/AcademySoftwareFoundation/rez/issues/865)
 
 ## 2.88.3 (2021-06-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.88.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.88.2...2.88.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.88.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.88.2...2.88.3)
 
 **Merged pull requests:**
 
-- Refactor: Split add_standard_build_actions introducing add_pre_build_commands [\#1077](https://github.com/nerdvegas/rez/pull/1077) ([Tilix4](https://github.com/Tilix4))
+- Refactor: Split add_standard_build_actions introducing add_pre_build_commands [\#1077](https://github.com/AcademySoftwareFoundation/rez/pull/1077) ([Tilix4](https://github.com/Tilix4))
 
 **Closed issues:**
 
-- include could not find load file: RezBuild error on Windows [\#974](https://github.com/nerdvegas/rez/issues/974)
+- include could not find load file: RezBuild error on Windows [\#974](https://github.com/AcademySoftwareFoundation/rez/issues/974)
 
 ## 2.88.2 (2021-05-20)
-[Source](https://github.com/nerdvegas/rez/tree/2.88.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.88.1...2.88.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.88.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.88.1...2.88.2)
 
 **Merged pull requests:**
 
-- added rez_version to context tracking amqp message [\#1079](https://github.com/nerdvegas/rez/pull/1079) ([nerdvegas](https://github.com/nerdvegas))
+- added rez_version to context tracking amqp message [\#1079](https://github.com/AcademySoftwareFoundation/rez/pull/1079) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.88.1 (2021-05-18)
-[Source](https://github.com/nerdvegas/rez/tree/2.88.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.88.0...2.88.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.88.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.88.0...2.88.1)
 
 **Merged pull requests:**
 
-- switch to cached root in variant binding [\#1076](https://github.com/nerdvegas/rez/pull/1076) ([nerdvegas](https://github.com/nerdvegas))
+- switch to cached root in variant binding [\#1076](https://github.com/AcademySoftwareFoundation/rez/pull/1076) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- windows package cache root switch does only work with "{root}" not this.root  [\#1065](https://github.com/nerdvegas/rez/issues/1065)
+- windows package cache root switch does only work with "{root}" not this.root  [\#1065](https://github.com/AcademySoftwareFoundation/rez/issues/1065)
 
 ## 2.88.0 (2021-05-13)
-[Source](https://github.com/nerdvegas/rez/tree/2.88.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.87.0...2.88.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.88.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.87.0...2.88.0)
 
 **Notes**
 
@@ -622,42 +622,42 @@ This is currently implemented for linux only.
 
 **Closed issues:**
 
-- fix linking within bundles [\#1072](https://github.com/nerdvegas/rez/issues/1072)
+- fix linking within bundles [\#1072](https://github.com/AcademySoftwareFoundation/rez/issues/1072)
 
 ## 2.87.0 (2021-05-11)
-[Source](https://github.com/nerdvegas/rez/tree/2.87.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.86.1...2.87.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.87.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.86.1...2.87.0)
 
 **Merged pull requests:**
 
-- added bundle support for a post_commands.py file [\#1073](https://github.com/nerdvegas/rez/pull/1073) ([nerdvegas](https://github.com/nerdvegas))
+- added bundle support for a post_commands.py file [\#1073](https://github.com/AcademySoftwareFoundation/rez/pull/1073) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add post-context rex file in bundles [\#1071](https://github.com/nerdvegas/rez/issues/1071)
+- add post-context rex file in bundles [\#1071](https://github.com/AcademySoftwareFoundation/rez/issues/1071)
 
 ## 2.86.1 (2021-05-04)
-[Source](https://github.com/nerdvegas/rez/tree/2.86.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.86.0...2.86.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.86.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.86.0...2.86.1)
 
 **Merged pull requests:**
 
-- Fix pkg cache test [\#1046](https://github.com/nerdvegas/rez/pull/1046) ([davidlatwe](https://github.com/davidlatwe))
+- Fix pkg cache test [\#1046](https://github.com/AcademySoftwareFoundation/rez/pull/1046) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.86.0 (2021-05-04)
-[Source](https://github.com/nerdvegas/rez/tree/2.86.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.85.0...2.86.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.86.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.85.0...2.86.0)
 
 **Merged pull requests:**
 
-- rez config --json FIELD [\#1064](https://github.com/nerdvegas/rez/pull/1064) ([j0yu](https://github.com/j0yu))
+- rez config --json FIELD [\#1064](https://github.com/AcademySoftwareFoundation/rez/pull/1064) ([j0yu](https://github.com/j0yu))
 
 ## 2.85.0 (2021-05-04)
-[Source](https://github.com/nerdvegas/rez/tree/2.85.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.84.0...2.85.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.85.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.84.0...2.85.0)
 
 **Merged pull requests:**
 
-- Let rez-selftest try using pytest [\#1051](https://github.com/nerdvegas/rez/pull/1051) ([davidlatwe](https://github.com/davidlatwe))
+- Let rez-selftest try using pytest [\#1051](https://github.com/AcademySoftwareFoundation/rez/pull/1051) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.84.0 (2021-04-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.84.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.83.0...2.84.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.84.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.83.0...2.84.0)
 
 **Notes**
 
@@ -665,14 +665,14 @@ New tool: `rez-rm`.
 
 **Merged pull requests:**
 
-- package removal [\#1063](https://github.com/nerdvegas/rez/pull/1063) ([nerdvegas](https://github.com/nerdvegas))
+- package removal [\#1063](https://github.com/AcademySoftwareFoundation/rez/pull/1063) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add package removal [\#1062](https://github.com/nerdvegas/rez/issues/1062)
+- add package removal [\#1062](https://github.com/AcademySoftwareFoundation/rez/issues/1062)
 
 ## 2.83.0 (2021-04-14)
-[Source](https://github.com/nerdvegas/rez/tree/2.83.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.82.0...2.83.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.83.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.82.0...2.83.0)
 
 **Notes**
 
@@ -680,14 +680,14 @@ New tool: `rez-mv`.
 
 **Merged pull requests:**
 
-- Package move [\#1061](https://github.com/nerdvegas/rez/pull/1061) ([nerdvegas](https://github.com/nerdvegas))
+- Package move [\#1061](https://github.com/AcademySoftwareFoundation/rez/pull/1061) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add pkg move feature [\#1059](https://github.com/nerdvegas/rez/issues/1059)
+- add pkg move feature [\#1059](https://github.com/AcademySoftwareFoundation/rez/issues/1059)
 
 ## 2.82.0 (2021-04-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.82.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.81.2...2.82.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.82.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.81.2...2.82.0)
 
 **Notes**
 
@@ -695,21 +695,21 @@ New tool: `rez-pkg-ignore`.
 
 **Merged pull requests:**
 
-- Issue 1052 pkg ignore [\#1054](https://github.com/nerdvegas/rez/pull/1054) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1052 pkg ignore [\#1054](https://github.com/AcademySoftwareFoundation/rez/pull/1054) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- make package ignore a formal api/tool [\#1052](https://github.com/nerdvegas/rez/issues/1052)
+- make package ignore a formal api/tool [\#1052](https://github.com/AcademySoftwareFoundation/rez/issues/1052)
 
 ## 2.81.2 (2021-04-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.81.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.81.1...2.81.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.81.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.81.1...2.81.2)
 
 **Closed issues:**
 
-- install related regression in v2.80.0 [\#1057](https://github.com/nerdvegas/rez/issues/1057)
+- install related regression in v2.80.0 [\#1057](https://github.com/AcademySoftwareFoundation/rez/issues/1057)
 
 ## 2.81.1 (2021-04-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.81.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.81.0...2.81.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.81.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.81.0...2.81.1)
 
 **Notes**
 
@@ -719,98 +719,98 @@ compatible.
 
 **Merged pull requests:**
 
-- Issue 1055 failing tests [\#1056](https://github.com/nerdvegas/rez/pull/1056) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1055 failing tests [\#1056](https://github.com/AcademySoftwareFoundation/rez/pull/1056) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- problem with alias in powershell [\#1017](https://github.com/nerdvegas/rez/issues/1017)
-- tests failing suddenly [\#1055](https://github.com/nerdvegas/rez/issues/1055)
+- problem with alias in powershell [\#1017](https://github.com/AcademySoftwareFoundation/rez/issues/1017)
+- tests failing suddenly [\#1055](https://github.com/AcademySoftwareFoundation/rez/issues/1055)
 
 ## 2.81.0 (2021-04-01)
-[Source](https://github.com/nerdvegas/rez/tree/2.81.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.80.0...2.81.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.81.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.80.0...2.81.0)
 
 **Merged pull requests:**
 
-- Flake8 [\#1050](https://github.com/nerdvegas/rez/pull/1050) ([nerdvegas](https://github.com/nerdvegas))
+- Flake8 [\#1050](https://github.com/AcademySoftwareFoundation/rez/pull/1050) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.80.0 (2021-03-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.80.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.79.1...2.80.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.80.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.79.1...2.80.0)
 
 **Merged pull requests:**
 
-- Fix rez-python arg disordered [\#1041](https://github.com/nerdvegas/rez/pull/1041) ([davidlatwe](https://github.com/davidlatwe))
+- Fix rez-python arg disordered [\#1041](https://github.com/AcademySoftwareFoundation/rez/pull/1041) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.79.1 (2021-03-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.79.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.79.0...2.79.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.79.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.79.0...2.79.1)
 
 **Merged pull requests:**
 
-- Fix sorting of rules with and without family (closes #1037) [\#1038](https://github.com/nerdvegas/rez/pull/1038) ([jasperges](https://github.com/jasperges))
+- Fix sorting of rules with and without family (closes #1037) [\#1038](https://github.com/AcademySoftwareFoundation/rez/pull/1038) ([jasperges](https://github.com/jasperges))
 
 **Closed issues:**
 
-- An exception is raised when combining filters with `-` and without `-`. [\#1037](https://github.com/nerdvegas/rez/issues/1037)
+- An exception is raised when combining filters with `-` and without `-`. [\#1037](https://github.com/AcademySoftwareFoundation/rez/issues/1037)
 
 ## 2.79.0 (2021-03-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.79.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.78.1...2.79.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.79.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.78.1...2.79.0)
 
 **Merged pull requests:**
 
-- add optionvars [\#1036](https://github.com/nerdvegas/rez/pull/1036) ([davidlatwe](https://github.com/davidlatwe))
+- add optionvars [\#1036](https://github.com/AcademySoftwareFoundation/rez/pull/1036) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.78.1 (2021-03-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.78.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.78.0...2.78.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.78.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.78.0...2.78.1)
 
 **Merged pull requests:**
 
-- auto benchmarking fix [\#1049](https://github.com/nerdvegas/rez/pull/1049) ([nerdvegas](https://github.com/nerdvegas))
+- auto benchmarking fix [\#1049](https://github.com/AcademySoftwareFoundation/rez/pull/1049) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.78.0 (2021-03-27)
-[Source](https://github.com/nerdvegas/rez/tree/2.78.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.77.1...2.78.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.78.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.77.1...2.78.0)
 
 **Merged pull requests:**
 
-- Issue 1044 auto benchmarking [\#1048](https://github.com/nerdvegas/rez/pull/1048) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1044 auto benchmarking [\#1048](https://github.com/AcademySoftwareFoundation/rez/pull/1048) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- automatically run benchmarking [\#1044](https://github.com/nerdvegas/rez/issues/1044)
+- automatically run benchmarking [\#1044](https://github.com/AcademySoftwareFoundation/rez/issues/1044)
 
 ## 2.77.1 (2021-03-16)
-[Source](https://github.com/nerdvegas/rez/tree/2.77.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.77.0...2.77.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.77.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.77.0...2.77.1)
 
 **Merged pull requests:**
 
-- Fix missing files in sdist [\#1042](https://github.com/nerdvegas/rez/pull/1042) ([davidlatwe](https://github.com/davidlatwe))
+- Fix missing files in sdist [\#1042](https://github.com/AcademySoftwareFoundation/rez/pull/1042) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.77.0 (2021-03-09)
-[Source](https://github.com/nerdvegas/rez/tree/2.77.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.76.0...2.77.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.77.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.76.0...2.77.0)
 
 **Merged pull requests:**
 
-- Adds more variables to the custom build system. [\#1013](https://github.com/nerdvegas/rez/pull/1013) ([bfloch](https://github.com/bfloch))
+- Adds more variables to the custom build system. [\#1013](https://github.com/AcademySoftwareFoundation/rez/pull/1013) ([bfloch](https://github.com/bfloch))
 
 ## 2.76.0 (2021-03-09)
-[Source](https://github.com/nerdvegas/rez/tree/2.76.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.75.1...2.76.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.76.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.75.1...2.76.0)
 
 **Merged pull requests:**
 
-- add EphemeralsBinding.get_range [\#1030](https://github.com/nerdvegas/rez/pull/1030) ([davidlatwe](https://github.com/davidlatwe))
+- add EphemeralsBinding.get_range [\#1030](https://github.com/AcademySoftwareFoundation/rez/pull/1030) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.75.1 (2021-03-09)
-[Source](https://github.com/nerdvegas/rez/tree/2.75.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.75.0...2.75.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.75.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.75.0...2.75.1)
 
 **Merged pull requests:**
 
-- fix rez_bin_path on windows [\#1031](https://github.com/nerdvegas/rez/pull/1031) ([nerdvegas](https://github.com/nerdvegas))
-- Fix rez.vendor.distlib for Windows [\#1035](https://github.com/nerdvegas/rez/pull/1035) ([davidlatwe](https://github.com/davidlatwe))
+- fix rez_bin_path on windows [\#1031](https://github.com/AcademySoftwareFoundation/rez/pull/1031) ([nerdvegas](https://github.com/nerdvegas))
+- Fix rez.vendor.distlib for Windows [\#1035](https://github.com/AcademySoftwareFoundation/rez/pull/1035) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- Issues with system.System.is_production_rez_install method on Windows. [\#1005](https://github.com/nerdvegas/rez/issues/1005)
+- Issues with system.System.is_production_rez_install method on Windows. [\#1005](https://github.com/AcademySoftwareFoundation/rez/issues/1005)
 
 ## 2.75.0 (2021-03-03)
-[Source](https://github.com/nerdvegas/rez/tree/2.74.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.73.0...2.75.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.74.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.73.0...2.75.0)
 
 **Notes**
 
@@ -820,65 +820,65 @@ compatible.
 
 **Merged pull requests:**
 
-- Issue 1032 pypi [\#1034](https://github.com/nerdvegas/rez/pull/1034) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 1032 pypi [\#1034](https://github.com/AcademySoftwareFoundation/rez/pull/1034) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Pypi entries are out of date [\#1032](https://github.com/nerdvegas/rez/issues/1032)
+- Pypi entries are out of date [\#1032](https://github.com/AcademySoftwareFoundation/rez/issues/1032)
 
 ## 2.73.0 (2021-03-02)
-[Source](https://github.com/nerdvegas/rez/tree/2.73.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.5...2.73.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.73.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.5...2.73.0)
 
 **Merged pull requests:**
 
-- context bundles [\#1029](https://github.com/nerdvegas/rez/pull/1029) ([nerdvegas](https://github.com/nerdvegas))
+- context bundles [\#1029](https://github.com/AcademySoftwareFoundation/rez/pull/1029) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- bundled contexts ("bundles") [\#1009](https://github.com/nerdvegas/rez/issues/1009)
+- bundled contexts ("bundles") [\#1009](https://github.com/AcademySoftwareFoundation/rez/issues/1009)
 
 ## 2.72.5 (2021-03-02)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.5) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.4...2.72.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.4...2.72.5)
 
 **Merged pull requests:**
 
-- Improve get_variant_from_uri on Windows [\#1011](https://github.com/nerdvegas/rez/pull/1011) ([davidlatwe](https://github.com/davidlatwe))
+- Improve get_variant_from_uri on Windows [\#1011](https://github.com/AcademySoftwareFoundation/rez/pull/1011) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.72.4 (2021-03-02)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.3...2.72.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.3...2.72.4)
 
 **Merged pull requests:**
 
-- Wait subprocess cleanup [\#1010](https://github.com/nerdvegas/rez/pull/1010) ([davidlatwe](https://github.com/davidlatwe))
+- Wait subprocess cleanup [\#1010](https://github.com/AcademySoftwareFoundation/rez/pull/1010) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.72.3 (2021-02-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.2...2.72.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.2...2.72.3)
 
 **Merged pull requests:**
 
-- Fix tab-completion behavior for rez deployments installed with python3 [\#1021](https://github.com/nerdvegas/rez/pull/1021) ([zachlewis](https://github.com/zachlewis))
+- Fix tab-completion behavior for rez deployments installed with python3 [\#1021](https://github.com/AcademySoftwareFoundation/rez/pull/1021) ([zachlewis](https://github.com/zachlewis))
 
 **Closed issues:**
 
-- Tab completion broken for rez deployments installed with Python-3.6 [\#1020](https://github.com/nerdvegas/rez/issues/1020)
+- Tab completion broken for rez deployments installed with Python-3.6 [\#1020](https://github.com/AcademySoftwareFoundation/rez/issues/1020)
 
 ## 2.72.2 (2021-02-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.1...2.72.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.1...2.72.2)
 
 **Merged pull requests:**
 
-- Fix install-as-rez-package script for Windows [\#1014](https://github.com/nerdvegas/rez/pull/1014) ([davidlatwe](https://github.com/davidlatwe))
+- Fix install-as-rez-package script for Windows [\#1014](https://github.com/AcademySoftwareFoundation/rez/pull/1014) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.72.1 (2021-02-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.72.0...2.72.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.72.0...2.72.1)
 
 **Merged pull requests:**
 
-- Fix dir/file remove error handling [\#1012](https://github.com/nerdvegas/rez/pull/1012) ([davidlatwe](https://github.com/davidlatwe))
-- Fixes bug where readlink is applied on regular files. [\#1019](https://github.com/nerdvegas/rez/pull/1019) ([bfloch](https://github.com/bfloch))
+- Fix dir/file remove error handling [\#1012](https://github.com/AcademySoftwareFoundation/rez/pull/1012) ([davidlatwe](https://github.com/davidlatwe))
+- Fixes bug where readlink is applied on regular files. [\#1019](https://github.com/AcademySoftwareFoundation/rez/pull/1019) ([bfloch](https://github.com/bfloch))
 
 ## 2.72.0 (2021-01-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.72.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.71.0...2.72.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.72.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.71.0...2.72.0)
 
 **Notes**
 
@@ -888,19 +888,19 @@ python-3.9.
 
 **Merged pull requests:**
 
-- venv based install [\#1006](https://github.com/nerdvegas/rez/pull/1006) ([nerdvegas](https://github.com/nerdvegas))
+- venv based install [\#1006](https://github.com/AcademySoftwareFoundation/rez/pull/1006) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Installation With Python >=3.9 Fails ('HTMLParser' object has no attribute 'unescape') [\#980](https://github.com/nerdvegas/rez/issues/980)
-- have install.py use venv in python3 [\#982](https://github.com/nerdvegas/rez/issues/982)
+- Installation With Python >=3.9 Fails ('HTMLParser' object has no attribute 'unescape') [\#980](https://github.com/AcademySoftwareFoundation/rez/issues/980)
+- have install.py use venv in python3 [\#982](https://github.com/AcademySoftwareFoundation/rez/issues/982)
 
 ## 2.71.0 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.71.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.5...2.71.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.71.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.5...2.71.0)
 
 **Notes**
 
-[Ephemeral packages](https://github.com/nerdvegas/rez/wiki/Ephemeral-Packages) are a major new feature. These
+[Ephemeral packages](https://github.com/AcademySoftwareFoundation/rez/wiki/Ephemeral-Packages) are a major new feature. These
 enable dependencies on abstract objects or machine capabilities (for example), and also act as a way to pass
 'options' to packages that can alter their behaviour. These will also form the basis for _package features_, an
 upcoming feature that will allow packages to depend on _features_ of other packages, rather than just their
@@ -908,49 +908,49 @@ version number.
 
 **Merged pull requests:**
 
-- Ephemeral packages [\#993](https://github.com/nerdvegas/rez/pull/993) ([nerdvegas](https://github.com/nerdvegas))
+- Ephemeral packages [\#993](https://github.com/AcademySoftwareFoundation/rez/pull/993) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.70.5 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.5) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.4...2.70.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.4...2.70.5)
 
 **Merged pull requests:**
 
-- Fix module 'Qt.QtWidgets' has no attribute'QPainter' [\#992](https://github.com/nerdvegas/rez/pull/992) ([loonghao](https://github.com/loonghao))
+- Fix module 'Qt.QtWidgets' has no attribute'QPainter' [\#992](https://github.com/AcademySoftwareFoundation/rez/pull/992) ([loonghao](https://github.com/loonghao))
 
 ## 2.70.4 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.3...2.70.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.3...2.70.4)
 
 **Merged pull requests:**
 
-- update open_file_for_write with simplified error handling [\#998](https://github.com/nerdvegas/rez/pull/998) ([nerdvegas](https://github.com/nerdvegas))
+- update open_file_for_write with simplified error handling [\#998](https://github.com/AcademySoftwareFoundation/rez/pull/998) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- 'rez build --install --prefix' error  [\#858](https://github.com/nerdvegas/rez/issues/858)
+- 'rez build --install --prefix' error  [\#858](https://github.com/AcademySoftwareFoundation/rez/issues/858)
 
 ## 2.70.3 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.2...2.70.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.2...2.70.3)
 
 **Merged pull requests:**
 
-- Fix no CLI args passed into forward script on Windows [\#990](https://github.com/nerdvegas/rez/pull/990) ([davidlatwe](https://github.com/davidlatwe))
+- Fix no CLI args passed into forward script on Windows [\#990](https://github.com/AcademySoftwareFoundation/rez/pull/990) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.70.2 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.1...2.70.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.1...2.70.2)
 
 **Merged pull requests:**
 
-- fix: exit file write retry loop after successfull write [\#989](https://github.com/nerdvegas/rez/pull/989) ([bpabel](https://github.com/bpabel))
+- fix: exit file write retry loop after successfull write [\#989](https://github.com/AcademySoftwareFoundation/rez/pull/989) ([bpabel](https://github.com/bpabel))
 
 ## 2.70.1 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.70.0...2.70.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.70.0...2.70.1)
 
 **Merged pull requests:**
 
-- Fixes release hook for Python 3 [\#981](https://github.com/nerdvegas/rez/pull/981) ([bfloch](https://github.com/bfloch))
+- Fixes release hook for Python 3 [\#981](https://github.com/AcademySoftwareFoundation/rez/pull/981) ([bfloch](https://github.com/bfloch))
 
 ## 2.70.0 (2020-12-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.70.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.7...2.70.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.70.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.7...2.70.0)
 
 **Backwards Compatibility Issues**
 
@@ -965,171 +965,171 @@ need to do to port your existing build script.
 
 **Merged pull requests:**
 
-- Remove bez [\#979](https://github.com/nerdvegas/rez/pull/979) ([nerdvegas](https://github.com/nerdvegas))
+- Remove bez [\#979](https://github.com/AcademySoftwareFoundation/rez/pull/979) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.69.7 (2020-12-22)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.7) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.6...2.69.7)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.7) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.6...2.69.7)
 
 **Merged pull requests:**
 
-- Issue 994 wiki workflow fixes [\#995](https://github.com/nerdvegas/rez/pull/995) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 994 wiki workflow fixes [\#995](https://github.com/AcademySoftwareFoundation/rez/pull/995) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- wiki workflow broken [\#994](https://github.com/nerdvegas/rez/issues/994)
+- wiki workflow broken [\#994](https://github.com/AcademySoftwareFoundation/rez/issues/994)
 
 ## 2.69.6 (2020-11-24)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.6) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.5...2.69.6)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.6) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.5...2.69.6)
 
 **Merged pull requests:**
 
-- avoid using fileConfig to init logging, as it overwrites root logger [\#978](https://github.com/nerdvegas/rez/pull/978) ([nerdvegas](https://github.com/nerdvegas))
+- avoid using fileConfig to init logging, as it overwrites root logger [\#978](https://github.com/AcademySoftwareFoundation/rez/pull/978) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez overwrites root logger [\#977](https://github.com/nerdvegas/rez/issues/977)
+- rez overwrites root logger [\#977](https://github.com/AcademySoftwareFoundation/rez/issues/977)
 
 ## 2.69.5 (2020-11-19)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.5) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.4...2.69.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.4...2.69.5)
 
 **Merged pull requests:**
 
-- Try telling who is/are requesting missing package [\#976](https://github.com/nerdvegas/rez/pull/976) ([davidlatwe](https://github.com/davidlatwe))
+- Try telling who is/are requesting missing package [\#976](https://github.com/AcademySoftwareFoundation/rez/pull/976) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.69.4 (2020-11-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.3...2.69.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.3...2.69.4)
 
 **Merged pull requests:**
 
-- Fix pip.py get purelib error. [\#973](https://github.com/nerdvegas/rez/pull/973) ([zclongpop123](https://github.com/zclongpop123))
+- Fix pip.py get purelib error. [\#973](https://github.com/AcademySoftwareFoundation/rez/pull/973) ([zclongpop123](https://github.com/zclongpop123))
 
 ## 2.69.3 (2020-11-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.2...2.69.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.2...2.69.3)
 
 **Merged pull requests:**
 
-- handling QFileDialog.getSaveFileName return type [\#963](https://github.com/nerdvegas/rez/pull/963) ([sparklabor](https://github.com/sparklabor))
+- handling QFileDialog.getSaveFileName return type [\#963](https://github.com/AcademySoftwareFoundation/rez/pull/963) ([sparklabor](https://github.com/sparklabor))
 
 **Closed issues:**
 
-- QFileDialog.getSaveFileName and getOpenFileName return tuple not str [\#962](https://github.com/nerdvegas/rez/issues/962)
+- QFileDialog.getSaveFileName and getOpenFileName return tuple not str [\#962](https://github.com/AcademySoftwareFoundation/rez/issues/962)
 
 ## 2.69.2 (2020-11-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.1...2.69.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.1...2.69.2)
 
 **Merged pull requests:**
 
-- 965| Fix io.UnsupportedOperation [\#966](https://github.com/nerdvegas/rez/pull/966) ([spsalefeve](https://github.com/spsalefeve))
+- 965| Fix io.UnsupportedOperation [\#966](https://github.com/AcademySoftwareFoundation/rez/pull/966) ([spsalefeve](https://github.com/spsalefeve))
 
 **Closed issues:**
 
-- io.UnsupportedOperation when using rez api with pytest [\#965](https://github.com/nerdvegas/rez/issues/965)
+- io.UnsupportedOperation when using rez api with pytest [\#965](https://github.com/AcademySoftwareFoundation/rez/issues/965)
 
 ## 2.69.1 (2020-11-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.69.0...2.69.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.69.0...2.69.1)
 
 **Merged pull requests:**
 
-- Update vendored pydot (1.4.2.dev0) [\#970](https://github.com/nerdvegas/rez/pull/970) ([davidlatwe](https://github.com/davidlatwe))
+- Update vendored pydot (1.4.2.dev0) [\#970](https://github.com/AcademySoftwareFoundation/rez/pull/970) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.69.0 (2020-11-17)
-[Source](https://github.com/nerdvegas/rez/tree/2.69.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.68.5...2.69.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.69.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.68.5...2.69.0)
 
 **Merged pull requests:**
 
-- Fix forwarding script on Windows (suite supporting) [\#968](https://github.com/nerdvegas/rez/pull/968) ([davidlatwe](https://github.com/davidlatwe))
+- Fix forwarding script on Windows (suite supporting) [\#968](https://github.com/AcademySoftwareFoundation/rez/pull/968) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.68.5 (2020-10-06)
-[Source](https://github.com/nerdvegas/rez/tree/2.68.5) | [Diff](https://github.com/nerdvegas/rez/compare/2.68.4...2.68.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.68.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.68.4...2.68.5)
 
 **Merged pull requests:**
 
-- Handling build/install directory remove error in build process [\#959](https://github.com/nerdvegas/rez/pull/959) ([davidlatwe](https://github.com/davidlatwe))
+- Handling build/install directory remove error in build process [\#959](https://github.com/AcademySoftwareFoundation/rez/pull/959) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.68.4 (2020-10-06)
-[Source](https://github.com/nerdvegas/rez/tree/2.68.4) | [Diff](https://github.com/nerdvegas/rez/compare/2.68.3...2.68.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.68.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.68.3...2.68.4)
 
 **Merged pull requests:**
 
-- Support rez-env -c <alias> or -- <alias> (Windows CMD shell) [\#948](https://github.com/nerdvegas/rez/pull/948) ([davidlatwe](https://github.com/davidlatwe))
+- Support rez-env -c <alias> or -- <alias> (Windows CMD shell) [\#948](https://github.com/AcademySoftwareFoundation/rez/pull/948) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- Alias can't be used on the same line as rez-env [\#708](https://github.com/nerdvegas/rez/issues/708)
+- Alias can't be used on the same line as rez-env [\#708](https://github.com/AcademySoftwareFoundation/rez/issues/708)
 
 ## 2.68.3 (2020-09-22)
-[Source](https://github.com/nerdvegas/rez/tree/2.68.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.68.0...2.68.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.68.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.68.0...2.68.3)
 
 **Merged pull requests:**
 
-- fix regression wrt unicode, subprocess [\#961](https://github.com/nerdvegas/rez/pull/961) ([nerdvegas](https://github.com/nerdvegas))
+- fix regression wrt unicode, subprocess [\#961](https://github.com/AcademySoftwareFoundation/rez/pull/961) ([nerdvegas](https://github.com/nerdvegas))
 
-- Fix unicode vcs changelog encode err [\#956](https://github.com/nerdvegas/rez/pull/956) ([davidlatwe](https://github.com/davidlatwe))
+- Fix unicode vcs changelog encode err [\#956](https://github.com/AcademySoftwareFoundation/rez/pull/956) ([davidlatwe](https://github.com/davidlatwe))
 
-- Fix repo location false mismatch [\#957](https://github.com/nerdvegas/rez/pull/957) ([davidlatwe](https://github.com/davidlatwe))
+- Fix repo location false mismatch [\#957](https://github.com/AcademySoftwareFoundation/rez/pull/957) ([davidlatwe](https://github.com/davidlatwe))
 
 ## 2.68.0 (2020-09-22)
-[Source](https://github.com/nerdvegas/rez/tree/2.68.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.67.1...2.68.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.68.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.67.1...2.68.0)
 
 **Backwards Compatibility Issues**
 
 Note that this release changes OS detection on linux. The results _should_ be the same, but if they
 do differ, and you need to retain the same OS name (which you probably will, because you'll have
 packages that depend on the analogous implicit package), then you can use the
-[platform_map](https://github.com/nerdvegas/rez/wiki/Configuring-Rez#platform_map) setting.
+[platform_map](https://github.com/AcademySoftwareFoundation/rez/wiki/Configuring-Rez#platform_map) setting.
 
 **Merged pull requests:**
 
-- Replace platform.linux_distribution by distro [\#954](https://github.com/nerdvegas/rez/pull/954) ([predat](https://github.com/predat))
+- Replace platform.linux_distribution by distro [\#954](https://github.com/AcademySoftwareFoundation/rez/pull/954) ([predat](https://github.com/predat))
 
 **Closed issues:**
 
-- rez platform_ broken with python3.8 [\#883](https://github.com/nerdvegas/rez/issues/883)
+- rez platform_ broken with python3.8 [\#883](https://github.com/AcademySoftwareFoundation/rez/issues/883)
 
 ## 2.67.1 (2020-09-11)
-[Source](https://github.com/nerdvegas/rez/tree/2.67.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.67.0...2.67.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.67.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.67.0...2.67.1)
 
 **Merged pull requests:**
 
-- made this.root visible to pkg preprocessor [\#953](https://github.com/nerdvegas/rez/pull/953) ([nerdvegas](https://github.com/nerdvegas))
+- made this.root visible to pkg preprocessor [\#953](https://github.com/AcademySoftwareFoundation/rez/pull/953) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- this.root is None in package preprocessor [\#952](https://github.com/nerdvegas/rez/issues/952)
+- this.root is None in package preprocessor [\#952](https://github.com/AcademySoftwareFoundation/rez/issues/952)
 
 ## 2.67.0 (2020-08-25)
-[Source](https://github.com/nerdvegas/rez/tree/2.67.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.66.1...2.67.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.67.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.66.1...2.67.0)
 
 **Merged pull requests:**
 
-- Ninja support [\#940](https://github.com/nerdvegas/rez/pull/940) ([bareya](https://github.com/bareya))
-- print warning once if pkg cache dir not present [\#942](https://github.com/nerdvegas/rez/pull/942) ([nerdvegas](https://github.com/nerdvegas))
+- Ninja support [\#940](https://github.com/AcademySoftwareFoundation/rez/pull/940) ([bareya](https://github.com/bareya))
+- print warning once if pkg cache dir not present [\#942](https://github.com/AcademySoftwareFoundation/rez/pull/942) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- don't raise on missing package cache dir [\#941](https://github.com/nerdvegas/rez/issues/941)
+- don't raise on missing package cache dir [\#941](https://github.com/AcademySoftwareFoundation/rez/issues/941)
 
 ## 2.66.1 (2020-08-25)
-[Source](https://github.com/nerdvegas/rez/tree/2.66.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.66.0...2.66.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.66.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.66.0...2.66.1)
 
 **Merged pull requests:**
 
-- Fix #934, no hash string in include script file name [\#935](https://github.com/nerdvegas/rez/pull/935) ([davidlatwe](https://github.com/davidlatwe))
-- Raise unversioned error when config not allowed [\#938](https://github.com/nerdvegas/rez/pull/938) ([davidlatwe](https://github.com/davidlatwe))
+- Fix #934, no hash string in include script file name [\#935](https://github.com/AcademySoftwareFoundation/rez/pull/935) ([davidlatwe](https://github.com/davidlatwe))
+- Raise unversioned error when config not allowed [\#938](https://github.com/AcademySoftwareFoundation/rez/pull/938) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- Installed package not including latest module [\#934](https://github.com/nerdvegas/rez/issues/934)
+- Installed package not including latest module [\#934](https://github.com/AcademySoftwareFoundation/rez/issues/934)
 
 ## 2.66.0 (2020-08-11)
-[Source](https://github.com/nerdvegas/rez/tree/2.66.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.65.0...2.66.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.66.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.65.0...2.66.0)
 
 **Merged pull requests:**
 
-- [docs] Sphinx API hosted on GitHub Pages [\#832](https://github.com/nerdvegas/rez/pull/832) ([j0yu](https://github.com/j0yu))
+- [docs] Sphinx API hosted on GitHub Pages [\#832](https://github.com/AcademySoftwareFoundation/rez/pull/832) ([j0yu](https://github.com/j0yu))
 
 ## 2.65.0 (2020-08-11)
-[Source](https://github.com/nerdvegas/rez/tree/2.65.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.64.0...2.65.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.65.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.64.0...2.65.0)
 
 **Notes**
 
@@ -1138,89 +1138,89 @@ to automatically update the wiki.
 
 **Merged pull requests:**
 
-- [wiki] Move update utils into main repo [\#831](https://github.com/nerdvegas/rez/pull/831) ([j0yu](https://github.com/j0yu))
+- [wiki] Move update utils into main repo [\#831](https://github.com/AcademySoftwareFoundation/rez/pull/831) ([j0yu](https://github.com/j0yu))
 
 ## 2.64.0 (2020-08-11)
-[Source](https://github.com/nerdvegas/rez/tree/2.64.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.63.0...2.64.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.64.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.63.0...2.64.0)
 
 **Merged pull requests:**
 
-- added DelayLoad config primitive [\#922](https://github.com/nerdvegas/rez/pull/922) ([nerdvegas](https://github.com/nerdvegas))
-- Sort keys in resolved context JSON [\#923](https://github.com/nerdvegas/rez/pull/923) ([dbr](https://github.com/dbr))
-- Respect sys path order when spawning shell on Windows [\#926](https://github.com/nerdvegas/rez/pull/926) ([davidlatwe](https://github.com/davidlatwe))
-- Fix #927, add encoding=utf-8 on file write [\#928](https://github.com/nerdvegas/rez/pull/928) ([davidlatwe](https://github.com/davidlatwe))
+- added DelayLoad config primitive [\#922](https://github.com/AcademySoftwareFoundation/rez/pull/922) ([nerdvegas](https://github.com/nerdvegas))
+- Sort keys in resolved context JSON [\#923](https://github.com/AcademySoftwareFoundation/rez/pull/923) ([dbr](https://github.com/dbr))
+- Respect sys path order when spawning shell on Windows [\#926](https://github.com/AcademySoftwareFoundation/rez/pull/926) ([davidlatwe](https://github.com/davidlatwe))
+- Fix #927, add encoding=utf-8 on file write [\#928](https://github.com/AcademySoftwareFoundation/rez/pull/928) ([davidlatwe](https://github.com/davidlatwe))
 
 **Closed issues:**
 
-- add 'delay_load' config primitive [\#921](https://github.com/nerdvegas/rez/issues/921)
-- New spawned shell's `PATH` is random ordered on Windows [\#925](https://github.com/nerdvegas/rez/issues/925)
-- Packages that contains Unicode character failed on install/release [\#927](https://github.com/nerdvegas/rez/issues/927)
+- add 'delay_load' config primitive [\#921](https://github.com/AcademySoftwareFoundation/rez/issues/921)
+- New spawned shell's `PATH` is random ordered on Windows [\#925](https://github.com/AcademySoftwareFoundation/rez/issues/925)
+- Packages that contains Unicode character failed on install/release [\#927](https://github.com/AcademySoftwareFoundation/rez/issues/927)
 
 ## 2.63.0 (2020-08-04)
-[Source](https://github.com/nerdvegas/rez/tree/2.63.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.62.0...2.63.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.63.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.62.0...2.63.0)
 
 **Merged pull requests:**
 
-- don't attempt to update pkg cache on failed resolve [\#916](https://github.com/nerdvegas/rez/pull/916) ([nerdvegas](https://github.com/nerdvegas))
-- fix pkg cache fail on windows, py<=2.7 [\#917](https://github.com/nerdvegas/rez/pull/917) ([nerdvegas](https://github.com/nerdvegas))
-- raise metadata error on bad pkg, rather than build-system-notfound [\#918](https://github.com/nerdvegas/rez/pull/918) ([nerdvegas](https://github.com/nerdvegas))
-- default to disable package caching during build [\#920](https://github.com/nerdvegas/rez/pull/920) ([nerdvegas](https://github.com/nerdvegas))
+- don't attempt to update pkg cache on failed resolve [\#916](https://github.com/AcademySoftwareFoundation/rez/pull/916) ([nerdvegas](https://github.com/nerdvegas))
+- fix pkg cache fail on windows, py<=2.7 [\#917](https://github.com/AcademySoftwareFoundation/rez/pull/917) ([nerdvegas](https://github.com/nerdvegas))
+- raise metadata error on bad pkg, rather than build-system-notfound [\#918](https://github.com/AcademySoftwareFoundation/rez/pull/918) ([nerdvegas](https://github.com/nerdvegas))
+- default to disable package caching during build [\#920](https://github.com/AcademySoftwareFoundation/rez/pull/920) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-packaage-cache issue on conflicting context [\#905](https://github.com/nerdvegas/rez/issues/905)
-- Package caching does not work on windows due to device not being implemented in py2 on Windows [\#912](https://github.com/nerdvegas/rez/issues/912)
-- Miss-leaded error message while building with invalid package metadata [\#915](https://github.com/nerdvegas/rez/issues/915)
-- add ability to disable pkg caching during build [\#919](https://github.com/nerdvegas/rez/issues/919)
+- rez-packaage-cache issue on conflicting context [\#905](https://github.com/AcademySoftwareFoundation/rez/issues/905)
+- Package caching does not work on windows due to device not being implemented in py2 on Windows [\#912](https://github.com/AcademySoftwareFoundation/rez/issues/912)
+- Miss-leaded error message while building with invalid package metadata [\#915](https://github.com/AcademySoftwareFoundation/rez/issues/915)
+- add ability to disable pkg caching during build [\#919](https://github.com/AcademySoftwareFoundation/rez/issues/919)
 
 ## 2.62.0 (2020-07-22)
-[Source](https://github.com/nerdvegas/rez/tree/2.62.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.61.1...2.62.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.62.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.61.1...2.62.0)
 
 **Merged pull requests:**
 
-- Allow configuration of filesystem lock mechanism [\#903](https://github.com/nerdvegas/rez/pull/903) ([dbr](https://github.com/dbr))
-- make context tracking tolerant of errors [\#911](https://github.com/nerdvegas/rez/pull/911) ([nerdvegas](https://github.com/nerdvegas))
+- Allow configuration of filesystem lock mechanism [\#903](https://github.com/AcademySoftwareFoundation/rez/pull/903) ([dbr](https://github.com/dbr))
+- make context tracking tolerant of errors [\#911](https://github.com/AcademySoftwareFoundation/rez/pull/911) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- SSL crash related to context tracking [\#910](https://github.com/nerdvegas/rez/issues/910)
+- SSL crash related to context tracking [\#910](https://github.com/AcademySoftwareFoundation/rez/issues/910)
 
 ## 2.61.1 (2020-07-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.61.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.61.0...2.61.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.61.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.61.0...2.61.1)
 
 **Merged pull requests:**
 
-- fix for rez occasionally installed into lib64 dir [\#902](https://github.com/nerdvegas/rez/pull/902) ([nerdvegas](https://github.com/nerdvegas))
+- fix for rez occasionally installed into lib64 dir [\#902](https://github.com/AcademySoftwareFoundation/rez/pull/902) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- occasional missing rez cli in rez-env [\#901](https://github.com/nerdvegas/rez/issues/901)
+- occasional missing rez cli in rez-env [\#901](https://github.com/AcademySoftwareFoundation/rez/issues/901)
 
 ## 2.61.0 (2020-07-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.61.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.60.1...2.61.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.61.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.60.1...2.61.0)
 
 **Notes**
 
-Package caching feature added, see [here](https://github.com/nerdvegas/rez/wiki/Package-Caching).
+Package caching feature added, see [here](https://github.com/AcademySoftwareFoundation/rez/wiki/Package-Caching).
 
 **Merged pull requests:**
 
-- Package cache [\#893](https://github.com/nerdvegas/rez/pull/893) ([nerdvegas](https://github.com/nerdvegas))
+- Package cache [\#893](https://github.com/AcademySoftwareFoundation/rez/pull/893) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.60.1 (2020-05-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.60.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.60.0...2.60.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.60.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.60.0...2.60.1)
 
 **Merged pull requests:**
 
-- fix bug in py3 (hash of unicode) [\#888](https://github.com/nerdvegas/rez/pull/888) ([nerdvegas](https://github.com/nerdvegas))
-- fix context serilisation wrt append_sys_path [\#890](https://github.com/nerdvegas/rez/pull/890) ([nerdvegas](https://github.com/nerdvegas))
+- fix bug in py3 (hash of unicode) [\#888](https://github.com/AcademySoftwareFoundation/rez/pull/888) ([nerdvegas](https://github.com/nerdvegas))
+- fix context serilisation wrt append_sys_path [\#890](https://github.com/AcademySoftwareFoundation/rez/pull/890) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- context sourcing broken (ResolvedContext.append_sys_path not serialised) [\#889](https://github.com/nerdvegas/rez/issues/889)
+- context sourcing broken (ResolvedContext.append_sys_path not serialised) [\#889](https://github.com/AcademySoftwareFoundation/rez/issues/889)
 
 ## 2.60.0 (2020-05-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.60.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.59.1...2.60.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.60.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.59.1...2.60.0)
 
 **Backwards Compatibility Issues**
 
@@ -1231,121 +1231,121 @@ more easily chain `rez-context` with other utilities such as grep, xargs etc.
 
 **Merged pull requests:**
 
-- added get_variant_from_uri functionality [\#886](https://github.com/nerdvegas/rez/pull/886) ([nerdvegas](https://github.com/nerdvegas))
-- Cli variant uri [\#887](https://github.com/nerdvegas/rez/pull/887) ([nerdvegas](https://github.com/nerdvegas))
+- added get_variant_from_uri functionality [\#886](https://github.com/AcademySoftwareFoundation/rez/pull/886) ([nerdvegas](https://github.com/nerdvegas))
+- Cli variant uri [\#887](https://github.com/AcademySoftwareFoundation/rez/pull/887) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.59.1 (2020-05-09)
-[Source](https://github.com/nerdvegas/rez/tree/2.59.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.59.0...2.59.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.59.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.59.0...2.59.1)
 
 **Merged pull requests:**
 
-- fixed - rez-context -g with prune-package fails [\#885](https://github.com/nerdvegas/rez/pull/885) ([nerdvegas](https://github.com/nerdvegas))
+- fixed - rez-context -g with prune-package fails [\#885](https://github.com/AcademySoftwareFoundation/rez/pull/885) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- rez-context -g with prune-package fails [\#884](https://github.com/nerdvegas/rez/issues/884)
+- rez-context -g with prune-package fails [\#884](https://github.com/AcademySoftwareFoundation/rez/issues/884)
 
 ## 2.59.0 (2020-04-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.59.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.58.1...2.59.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.59.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.58.1...2.59.0)
 
 **Merged pull requests:**
 
-- Fix issue 826 - correct python and pip fallback [\#878](https://github.com/nerdvegas/rez/pull/878) ([j0yu](https://github.com/j0yu))
+- Fix issue 826 - correct python and pip fallback [\#878](https://github.com/AcademySoftwareFoundation/rez/pull/878) ([j0yu](https://github.com/j0yu))
 
 **Closed issues:**
 
-- rez-pip issues finding pip executable [\#826](https://github.com/nerdvegas/rez/issues/826)
+- rez-pip issues finding pip executable [\#826](https://github.com/AcademySoftwareFoundation/rez/issues/826)
 
 ## 2.58.1 (2020-04-22)
-[Source](https://github.com/nerdvegas/rez/tree/2.58.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.58.0...2.58.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.58.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.58.0...2.58.1)
 
 **Merged pull requests:**
 
-- Fix ISSUE-879: AttributeError: 'Namespace' object has no attribute 'func' [\#880](https://github.com/nerdvegas/rez/pull/880) ([rfletchr](https://github.com/rfletchr))
+- Fix ISSUE-879: AttributeError: 'Namespace' object has no attribute 'func' [\#880](https://github.com/AcademySoftwareFoundation/rez/pull/880) ([rfletchr](https://github.com/rfletchr))
 
 **Closed issues:**
 
-- AttributeError: 'Namespace' object has no attribute 'func' [\#879](https://github.com/nerdvegas/rez/issues/879)
+- AttributeError: 'Namespace' object has no attribute 'func' [\#879](https://github.com/AcademySoftwareFoundation/rez/issues/879)
 
 ## 2.58.0 (2020-04-15)
-[Source](https://github.com/nerdvegas/rez/tree/2.58.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.57.0...2.58.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.58.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.57.0...2.58.0)
 
 **Merged pull requests:**
 
-- Expose package orderers in rez config [\#868](https://github.com/nerdvegas/rez/pull/868) ([rlessardrodeofx](https://github.com/rlessardrodeofx))
+- Expose package orderers in rez config [\#868](https://github.com/AcademySoftwareFoundation/rez/pull/868) ([rlessardrodeofx](https://github.com/rlessardrodeofx))
 
 **Closed issues:**
 
-- add configurability of package orderers [\#329](https://github.com/nerdvegas/rez/issues/329)
+- add configurability of package orderers [\#329](https://github.com/AcademySoftwareFoundation/rez/issues/329)
 
 ## 2.57.0 (2020-04-14)
-[Source](https://github.com/nerdvegas/rez/tree/2.57.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.56.2...2.57.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.57.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.56.2...2.57.0)
 
 **Merged pull requests:**
 
-- Added distribution author and help information [\#873](https://github.com/nerdvegas/rez/pull/873) ([ColinKennedy](https://github.com/ColinKennedy))
+- Added distribution author and help information [\#873](https://github.com/AcademySoftwareFoundation/rez/pull/873) ([ColinKennedy](https://github.com/ColinKennedy))
 
 **Closed issues:**
 
-- rez-pip - Add help / authors attributes [\#838](https://github.com/nerdvegas/rez/issues/838)
+- rez-pip - Add help / authors attributes [\#838](https://github.com/AcademySoftwareFoundation/rez/issues/838)
 
 ## 2.56.2 (2020-04-14)
-[Source](https://github.com/nerdvegas/rez/tree/2.56.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.56.1...2.56.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.56.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.56.1...2.56.2)
 
 **Merged pull requests:**
 
-- Fix for git rev-parse error out before checking for allow_no_upstream [\#872](https://github.com/nerdvegas/rez/pull/872) ([alexxbb](https://github.com/alexxbb))
+- Fix for git rev-parse error out before checking for allow_no_upstream [\#872](https://github.com/AcademySoftwareFoundation/rez/pull/872) ([alexxbb](https://github.com/alexxbb))
 
 **Closed issues:**
 
-- override git plugin config in package.py [\#871](https://github.com/nerdvegas/rez/issues/871)
+- override git plugin config in package.py [\#871](https://github.com/AcademySoftwareFoundation/rez/issues/871)
 
 ## 2.56.1 (2020-03-31)
-[Source](https://github.com/nerdvegas/rez/tree/2.56.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.56.0...2.56.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.56.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.56.0...2.56.1)
 
 **Merged pull requests:**
 
-- Log during pip install [\#867](https://github.com/nerdvegas/rez/pull/867) ([j0yu](https://github.com/j0yu))
+- Log during pip install [\#867](https://github.com/AcademySoftwareFoundation/rez/pull/867) ([j0yu](https://github.com/j0yu))
 
 ## 2.56.0 (2020-03-31)
-[Source](https://github.com/nerdvegas/rez/tree/2.56.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.55.0...2.56.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.56.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.55.0...2.56.0)
 
 **Merged pull requests:**
 
-- pip install path remap [\#866](https://github.com/nerdvegas/rez/pull/866) ([j0yu](https://github.com/j0yu))
+- pip install path remap [\#866](https://github.com/AcademySoftwareFoundation/rez/pull/866) ([j0yu](https://github.com/j0yu))
 
 **Closed issues:**
 
-- rez-pip - no case for ../../include/... file [\#861](https://github.com/nerdvegas/rez/issues/861)
+- rez-pip - no case for ../../include/... file [\#861](https://github.com/AcademySoftwareFoundation/rez/issues/861)
 
 ## 2.55.0 (2020-03-21)
-[Source](https://github.com/nerdvegas/rez/tree/2.55.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.54.0...2.55.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.55.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.54.0...2.55.0)
 
 **Merged pull requests:**
 
-- Fixed bug in test variant selection [\#842](https://github.com/nerdvegas/rez/pull/842) ([nerdvegas](https://github.com/nerdvegas))
-- pre_test_commands [\#844](https://github.com/nerdvegas/rez/pull/844) ([nerdvegas](https://github.com/nerdvegas))
+- Fixed bug in test variant selection [\#842](https://github.com/AcademySoftwareFoundation/rez/pull/842) ([nerdvegas](https://github.com/nerdvegas))
+- pre_test_commands [\#844](https://github.com/AcademySoftwareFoundation/rez/pull/844) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- tests "on_variants" not working as expected in some cases [\#841](https://github.com/nerdvegas/rez/issues/841)
-- pre_test_commands [\#843](https://github.com/nerdvegas/rez/issues/843)
+- tests "on_variants" not working as expected in some cases [\#841](https://github.com/AcademySoftwareFoundation/rez/issues/841)
+- pre_test_commands [\#843](https://github.com/AcademySoftwareFoundation/rez/issues/843)
 
 ## 2.54.0 (2020-02-20)
-[Source](https://github.com/nerdvegas/rez/tree/2.54.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.53.1...2.54.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.54.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.53.1...2.54.0)
 
 **Merged pull requests:**
 
-- Install as package part2 [\#845](https://github.com/nerdvegas/rez/pull/845) ([nerdvegas](https://github.com/nerdvegas))
-- Allow absolute path for build directory [\#853](https://github.com/nerdvegas/rez/pull/853) ([joehigham-bss](https://github.com/joehigham-bss))
-- [rez-pip] Fix for ptvsd install [\#855](https://github.com/nerdvegas/rez/pull/855) ([j0yu](https://github.com/j0yu))
+- Install as package part2 [\#845](https://github.com/AcademySoftwareFoundation/rez/pull/845) ([nerdvegas](https://github.com/nerdvegas))
+- Allow absolute path for build directory [\#853](https://github.com/AcademySoftwareFoundation/rez/pull/853) ([joehigham-bss](https://github.com/joehigham-bss))
+- [rez-pip] Fix for ptvsd install [\#855](https://github.com/AcademySoftwareFoundation/rez/pull/855) ([j0yu](https://github.com/j0yu))
 
 **Closed issues:**
 
-- "rez-pip -i ptvsd" produces bad package [\#821](https://github.com/nerdvegas/rez/issues/821)
+- "rez-pip -i ptvsd" produces bad package [\#821](https://github.com/AcademySoftwareFoundation/rez/issues/821)
 
 ## 2.53.1 (2020-02-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.53.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.53.0...2.53.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.53.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.53.0...2.53.1)
 
 **Notes**
 
@@ -1353,62 +1353,62 @@ Misc Python-3 related issues.
 
 **Merged pull requests:**
 
-- PR: Fix "StringIO" imports and accesses. [\#850](https://github.com/nerdvegas/rez/pull/850) ([KelSolaar](https://github.com/KelSolaar))
-- PR: Use "QtCompat" to handle "QHeaderView" incompatibilities and fix broken "resolve" button in "rez-gui". [\#851](https://github.com/nerdvegas/rez/pull/851) ([KelSolaar](https://github.com/KelSolaar))
+- PR: Fix "StringIO" imports and accesses. [\#850](https://github.com/AcademySoftwareFoundation/rez/pull/850) ([KelSolaar](https://github.com/KelSolaar))
+- PR: Use "QtCompat" to handle "QHeaderView" incompatibilities and fix broken "resolve" button in "rez-gui". [\#851](https://github.com/AcademySoftwareFoundation/rez/pull/851) ([KelSolaar](https://github.com/KelSolaar))
 
 **Closed issues:**
 
-- "ImportError" exception raised while using "rez-gui" in Python 3. [\#848](https://github.com/nerdvegas/rez/issues/848)
-- "AttributeError" exception raised when using "rez-gui" Package Browser with Pyside2 . [\#849](https://github.com/nerdvegas/rez/issues/849)
+- "ImportError" exception raised while using "rez-gui" in Python 3. [\#848](https://github.com/AcademySoftwareFoundation/rez/issues/848)
+- "AttributeError" exception raised when using "rez-gui" Package Browser with Pyside2 . [\#849](https://github.com/AcademySoftwareFoundation/rez/issues/849)
 
 ## 2.53.0 (2020-02-04)
-[Source](https://github.com/nerdvegas/rez/tree/2.53.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.52.2...2.53.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.53.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.52.2...2.53.0)
 
 **Merged pull requests:**
 
-- [Feature] Add rez-pip extra args passthrough [\#827](https://github.com/nerdvegas/rez/pull/827) ([lambdaclan](https://github.com/lambdaclan))
+- [Feature] Add rez-pip extra args passthrough [\#827](https://github.com/AcademySoftwareFoundation/rez/pull/827) ([lambdaclan](https://github.com/lambdaclan))
 
 **Closed issues:**
 
-- rez-pip creates .pyc files by default [\#816](https://github.com/nerdvegas/rez/issues/816)
+- rez-pip creates .pyc files by default [\#816](https://github.com/AcademySoftwareFoundation/rez/issues/816)
 
 ## 2.52.2 (2020-01-31)
-[Source](https://github.com/nerdvegas/rez/tree/2.52.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.52.1...2.52.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.52.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.52.1...2.52.2)
 
 **Merged pull requests:**
 
-- deprecate trailing underscored sourcefiles [\#839](https://github.com/nerdvegas/rez/pull/839) ([nerdvegas](https://github.com/nerdvegas))
-- Minor pr3 fixes [\#840](https://github.com/nerdvegas/rez/pull/840) ([nerdvegas](https://github.com/nerdvegas))
+- deprecate trailing underscored sourcefiles [\#839](https://github.com/AcademySoftwareFoundation/rez/pull/839) ([nerdvegas](https://github.com/nerdvegas))
+- Minor pr3 fixes [\#840](https://github.com/AcademySoftwareFoundation/rez/pull/840) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.52.1 (2020-01-21)
-[Source](https://github.com/nerdvegas/rez/tree/2.52.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.52.0...2.52.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.52.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.52.0...2.52.1)
 
 **Merged pull requests:**
 
-- added new env vars - REZ_SHELL_INIT_TIMESTAMP, REZ_SHELL_INTERACTIVE [\#834](https://github.com/nerdvegas/rez/pull/834) ([nerdvegas](https://github.com/nerdvegas))
+- added new env vars - REZ_SHELL_INIT_TIMESTAMP, REZ_SHELL_INTERACTIVE [\#834](https://github.com/AcademySoftwareFoundation/rez/pull/834) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- add env-var to record shell init time [\#833](https://github.com/nerdvegas/rez/issues/833)
+- add env-var to record shell init time [\#833](https://github.com/AcademySoftwareFoundation/rez/issues/833)
 
 ## 2.52.0 (2020-01-18)
-[Source](https://github.com/nerdvegas/rez/tree/2.52.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.51.0...2.52.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.52.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.51.0...2.52.0)
 
 **Notes**
 
-Adds a new [pre_build_commands](https://github.com/nerdvegas/rez/wiki/Package-Commands#pre-build-commands)
+Adds a new [pre_build_commands](https://github.com/AcademySoftwareFoundation/rez/wiki/Package-Commands#pre-build-commands)
 package.py attribute, for adding runtime build configuration.
 
 **Merged pull requests:**
 
-- Rep002 pre build commands [\#825](https://github.com/nerdvegas/rez/pull/825) ([nerdvegas](https://github.com/nerdvegas))
+- Rep002 pre build commands [\#825](https://github.com/AcademySoftwareFoundation/rez/pull/825) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.51.0 (2020-01-18)
-[Source](https://github.com/nerdvegas/rez/tree/2.51.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.50.0...2.51.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.51.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.50.0...2.51.0)
 
 **Notes**
 
-This release goes a large way to implementing [REP-001](https://github.com/nerdvegas/rez/issues/665)
+This release goes a large way to implementing [REP-001](https://github.com/AcademySoftwareFoundation/rez/issues/665)
 
 Includes:
 - Pre-install/release running of package tests;
@@ -1421,55 +1421,55 @@ Still to do:
 
 **Merged pull requests:**
 
-- Rep001 1 (rez-test improvements) [\#807](https://github.com/nerdvegas/rez/pull/807) ([nerdvegas](https://github.com/nerdvegas))
-- Rep001 2 hooks [\#811](https://github.com/nerdvegas/rez/pull/811) ([nerdvegas](https://github.com/nerdvegas))
+- Rep001 1 (rez-test improvements) [\#807](https://github.com/AcademySoftwareFoundation/rez/pull/807) ([nerdvegas](https://github.com/nerdvegas))
+- Rep001 2 hooks [\#811](https://github.com/AcademySoftwareFoundation/rez/pull/811) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.50.0 (2019-12-12)
-[Source](https://github.com/nerdvegas/rez/tree/2.50.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.49.0...2.50.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.50.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.49.0...2.50.0)
 
 **Merged pull requests:**
 
-- removed odd case of _Bound instantiation with Version [\#815](https://github.com/nerdvegas/rez/pull/815) ([nerdvegas](https://github.com/nerdvegas))
-- memcached incompatibility fix [\#818](https://github.com/nerdvegas/rez/pull/818) ([nerdvegas](https://github.com/nerdvegas))
-- Bug/819 enable colorization on windows [\#820](https://github.com/nerdvegas/rez/pull/820) ([instinct-vfx](https://github.com/instinct-vfx))
+- removed odd case of _Bound instantiation with Version [\#815](https://github.com/AcademySoftwareFoundation/rez/pull/815) ([nerdvegas](https://github.com/nerdvegas))
+- memcached incompatibility fix [\#818](https://github.com/AcademySoftwareFoundation/rez/pull/818) ([nerdvegas](https://github.com/nerdvegas))
+- Bug/819 enable colorization on windows [\#820](https://github.com/AcademySoftwareFoundation/rez/pull/820) ([instinct-vfx](https://github.com/instinct-vfx))
 
 **Closed issues:**
 
-- potential memcached client incompatibility [\#817](https://github.com/nerdvegas/rez/issues/817)
-- Remove hard prevention of colorization on windows [\#819](https://github.com/nerdvegas/rez/issues/819)
+- potential memcached client incompatibility [\#817](https://github.com/AcademySoftwareFoundation/rez/issues/817)
+- Remove hard prevention of colorization on windows [\#819](https://github.com/AcademySoftwareFoundation/rez/issues/819)
 
 ## 2.49.0 (2019-12-05)
-[Source](https://github.com/nerdvegas/rez/tree/2.49.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.48.1...2.49.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.49.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.48.1...2.49.0)
 
 **Merged pull requests:**
 
-- Migrate rezgui.qt imports to Qt.py [\#804](https://github.com/nerdvegas/rez/pull/804) ([douglaslassance](https://github.com/douglaslassance))
+- Migrate rezgui.qt imports to Qt.py [\#804](https://github.com/AcademySoftwareFoundation/rez/pull/804) ([douglaslassance](https://github.com/douglaslassance))
 
 ## 2.48.1 (2019-12-05)
-[Source](https://github.com/nerdvegas/rez/tree/2.48.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.48.0...2.48.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.48.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.48.0...2.48.1)
 
 **Merged pull requests:**
 
-- Fixes #792 cmd empty echo [\#793](https://github.com/nerdvegas/rez/pull/793) ([bfloch](https://github.com/bfloch))
+- Fixes #792 cmd empty echo [\#793](https://github.com/AcademySoftwareFoundation/rez/pull/793) ([bfloch](https://github.com/bfloch))
 
 **Closed issues:**
 
-- cmd handles empty echo incorrectly [\#792](https://github.com/nerdvegas/rez/issues/792)
+- cmd handles empty echo incorrectly [\#792](https://github.com/AcademySoftwareFoundation/rez/issues/792)
 
 ## 2.48.0 (2019-11-26)
-[Source](https://github.com/nerdvegas/rez/tree/2.48.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.14...2.48.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.48.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.14...2.48.0)
 
 **Merged pull requests:**
 
-- rez.pip: Support python 2 executable on Windows (796) [\#798](https://github.com/nerdvegas/rez/pull/798) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
-- Feature/add 'prefix' argument to rez-pip [\#802](https://github.com/nerdvegas/rez/pull/802) ([predat](https://github.com/predat))
+- rez.pip: Support python 2 executable on Windows (796) [\#798](https://github.com/AcademySoftwareFoundation/rez/pull/798) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- Feature/add 'prefix' argument to rez-pip [\#802](https://github.com/AcademySoftwareFoundation/rez/pull/802) ([predat](https://github.com/predat))
 
 **Closed issues:**
 
-- find_pip_from_context failing on Windows platform [\#796](https://github.com/nerdvegas/rez/issues/796)
+- find_pip_from_context failing on Windows platform [\#796](https://github.com/AcademySoftwareFoundation/rez/issues/796)
 
 ## 2.47.14 (2019-11-13)
-[Source](https://github.com/nerdvegas/rez/tree/2.47.14) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.13...2.47.14)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.14) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.13...2.47.14)
 
 **Notes**
 
@@ -1489,16 +1489,16 @@ If a separate push is made in this time, it can fail, as the Windows test expect
 
 **Merged pull requests:**
 
-- Windows docker enhancements [\#794](https://github.com/nerdvegas/rez/pull/794) ([bfloch](https://github.com/bfloch))
-- Remove the login so that PR work at least for the non-image workflows. [\#795](https://github.com/nerdvegas/rez/pull/795) ([bfloch](https://github.com/bfloch))
-- Issue 800 windows ci use checkout [\#801](https://github.com/nerdvegas/rez/pull/801) ([nerdvegas](https://github.com/nerdvegas))
+- Windows docker enhancements [\#794](https://github.com/AcademySoftwareFoundation/rez/pull/794) ([bfloch](https://github.com/bfloch))
+- Remove the login so that PR work at least for the non-image workflows. [\#795](https://github.com/AcademySoftwareFoundation/rez/pull/795) ([bfloch](https://github.com/bfloch))
+- Issue 800 windows ci use checkout [\#801](https://github.com/AcademySoftwareFoundation/rez/pull/801) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- windows ci: Use Actions checkout [\#800](https://github.com/nerdvegas/rez/issues/800)
+- windows ci: Use Actions checkout [\#800](https://github.com/AcademySoftwareFoundation/rez/issues/800)
 
 ## 2.47.13 (2019-11-08)
-[Source](https://github.com/nerdvegas/rez/tree/2.47.13) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.12...2.47.13)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.13) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.12...2.47.13)
 
 **Notes**
 
@@ -1511,14 +1511,14 @@ below, the following changes were also made:
 
 **Merged pull requests:**
 
-- Updated actions badges in README [\#786](https://github.com/nerdvegas/rez/pull/786) ([j0yu](https://github.com/j0yu))
+- Updated actions badges in README [\#786](https://github.com/AcademySoftwareFoundation/rez/pull/786) ([j0yu](https://github.com/j0yu))
 
 **Closed issues:**
 
-- Fix README actions badges not showing current master status [\#785](https://github.com/nerdvegas/rez/issues/785)
+- Fix README actions badges not showing current master status [\#785](https://github.com/AcademySoftwareFoundation/rez/issues/785)
 
 ## 2.47.12 (2019-11-06)
-[Source](https://github.com/nerdvegas/rez/tree/2.47.12) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.11...2.47.12)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.12) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.11...2.47.12)
 
 **Notes**
 
@@ -1528,95 +1528,95 @@ a limit, causing the `cmd` shell to fail in several tests.
 
 **Merged pull requests:**
 
-- Windows Tests via Docker [\#781](https://github.com/nerdvegas/rez/pull/781) ([bfloch](https://github.com/bfloch))
+- Windows Tests via Docker [\#781](https://github.com/AcademySoftwareFoundation/rez/pull/781) ([bfloch](https://github.com/bfloch))
 
 ## 2.47.11 (2019-11-06)
-[Source](https://github.com/nerdvegas/rez/tree/2.47.11) | [Diff](https://github.com/nerdvegas/rez/compare/2.47.10...2.47.11)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.11) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.10...2.47.11)
 
 **Merged pull requests:**
 
-- Fixes some failing tests on windows [\#775](https://github.com/nerdvegas/rez/pull/775) ([willjp](https://github.com/willjp))
+- Fixes some failing tests on windows [\#775](https://github.com/AcademySoftwareFoundation/rez/pull/775) ([willjp](https://github.com/willjp))
 
 ## 2.47.10 (2019-11-06)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.10) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.9...2.47.10)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.10) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.9...2.47.10)
 
 **Merged pull requests:**
 
-- Replace Popen with check_output to catch errors in installation [\#778](https://github.com/nerdvegas/rez/pull/778) ([instinct-vfx](https://github.com/instinct-vfx))
-- Popen UnicodeDecodeError partial fix [\#779](https://github.com/nerdvegas/rez/pull/779) ([willjp](https://github.com/willjp))
-- Unwanted debug printing [\#780](https://github.com/nerdvegas/rez/pull/780) ([predat](https://github.com/predat))
+- Replace Popen with check_output to catch errors in installation [\#778](https://github.com/AcademySoftwareFoundation/rez/pull/778) ([instinct-vfx](https://github.com/instinct-vfx))
+- Popen UnicodeDecodeError partial fix [\#779](https://github.com/AcademySoftwareFoundation/rez/pull/779) ([willjp](https://github.com/willjp))
+- Unwanted debug printing [\#780](https://github.com/AcademySoftwareFoundation/rez/pull/780) ([predat](https://github.com/predat))
 
 **Closed issues:**
 
-- rez-release UnicodeDecodeError (windows) [\#776](https://github.com/nerdvegas/rez/issues/776)
-- Errors in pip installation part go unnoticed by rez install.py [\#777](https://github.com/nerdvegas/rez/issues/777)
+- rez-release UnicodeDecodeError (windows) [\#776](https://github.com/AcademySoftwareFoundation/rez/issues/776)
+- Errors in pip installation part go unnoticed by rez install.py [\#777](https://github.com/AcademySoftwareFoundation/rez/issues/777)
 
 ## 2.47.9 (2019-10-25)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.9) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.8...2.47.9)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.9) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.8...2.47.9)
 
 **Merged pull requests:**
 
-- rez.util.ProgressBar checks `Bar.__del__` exists before invocation #769 [\#774](https://github.com/nerdvegas/rez/pull/774) ([willjp](https://github.com/willjp))
+- rez.util.ProgressBar checks `Bar.__del__` exists before invocation #769 [\#774](https://github.com/AcademySoftwareFoundation/rez/pull/774) ([willjp](https://github.com/willjp))
 
 **Closed issues:**
 
-- rez-depends -- AttributeError: type object 'Bar' has no attribute '__del__' (win, py-3, rez-2.47.7) [\#769](https://github.com/nerdvegas/rez/issues/769)
+- rez-depends -- AttributeError: type object 'Bar' has no attribute '__del__' (win, py-3, rez-2.47.7) [\#769](https://github.com/AcademySoftwareFoundation/rez/issues/769)
 
 ## 2.47.8 (2019-10-24)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.8) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.7...2.47.8)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.8) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.7...2.47.8)
 
 **Merged pull requests:**
 
-- Issue 763 prompt leak [\#767](https://github.com/nerdvegas/rez/pull/767) ([nerdvegas](https://github.com/nerdvegas))
-- Fixes cmd due to oversight in 9c8334a106de900964e52f1ed8ee4155acdfe142 [\#770](https://github.com/nerdvegas/rez/pull/770) ([bfloch](https://github.com/bfloch))
-- Skip `test_build_cmake` on Windows. [\#772](https://github.com/nerdvegas/rez/pull/772) ([bfloch](https://github.com/bfloch))
+- Issue 763 prompt leak [\#767](https://github.com/AcademySoftwareFoundation/rez/pull/767) ([nerdvegas](https://github.com/nerdvegas))
+- Fixes cmd due to oversight in 9c8334a106de900964e52f1ed8ee4155acdfe142 [\#770](https://github.com/AcademySoftwareFoundation/rez/pull/770) ([bfloch](https://github.com/bfloch))
+- Skip `test_build_cmake` on Windows. [\#772](https://github.com/AcademySoftwareFoundation/rez/pull/772) ([bfloch](https://github.com/bfloch))
 
 **Closed issues:**
 
-- cross-shell prompt leakage can cause error [\#763](https://github.com/nerdvegas/rez/issues/763)
+- cross-shell prompt leakage can cause error [\#763](https://github.com/AcademySoftwareFoundation/rez/issues/763)
 
 ## 2.47.7 (2019-10-22)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.7) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.6...2.47.7)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.7) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.6...2.47.7)
 
 **Notes**
 
 * Rez-pip: Add a new logic to find which pip will be used to install pip packages.
 * Rez-pip: New deprecation warning when --pip-version is used.
-* See https://github.com/nerdvegas/rez/wiki/Pip for more details on rez-pip.
+* See https://github.com/AcademySoftwareFoundation/rez/wiki/Pip for more details on rez-pip.
 
 **Merged pull requests:**
 
-- rez-pip: Assume pip provided by python package [\#757](https://github.com/nerdvegas/rez/pull/757) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- rez-pip: Assume pip provided by python package [\#757](https://github.com/AcademySoftwareFoundation/rez/pull/757) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
 
 **Closed issues:**
 
-- rez-pip should assume python provided pip [\#706](https://github.com/nerdvegas/rez/issues/706)
-- rez-pip python 3 error [\#764](https://github.com/nerdvegas/rez/issues/764)
+- rez-pip should assume python provided pip [\#706](https://github.com/AcademySoftwareFoundation/rez/issues/706)
+- rez-pip python 3 error [\#764](https://github.com/AcademySoftwareFoundation/rez/issues/764)
 
 ## 2.47.6 (2019-10-22)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.6) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.5...2.47.6)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.6) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.5...2.47.6)
 
 **Merged pull requests:**
 
-- Subproc wrapper part2 [\#762](https://github.com/nerdvegas/rez/pull/762) ([nerdvegas](https://github.com/nerdvegas))
+- Subproc wrapper part2 [\#762](https://github.com/AcademySoftwareFoundation/rez/pull/762) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- ResourceWarning with ResolvedContext.execute_shell (py3) [\#761](https://github.com/nerdvegas/rez/issues/761)
+- ResourceWarning with ResolvedContext.execute_shell (py3) [\#761](https://github.com/AcademySoftwareFoundation/rez/issues/761)
 
 ## 2.47.5 (2019-10-22)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.5) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.4...2.47.5)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.5) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.4...2.47.5)
 
 **Merged pull requests:**
 
-- revert progress iteration and update vendored [\#766](https://github.com/nerdvegas/rez/pull/766) ([maxnbk](https://github.com/maxnbk))
+- revert progress iteration and update vendored [\#766](https://github.com/AcademySoftwareFoundation/rez/pull/766) ([maxnbk](https://github.com/maxnbk))
 
 **Closed issues:**
 
-- rez-depends -- 'ProgressBar' object is not an iterator (py-3, rez-2.47.4) [\#765](https://github.com/nerdvegas/rez/issues/765)
+- rez-depends -- 'ProgressBar' object is not an iterator (py-3, rez-2.47.4) [\#765](https://github.com/AcademySoftwareFoundation/rez/issues/765)
 
 ## 2.47.4 (2019-10-11)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.4) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.3...2.47.4)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.4) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.3...2.47.4)
 
 **Notes**
 
@@ -1624,11 +1624,11 @@ More Python3 compatibility changes.
 
 **Merged pull requests:**
 
-- use subprocess in 'text' mode in most cases [\#753](https://github.com/nerdvegas/rez/pull/753) ([nerdvegas](https://github.com/nerdvegas))
-- add __bool__ operator [\#755](https://github.com/nerdvegas/rez/pull/755) ([nerdvegas](https://github.com/nerdvegas))
+- use subprocess in 'text' mode in most cases [\#753](https://github.com/AcademySoftwareFoundation/rez/pull/753) ([nerdvegas](https://github.com/nerdvegas))
+- add __bool__ operator [\#755](https://github.com/AcademySoftwareFoundation/rez/pull/755) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.47.3 (2019-09-28)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.3) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.2...2.47.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.2...2.47.3)
 
 **Notes**
 
@@ -1640,10 +1640,10 @@ More Python3 compatibility changes.
 
 **Merged pull requests:**
 
-- Gh actions - first pass [\#750](https://github.com/nerdvegas/rez/pull/750) ([nerdvegas](https://github.com/nerdvegas))
+- Gh actions - first pass [\#750](https://github.com/AcademySoftwareFoundation/rez/pull/750) ([nerdvegas](https://github.com/nerdvegas))
 
 ## 2.47.2 (2019-09-17)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.2) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.1...2.47.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.1...2.47.2)
 
 **Notes**
 
@@ -1651,23 +1651,23 @@ Py3 fixes found after testing.
 
 **Merged pull requests:**
 
-- Fix py3 errors and warnings [\#748](https://github.com/nerdvegas/rez/pull/748) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- Fix py3 errors and warnings [\#748](https://github.com/AcademySoftwareFoundation/rez/pull/748) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
 
 
 ## 2.47.1 (2019-09-17)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.1) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.47.0...2.47.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.47.0...2.47.1)
 
 **Merged pull requests:**
 
-- Issue 696 shell availability [\#747](https://github.com/nerdvegas/rez/pull/747) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 696 shell availability [\#747](https://github.com/AcademySoftwareFoundation/rez/pull/747) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- Shell plugin Support API [\#696](https://github.com/nerdvegas/rez/issues/696)
+- Shell plugin Support API [\#696](https://github.com/AcademySoftwareFoundation/rez/issues/696)
 
 
 ## 2.47.0 (2019-09-13)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.47.0) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.46.0...2.47.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.47.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.46.0...2.47.0)
 
 **Notes**
 
@@ -1678,15 +1678,15 @@ Note also that this release fixes a regression in Windows, introduced in 2.35.0.
 
 **Merged pull requests:**
 
-- Enhancements for shell plugins [\#698](https://github.com/nerdvegas/rez/pull/698) ([bfloch](https://github.com/bfloch))
+- Enhancements for shell plugins [\#698](https://github.com/AcademySoftwareFoundation/rez/pull/698) ([bfloch](https://github.com/bfloch))
 
 **Closed issues:**
 
-- Quotation marks issues on Windows. [\#691](https://github.com/nerdvegas/rez/issues/691)
-- Rex and expandable in other shells [\#694](https://github.com/nerdvegas/rez/issues/694)
+- Quotation marks issues on Windows. [\#691](https://github.com/AcademySoftwareFoundation/rez/issues/691)
+- Rex and expandable in other shells [\#694](https://github.com/AcademySoftwareFoundation/rez/issues/694)
 
 ## 2.46.0 (2019-09-13)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.46.0) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.45.1...2.46.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.46.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.45.1...2.46.0)
 
 **Notes**
 
@@ -1698,11 +1698,11 @@ Tests have shown performance to be identical, but you may find a case where it i
 
 **Merged pull requests:**
 
-- py3 iterators conversion [\#736](https://github.com/nerdvegas/rez/pull/736) ([maxnbk](https://github.com/maxnbk))
-- py3 finalizations [\#742](https://github.com/nerdvegas/rez/pull/742) ([maxnbk](https://github.com/maxnbk))
+- py3 iterators conversion [\#736](https://github.com/AcademySoftwareFoundation/rez/pull/736) ([maxnbk](https://github.com/maxnbk))
+- py3 finalizations [\#742](https://github.com/AcademySoftwareFoundation/rez/pull/742) ([maxnbk](https://github.com/maxnbk))
 
 ## 2.45.1 (2019-09-11)
-[Source](https://github.com/repos/nerdvegas/rez/tree/2.45.1) | [Diff](https://github.com/repos/nerdvegas/rez/compare/2.45.0...2.45.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.45.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.45.0...2.45.1)
 
 **Notes**
 
@@ -1710,16 +1710,16 @@ Misc Py3 compatibility updates, part 4.
 
 **Merged pull requests:**
 
-- robust py2/3 use of getargspec/getfullargspec [\#743](https://github.com/nerdvegas/rez/pull/743) ([nerdvegas](https://github.com/nerdvegas))
-- address #744 (rex dictmixin issue) [\#745](https://github.com/nerdvegas/rez/pull/745) ([maxnbk](https://github.com/maxnbk))
+- robust py2/3 use of getargspec/getfullargspec [\#743](https://github.com/AcademySoftwareFoundation/rez/pull/743) ([nerdvegas](https://github.com/nerdvegas))
+- address #744 (rex dictmixin issue) [\#745](https://github.com/AcademySoftwareFoundation/rez/pull/745) ([maxnbk](https://github.com/maxnbk))
 
 **Closed issues:**
 
-- #712 merged in 2.43.0 caused external environ not to pass through to resolve [\#744](https://github.com/nerdvegas/rez/issues/744)
+- #712 merged in 2.43.0 caused external environ not to pass through to resolve [\#744](https://github.com/AcademySoftwareFoundation/rez/issues/744)
 
 
 ## 2.45.0 (2019-09-10)
-[Source](https://github.com/nerdvegas/rez/tree/2.45.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.44.2...2.45.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.45.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.44.2...2.45.0)
 
 **Notes**
 
@@ -1727,26 +1727,26 @@ Misc Py3 compatibility updates, part 3.
 
 **Merged pull requests:**
 
-- bytecode / pycache related changes [\#733](https://github.com/nerdvegas/rez/pull/733) ([maxnbk](https://github.com/maxnbk))
-- address py3.8 deprecation of collections direct ABC access [\#740](https://github.com/nerdvegas/rez/pull/740) ([maxnbk](https://github.com/maxnbk))
-- fix metaclass usage in example code [\#741](https://github.com/nerdvegas/rez/pull/741) ([maxnbk](https://github.com/maxnbk))
-- Vendor readme [\#738](https://github.com/nerdvegas/rez/pull/738) ([nerdvegas](https://github.com/nerdvegas))
+- bytecode / pycache related changes [\#733](https://github.com/AcademySoftwareFoundation/rez/pull/733) ([maxnbk](https://github.com/maxnbk))
+- address py3.8 deprecation of collections direct ABC access [\#740](https://github.com/AcademySoftwareFoundation/rez/pull/740) ([maxnbk](https://github.com/maxnbk))
+- fix metaclass usage in example code [\#741](https://github.com/AcademySoftwareFoundation/rez/pull/741) ([maxnbk](https://github.com/maxnbk))
+- Vendor readme [\#738](https://github.com/AcademySoftwareFoundation/rez/pull/738) ([nerdvegas](https://github.com/nerdvegas))
 
 
 ## 2.44.2 (2019-09-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.44.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.44.1...2.44.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.44.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.44.1...2.44.2)
 
 **Merged pull requests:**
 
-- install variant.json file in the same manner as other extra install files [\#731](https://github.com/nerdvegas/rez/pull/731) ([nerdvegas](https://github.com/nerdvegas))
+- install variant.json file in the same manner as other extra install files [\#731](https://github.com/AcademySoftwareFoundation/rez/pull/731) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- permissions failure on release (variant.json) [\#730](https://github.com/nerdvegas/rez/issues/730)
+- permissions failure on release (variant.json) [\#730](https://github.com/AcademySoftwareFoundation/rez/issues/730)
 
 
 ## 2.44.1 (2019-09-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.44.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.44.0...2.44.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.44.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.44.0...2.44.1)
 
 **Notes**
 
@@ -1754,12 +1754,12 @@ Misc Py3 compatibility updates, part 2.
 
 **Merged pull requests:**
 
-- update imports in vendored pydot for py3 [\#728](https://github.com/nerdvegas/rez/pull/728) ([maxnbk](https://github.com/maxnbk))
-- update vendored schema for py3 [\#729](https://github.com/nerdvegas/rez/pull/729) ([maxnbk](https://github.com/maxnbk))
+- update imports in vendored pydot for py3 [\#728](https://github.com/AcademySoftwareFoundation/rez/pull/728) ([maxnbk](https://github.com/maxnbk))
+- update vendored schema for py3 [\#729](https://github.com/AcademySoftwareFoundation/rez/pull/729) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.44.0 (2019-09-06)
-[Source](https://github.com/nerdvegas/rez/tree/2.44.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.43.0...2.44.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.44.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.43.0...2.44.0)
 
 **Notes**
 
@@ -1767,16 +1767,16 @@ Misc Py3 compatibility updates, part 2.
 
 **Merged pull requests:**
 
-- pull basestring from six.string_types - py2 gets basestring, py3 gets str [\#721](https://github.com/nerdvegas/rez/pull/721) ([maxnbk](https://github.com/maxnbk))
-- import StringIO from six.moves [\#722](https://github.com/nerdvegas/rez/pull/722) ([maxnbk](https://github.com/maxnbk))
-- update vendored colorama from 0.3.1 to 0.4.1 [\#723](https://github.com/nerdvegas/rez/pull/723) ([maxnbk](https://github.com/maxnbk))
-- update vendored memcache from 1.5.3 to 1.5.9 [\#724](https://github.com/nerdvegas/rez/pull/724) ([maxnbk](https://github.com/maxnbk))
-- make Version properly iterable in py3 [\#725](https://github.com/nerdvegas/rez/pull/725) ([maxnbk](https://github.com/maxnbk))
-- modernize function manipulations and attrs [\#727](https://github.com/nerdvegas/rez/pull/727) ([maxnbk](https://github.com/maxnbk))
+- pull basestring from six.string_types - py2 gets basestring, py3 gets str [\#721](https://github.com/AcademySoftwareFoundation/rez/pull/721) ([maxnbk](https://github.com/maxnbk))
+- import StringIO from six.moves [\#722](https://github.com/AcademySoftwareFoundation/rez/pull/722) ([maxnbk](https://github.com/maxnbk))
+- update vendored colorama from 0.3.1 to 0.4.1 [\#723](https://github.com/AcademySoftwareFoundation/rez/pull/723) ([maxnbk](https://github.com/maxnbk))
+- update vendored memcache from 1.5.3 to 1.5.9 [\#724](https://github.com/AcademySoftwareFoundation/rez/pull/724) ([maxnbk](https://github.com/maxnbk))
+- make Version properly iterable in py3 [\#725](https://github.com/AcademySoftwareFoundation/rez/pull/725) ([maxnbk](https://github.com/maxnbk))
+- modernize function manipulations and attrs [\#727](https://github.com/AcademySoftwareFoundation/rez/pull/727) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.43.0 (2019-09-05)
-[Source](https://github.com/nerdvegas/rez/tree/2.43.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.42.2...2.43.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.43.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.42.2...2.43.0)
 
 **Notes**
 
@@ -1784,26 +1784,26 @@ Misc Py3 compatibility updates.
 
 **Merged pull requests:**
 
-- very small py3 compat changes [\#712](https://github.com/nerdvegas/rez/pull/712) ([maxnbk](https://github.com/maxnbk))
-- .next() to next() [\#713](https://github.com/nerdvegas/rez/pull/713) ([maxnbk](https://github.com/maxnbk))
-- yaml upgrade [\#714](https://github.com/nerdvegas/rez/pull/714) ([maxnbk](https://github.com/maxnbk))
-- improve non-string iterable handling [\#715](https://github.com/nerdvegas/rez/pull/715) ([maxnbk](https://github.com/maxnbk))
-- replace async with block to avoid py3 async keyword [\#716](https://github.com/nerdvegas/rez/pull/716) ([maxnbk](https://github.com/maxnbk))
-- import queue module through six [\#717](https://github.com/nerdvegas/rez/pull/717) ([maxnbk](https://github.com/maxnbk))
-- swap 2.6 support for 3.x in version module [\#718](https://github.com/nerdvegas/rez/pull/718) ([maxnbk](https://github.com/maxnbk))
+- very small py3 compat changes [\#712](https://github.com/AcademySoftwareFoundation/rez/pull/712) ([maxnbk](https://github.com/maxnbk))
+- .next() to next() [\#713](https://github.com/AcademySoftwareFoundation/rez/pull/713) ([maxnbk](https://github.com/maxnbk))
+- yaml upgrade [\#714](https://github.com/AcademySoftwareFoundation/rez/pull/714) ([maxnbk](https://github.com/maxnbk))
+- improve non-string iterable handling [\#715](https://github.com/AcademySoftwareFoundation/rez/pull/715) ([maxnbk](https://github.com/maxnbk))
+- replace async with block to avoid py3 async keyword [\#716](https://github.com/AcademySoftwareFoundation/rez/pull/716) ([maxnbk](https://github.com/maxnbk))
+- import queue module through six [\#717](https://github.com/AcademySoftwareFoundation/rez/pull/717) ([maxnbk](https://github.com/maxnbk))
+- swap 2.6 support for 3.x in version module [\#718](https://github.com/AcademySoftwareFoundation/rez/pull/718) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.42.2 (2019-08-31)
-[Source](https://github.com/nerdvegas/rez/tree/2.42.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.42.1...2.42.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.42.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.42.1...2.42.2)
 
 **Merged pull requests:**
 
-- fixed bez rezbuild.py breaking on old-style print [\#705](https://github.com/nerdvegas/rez/pull/705) ([nerdvegas](https://github.com/nerdvegas))
-- zsh tests passing by way of enabling analogue for bash shell completion [\#711](https://github.com/nerdvegas/rez/pull/711) ([maxnbk](https://github.com/maxnbk))
+- fixed bez rezbuild.py breaking on old-style print [\#705](https://github.com/AcademySoftwareFoundation/rez/pull/705) ([nerdvegas](https://github.com/nerdvegas))
+- zsh tests passing by way of enabling analogue for bash shell completion [\#711](https://github.com/AcademySoftwareFoundation/rez/pull/711) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.42.1 (2019-08-31)
-[Source](https://github.com/nerdvegas/rez/tree/2.42.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.42.0...2.42.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.42.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.42.0...2.42.1)
 
 **Notes**
 
@@ -1811,30 +1811,30 @@ This PR introduces py3 compatibilities that do not functionally alter py2 code.
 
 **Merged pull requests:**
 
-- miscellanous atomic nonaffective py2/py3 compatibilities [\#710](https://github.com/nerdvegas/rez/pull/710) ([maxnbk](https://github.com/maxnbk))
+- miscellanous atomic nonaffective py2/py3 compatibilities [\#710](https://github.com/AcademySoftwareFoundation/rez/pull/710) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.42.0 (2019-08-30)
-[Source](https://github.com/nerdvegas/rez/tree/2.42.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.41.0...2.42.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.42.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.41.0...2.42.0)
 
 **Merged pull requests:**
 
-- Pip improvements [\#667](https://github.com/nerdvegas/rez/pull/667) ([nerdvegas](https://github.com/nerdvegas))
-- remove unneeded backports / vendored libraries [\#702](https://github.com/nerdvegas/rez/pull/702) ([maxnbk](https://github.com/maxnbk))
+- Pip improvements [\#667](https://github.com/AcademySoftwareFoundation/rez/pull/667) ([nerdvegas](https://github.com/nerdvegas))
+- remove unneeded backports / vendored libraries [\#702](https://github.com/AcademySoftwareFoundation/rez/pull/702) ([maxnbk](https://github.com/maxnbk))
 
 
 ## 2.41.0 (2019-08-29)
-[Source](https://github.com/nerdvegas/rez/tree/2.41.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.3...2.41.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.41.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.40.3...2.41.0)
 
 **Merged pull requests:**
 
-- a few prints to py3-compat [\#701](https://github.com/nerdvegas/rez/pull/701) ([maxnbk](https://github.com/maxnbk))
-- Fixing error with changelog referenced before assigment [\#700](https://github.com/nerdvegas/rez/pull/700) ([bareya](https://github.com/bareya))
-- Adding GCC bind [\#699](https://github.com/nerdvegas/rez/pull/699) ([bareya](https://github.com/bareya))
+- a few prints to py3-compat [\#701](https://github.com/AcademySoftwareFoundation/rez/pull/701) ([maxnbk](https://github.com/maxnbk))
+- Fixing error with changelog referenced before assigment [\#700](https://github.com/AcademySoftwareFoundation/rez/pull/700) ([bareya](https://github.com/bareya))
+- Adding GCC bind [\#699](https://github.com/AcademySoftwareFoundation/rez/pull/699) ([bareya](https://github.com/bareya))
 
 
 ## 2.40.3 (2019-08-15)
-[Source](https://github.com/nerdvegas/rez/tree/2.40.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.2...2.40.3)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.40.3) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.40.2...2.40.3)
 
 **Notes**
 
@@ -1843,15 +1843,15 @@ in which plugins are loaded, so that builtins are loaded last.
 
 **Merged pull requests:**
 
-- Reverse order for plugins loading [\#692](https://github.com/nerdvegas/rez/pull/692) ([predat](https://github.com/predat))
+- Reverse order for plugins loading [\#692](https://github.com/AcademySoftwareFoundation/rez/pull/692) ([predat](https://github.com/predat))
 
 **Closed issues:**
 
-- rezplugins loading order [\#677](https://github.com/nerdvegas/rez/issues/677)
+- rezplugins loading order [\#677](https://github.com/AcademySoftwareFoundation/rez/issues/677)
 
 
 ## 2.40.2 (2019-08-15)
-[Source](https://github.com/nerdvegas/rez/tree/2.40.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.1...2.40.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.40.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.40.1...2.40.2)
 
 **Notes**
 
@@ -1866,11 +1866,11 @@ The behaviour on Windows is now:
 
 **Merged pull requests:**
 
-- [FIX] Make package resolve request respect case sensitivity -- Windows [\#689](https://github.com/nerdvegas/rez/pull/689) ([lambdaclan](https://github.com/lambdaclan))
+- [FIX] Make package resolve request respect case sensitivity -- Windows [\#689](https://github.com/AcademySoftwareFoundation/rez/pull/689) ([lambdaclan](https://github.com/lambdaclan))
 
 
 ## 2.40.1 (2019-08-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.40.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.0...2.40.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.40.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.40.0...2.40.1)
 
 **Notes**
 
@@ -1878,15 +1878,15 @@ Fixes regression introduced in v2.39.0.
 
 **Merged pull requests:**
 
-- added missing plugin config [\#690](https://github.com/nerdvegas/rez/pull/690) ([nerdvegas](https://github.com/nerdvegas))
+- added missing plugin config [\#690](https://github.com/AcademySoftwareFoundation/rez/pull/690) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- [Regression - Version >= 2.39.0] ConfigurationError: Error in Rez configuration under plugins.shell [\#688](https://github.com/nerdvegas/rez/issues/688)
+- [Regression - Version >= 2.39.0] ConfigurationError: Error in Rez configuration under plugins.shell [\#688](https://github.com/AcademySoftwareFoundation/rez/issues/688)
 
 
 ## 2.40.0 (2019-08-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.40.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.39.0...2.40.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.40.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.39.0...2.40.0)
 
 **Notes**
 
@@ -1894,15 +1894,15 @@ Fixes regression introduced in v2.39.0.
 
 **Merged pull requests:**
 
-- initial implementation of zsh shell plugin [\#686](https://github.com/nerdvegas/rez/pull/686) ([maxnbk](https://github.com/maxnbk))
+- initial implementation of zsh shell plugin [\#686](https://github.com/AcademySoftwareFoundation/rez/pull/686) ([maxnbk](https://github.com/maxnbk))
 
 **Closed issues:**
 
-- zsh plugin for rez [\#451](https://github.com/nerdvegas/rez/issues/451)
+- zsh plugin for rez [\#451](https://github.com/AcademySoftwareFoundation/rez/issues/451)
 
 
 ## 2.39.0 (2019-08-07)
-[Source](https://github.com/nerdvegas/rez/tree/2.39.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.38.2...2.39.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.39.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.38.2...2.39.0)
 
 **Notes**
 
@@ -1911,16 +1911,16 @@ Fixes regression introduced in v2.39.0.
 
 **Merged pull requests:**
 
-- Fix missing import in powershell plugin [\#674](https://github.com/nerdvegas/rez/pull/674) ([instinct-vfx](https://github.com/instinct-vfx))
-- Add powershell core 6+ support (pwsh) [\#679](https://github.com/nerdvegas/rez/pull/679) ([instinct-vfx](https://github.com/instinct-vfx))
+- Fix missing import in powershell plugin [\#674](https://github.com/AcademySoftwareFoundation/rez/pull/674) ([instinct-vfx](https://github.com/instinct-vfx))
+- Add powershell core 6+ support (pwsh) [\#679](https://github.com/AcademySoftwareFoundation/rez/pull/679) ([instinct-vfx](https://github.com/instinct-vfx))
 
 **Closed issues:**
 
-- Add shell plugin for poweshell 6+ [\#678](https://github.com/nerdvegas/rez/issues/678)
+- Add shell plugin for poweshell 6+ [\#678](https://github.com/AcademySoftwareFoundation/rez/issues/678)
 
 
 ## 2.38.2 (2019-07-23)
-[Source](https://github.com/nerdvegas/rez/tree/2.38.2) | [Diff](https://github.com/nerdvegas/rez/compare/2.38.1...2.38.2)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.38.2) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.38.1...2.38.2)
 
 **Notes**
 
@@ -1928,15 +1928,15 @@ Fixes regression in 2.38.0 that unintentionally renamed _rez_fwd tool to _rez-fw
 
 **Merged pull requests:**
 
-- fixed regression in 2.38.0 that unintentionally renamed _rez_fwd to _rez-fwd [\#676](https://github.com/nerdvegas/rez/pull/676) ([nerdvegas](https://github.com/nerdvegas))
+- fixed regression in 2.38.0 that unintentionally renamed _rez_fwd to _rez-fwd [\#676](https://github.com/AcademySoftwareFoundation/rez/pull/676) ([nerdvegas](https://github.com/nerdvegas))
 
 **Closed issues:**
 
-- build scripts generated with incorrect shebang arg [\#671](https://github.com/nerdvegas/rez/issues/671)
+- build scripts generated with incorrect shebang arg [\#671](https://github.com/AcademySoftwareFoundation/rez/issues/671)
 
 
 ## 2.38.1 (2019-07-20)
-[Source](https://github.com/nerdvegas/rez/tree/2.38.1) | [Diff](https://github.com/nerdvegas/rez/compare/2.38.0...2.38.1)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.38.1) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.38.0...2.38.1)
 
 **Notes**
 
@@ -1944,11 +1944,11 @@ Fixes issue on Windows where rez-bind'ing pip creates a broken package.
 
 **Merged pull requests:**
 
-- [Fix] Windows rez-bind pip [\#659](https://github.com/nerdvegas/rez/pull/659) ([lambdaclan](https://github.com/lambdaclan))
+- [Fix] Windows rez-bind pip [\#659](https://github.com/AcademySoftwareFoundation/rez/pull/659) ([lambdaclan](https://github.com/lambdaclan))
 
 
 ## 2.38.0 (2019-07-20)
-[Source](https://github.com/nerdvegas/rez/tree/2.38.0) | [Diff](https://github.com/nerdvegas/rez/compare/2.37.1...2.38.0)
+[Source](https://github.com/AcademySoftwareFoundation/rez/tree/2.38.0) | [Diff](https://github.com/AcademySoftwareFoundation/rez/compare/2.37.1...2.38.0)
 
 **Notes**
 
@@ -1965,11 +1965,11 @@ Updates the installer (install.py).
 
 **Merged pull requests:**
 
-- Installer updates [\#662](https://github.com/nerdvegas/rez/pull/662) ([nerdvegas](https://github.com/nerdvegas))
+- Installer updates [\#662](https://github.com/AcademySoftwareFoundation/rez/pull/662) ([nerdvegas](https://github.com/nerdvegas))
 
 
-## [2.37.1](https://github.com/nerdvegas/rez/tree/2.37.1) (2019-07-20)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.37.0...2.37.1)
+## [2.37.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.37.1) (2019-07-20)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.37.0...2.37.1)
 
 **Notes**
 
@@ -1980,11 +1980,11 @@ object, it now returns a list of graph objects.
 
 **Merged pull requests:**
 
-- Fix pydot regression [\#668](https://github.com/nerdvegas/rez/pull/668) ([nerdvegas](https://github.com/nerdvegas))
+- Fix pydot regression [\#668](https://github.com/AcademySoftwareFoundation/rez/pull/668) ([nerdvegas](https://github.com/nerdvegas))
 
 
-## [2.37.0](https://github.com/nerdvegas/rez/tree/2.37.0) (2019-07-19)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.36.2...2.37.0)
+## [2.37.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.37.0) (2019-07-19)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.36.2...2.37.0)
 
 **Notes**
 
@@ -1993,39 +1993,39 @@ https://docs.microsoft.com/en-us/powershell/
 
 **Merged pull requests:**
 
-- Implement PowerShell [\#644](https://github.com/nerdvegas/rez/pull/644) ([mottosso](https://github.com/mottosso))
+- Implement PowerShell [\#644](https://github.com/AcademySoftwareFoundation/rez/pull/644) ([mottosso](https://github.com/mottosso))
 
 
-## [2.36.2](https://github.com/nerdvegas/rez/tree/2.36.2) (2019-07-16)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.36.1...2.36.2)
-
-**Merged pull requests:**
-
-- [Feature] Pure python package detection [\#628](https://github.com/nerdvegas/rez/pull/628) ([lambdaclan](https://github.com/lambdaclan))
-
-
-## [2.36.1](https://github.com/nerdvegas/rez/tree/2.36.1) (2019-07-16)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.36.0...2.36.1)
+## [2.36.2](https://github.com/AcademySoftwareFoundation/rez/tree/2.36.2) (2019-07-16)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.36.1...2.36.2)
 
 **Merged pull requests:**
 
-- [Fix] Sh failing in `test_shells.TeshShells.text_rex_code_alias` [\#663](https://github.com/nerdvegas/rez/pull/663) ([bfloch](https://github.com/bfloch))
+- [Feature] Pure python package detection [\#628](https://github.com/AcademySoftwareFoundation/rez/pull/628) ([lambdaclan](https://github.com/lambdaclan))
 
 
-## [2.36.0](https://github.com/nerdvegas/rez/tree/2.36.0) (2019-07-16)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.35.0...2.36.0)
+## [2.36.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.36.1) (2019-07-16)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.36.0...2.36.1)
 
 **Merged pull requests:**
 
-- Add a package_preprocess_mode [\#651](https://github.com/nerdvegas/rez/pull/651) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- [Fix] Sh failing in `test_shells.TeshShells.text_rex_code_alias` [\#663](https://github.com/AcademySoftwareFoundation/rez/pull/663) ([bfloch](https://github.com/bfloch))
+
+
+## [2.36.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.36.0) (2019-07-16)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.35.0...2.36.0)
+
+**Merged pull requests:**
+
+- Add a package_preprocess_mode [\#651](https://github.com/AcademySoftwareFoundation/rez/pull/651) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
 
 **Closed issues:**
 
-- Support "additive" preprocess functions [\#609](https://github.com/nerdvegas/rez/issues/609)
+- Support "additive" preprocess functions [\#609](https://github.com/AcademySoftwareFoundation/rez/issues/609)
 
 
-## [2.35.0](https://github.com/nerdvegas/rez/tree/2.35.0) (2019-07-10)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.34.0...2.35.0)
+## [2.35.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.35.0) (2019-07-10)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.34.0...2.35.0)
 
 **Backwards Compatibility Issues**
 
@@ -2035,225 +2035,225 @@ be on the lookout for unintended side effects and report them if they arise.
 
 **Merged pull requests:**
 
-- WIP No more "Terminate Batch Job? (Y/N)" - Take 2 [\#627](https://github.com/nerdvegas/rez/pull/627) ([mottosso](https://github.com/mottosso))
+- WIP No more "Terminate Batch Job? (Y/N)" - Take 2 [\#627](https://github.com/AcademySoftwareFoundation/rez/pull/627) ([mottosso](https://github.com/mottosso))
 
 **Closed issues:**
 
-- Shell history not working in cmd.exe or PowerShell [\#616](https://github.com/nerdvegas/rez/issues/616)
+- Shell history not working in cmd.exe or PowerShell [\#616](https://github.com/AcademySoftwareFoundation/rez/issues/616)
 
 
-## [2.34.0](https://github.com/nerdvegas/rez/tree/2.34.0) (2019-07-10)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.33.0...2.34.0)
-
-**Merged pull requests:**
-
-- [Fix] Wheel pip regressions [\#656](https://github.com/nerdvegas/rez/pull/656) ([lambdaclan](https://github.com/lambdaclan))
-
-
-## [2.33.0](https://github.com/nerdvegas/rez/tree/2.33.0) (2019-06-26)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.32.1...2.33.0)
+## [2.34.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.34.0) (2019-07-10)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.33.0...2.34.0)
 
 **Merged pull requests:**
 
-- Update distlib vendor library [\#654](https://github.com/nerdvegas/rez/pull/654) ([lambdaclan](https://github.com/lambdaclan))
-- [WIP] Feature/pip install modern [\#602](https://github.com/nerdvegas/rez/pull/602) ([lambdaclan](https://github.com/lambdaclan))
+- [Fix] Wheel pip regressions [\#656](https://github.com/AcademySoftwareFoundation/rez/pull/656) ([lambdaclan](https://github.com/lambdaclan))
 
 
-## [2.32.1](https://github.com/nerdvegas/rez/tree/2.32.1) (2019-06-24)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.32.0...2.32.1)
-
-**Merged pull requests:**
-
-- Support for external PyYAML and Python 3 [\#622](https://github.com/nerdvegas/rez/pull/622) ([mottosso](https://github.com/mottosso))
-- Fix escaping backslashes in tcsh on Mac OS [\#497](https://github.com/nerdvegas/rez/pull/497) ([skral](https://github.com/skral))
-
-
-## [2.32.0](https://github.com/nerdvegas/rez/tree/2.32.0) (2019-06-23)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.31.4...2.32.0)
+## [2.33.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.33.0) (2019-06-26)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.32.1...2.33.0)
 
 **Merged pull requests:**
 
-- Implement preprocess function support for rezconfig.py (takeover) [\#650](https://github.com/nerdvegas/rez/pull/650) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+- Update distlib vendor library [\#654](https://github.com/AcademySoftwareFoundation/rez/pull/654) ([lambdaclan](https://github.com/lambdaclan))
+- [WIP] Feature/pip install modern [\#602](https://github.com/AcademySoftwareFoundation/rez/pull/602) ([lambdaclan](https://github.com/lambdaclan))
 
 
-## [2.31.4](https://github.com/nerdvegas/rez/tree/2.31.4) (2019-06-22)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.31.3...2.31.4)
-
-**Merged pull requests:**
-
-- Expose Python standard module __file__ and __name__ to rezconfig [\#636](https://github.com/nerdvegas/rez/pull/636) ([mottosso](https://github.com/mottosso))
-
-
-## [2.31.3](https://github.com/nerdvegas/rez/tree/2.31.3) (2019-06-22)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.31.2...2.31.3)
+## [2.32.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.32.1) (2019-06-24)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.32.0...2.32.1)
 
 **Merged pull requests:**
 
-- Bugfix for alias() on Windows [\#607](https://github.com/nerdvegas/rez/pull/607) ([mottosso](https://github.com/mottosso))
+- Support for external PyYAML and Python 3 [\#622](https://github.com/AcademySoftwareFoundation/rez/pull/622) ([mottosso](https://github.com/mottosso))
+- Fix escaping backslashes in tcsh on Mac OS [\#497](https://github.com/AcademySoftwareFoundation/rez/pull/497) ([skral](https://github.com/skral))
 
 
-## [2.31.2](https://github.com/nerdvegas/rez/tree/2.31.2) (2019-06-22)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.31.1...2.31.2)
+## [2.32.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.32.0) (2019-06-23)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.31.4...2.32.0)
 
 **Merged pull requests:**
 
-- Fix #558 [\#647](https://github.com/nerdvegas/rez/pull/647) ([mottosso](https://github.com/mottosso))
+- Implement preprocess function support for rezconfig.py (takeover) [\#650](https://github.com/AcademySoftwareFoundation/rez/pull/650) ([JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
+
+
+## [2.31.4](https://github.com/AcademySoftwareFoundation/rez/tree/2.31.4) (2019-06-22)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.31.3...2.31.4)
+
+**Merged pull requests:**
+
+- Expose Python standard module __file__ and __name__ to rezconfig [\#636](https://github.com/AcademySoftwareFoundation/rez/pull/636) ([mottosso](https://github.com/mottosso))
+
+
+## [2.31.3](https://github.com/AcademySoftwareFoundation/rez/tree/2.31.3) (2019-06-22)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.31.2...2.31.3)
+
+**Merged pull requests:**
+
+- Bugfix for alias() on Windows [\#607](https://github.com/AcademySoftwareFoundation/rez/pull/607) ([mottosso](https://github.com/mottosso))
+
+
+## [2.31.2](https://github.com/AcademySoftwareFoundation/rez/tree/2.31.2) (2019-06-22)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.31.1...2.31.2)
+
+**Merged pull requests:**
+
+- Fix #558 [\#647](https://github.com/AcademySoftwareFoundation/rez/pull/647) ([mottosso](https://github.com/mottosso))
 
 **Closed issues:**
 
-- rez-build breaks if "|" in a required package's version on Windows [\#558](https://github.com/nerdvegas/rez/issues/558)
+- rez-build breaks if "|" in a required package's version on Windows [\#558](https://github.com/AcademySoftwareFoundation/rez/issues/558)
 
 
-## [2.31.1](https://github.com/nerdvegas/rez/tree/2.31.1) (2019-06-18)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.31.0...2.31.1)
-
-**Merged pull requests:**
-
-- Automatically create missing package repository dir [\#623](https://github.com/nerdvegas/rez/pull/623) ([mottosso](https://github.com/mottosso))
-
-
-## [2.31.0](https://github.com/nerdvegas/rez/tree/2.31.0) (2019-06-04)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.30.2...2.31.0)
+## [2.31.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.31.1) (2019-06-18)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.31.0...2.31.1)
 
 **Merged pull requests:**
 
-- Fix/add support for reversed version range [\#618](https://github.com/nerdvegas/rez/pull/618) ([instinct-vfx](https://github.com/instinct-vfx))
+- Automatically create missing package repository dir [\#623](https://github.com/AcademySoftwareFoundation/rez/pull/623) ([mottosso](https://github.com/mottosso))
 
 
-## [2.30.2](https://github.com/nerdvegas/rez/tree/2.30.2) (2019-06-03)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.30.1...2.30.2)
-
-**Merged pull requests:**
-
-- Update print statements to be Python 3 compatible [\#641](https://github.com/nerdvegas/rez/pull/641) ([bpabel](https://github.com/bpabel))
-
-
-## [2.30.1](https://github.com/nerdvegas/rez/tree/2.30.1) (2019-06-03)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.30.0...2.30.1)
+## [2.31.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.31.0) (2019-06-04)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.30.2...2.31.0)
 
 **Merged pull requests:**
 
-- WIP Fix file permissions of package.py on Windows [\#598](https://github.com/nerdvegas/rez/pull/598) ([mottosso](https://github.com/mottosso))
+- Fix/add support for reversed version range [\#618](https://github.com/AcademySoftwareFoundation/rez/pull/618) ([instinct-vfx](https://github.com/instinct-vfx))
 
 
-## [2.30.0](https://github.com/nerdvegas/rez/tree/2.30.0) (2019-05-07)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.29.1...2.30.0)
+## [2.30.2](https://github.com/AcademySoftwareFoundation/rez/tree/2.30.2) (2019-06-03)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.30.1...2.30.2)
 
 **Merged pull requests:**
 
-- fqdn [\#621](https://github.com/nerdvegas/rez/pull/621) ([bpabel](https://github.com/bpabel))
-- Fix path list with whitespace [\#588](https://github.com/nerdvegas/rez/pull/588) ([asztalosdani](https://github.com/asztalosdani))
-- Close the amqp connection after message publish [\#615](https://github.com/nerdvegas/rez/pull/615) ([loup-kreidl](https://github.com/loup-kreidl))
+- Update print statements to be Python 3 compatible [\#641](https://github.com/AcademySoftwareFoundation/rez/pull/641) ([bpabel](https://github.com/bpabel))
+
+
+## [2.30.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.30.1) (2019-06-03)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.30.0...2.30.1)
+
+**Merged pull requests:**
+
+- WIP Fix file permissions of package.py on Windows [\#598](https://github.com/AcademySoftwareFoundation/rez/pull/598) ([mottosso](https://github.com/mottosso))
+
+
+## [2.30.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.30.0) (2019-05-07)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.29.1...2.30.0)
+
+**Merged pull requests:**
+
+- fqdn [\#621](https://github.com/AcademySoftwareFoundation/rez/pull/621) ([bpabel](https://github.com/bpabel))
+- Fix path list with whitespace [\#588](https://github.com/AcademySoftwareFoundation/rez/pull/588) ([asztalosdani](https://github.com/asztalosdani))
+- Close the amqp connection after message publish [\#615](https://github.com/AcademySoftwareFoundation/rez/pull/615) ([loup-kreidl](https://github.com/loup-kreidl))
 
 **Closed issues:**
 
-- rezbuild.py broken [\#619](https://github.com/nerdvegas/rez/issues/619)
-- rez-env Performance and socket.getfqdn() [\#617](https://github.com/nerdvegas/rez/issues/617)
-- "parse_build_args.py" file parser arguments are not accessible anymore in "os.environ". [\#590](https://github.com/nerdvegas/rez/issues/590)
+- rezbuild.py broken [\#619](https://github.com/AcademySoftwareFoundation/rez/issues/619)
+- rez-env Performance and socket.getfqdn() [\#617](https://github.com/AcademySoftwareFoundation/rez/issues/617)
+- "parse_build_args.py" file parser arguments are not accessible anymore in "os.environ". [\#590](https://github.com/AcademySoftwareFoundation/rez/issues/590)
 
 
-## [2.29.1](https://github.com/nerdvegas/rez/tree/2.29.1) (2019-04-22)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.29.0...2.29.1)
+## [2.29.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.29.1) (2019-04-22)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.29.0...2.29.1)
 
 **Merged pull requests:**
 
-- Bugfix/custom build arguments [\#601](https://github.com/nerdvegas/rez/pull/601) ([lambdaclan](https://github.com/lambdaclan))
+- Bugfix/custom build arguments [\#601](https://github.com/AcademySoftwareFoundation/rez/pull/601) ([lambdaclan](https://github.com/lambdaclan))
 
 **Closed issues:**
 
-- bug in rez-build --bs option [\#604](https://github.com/nerdvegas/rez/issues/604)
+- bug in rez-build --bs option [\#604](https://github.com/AcademySoftwareFoundation/rez/issues/604)
 
 
-## [2.29.0](https://github.com/nerdvegas/rez/tree/2.29.0) (2019-04-09)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.28.0...2.29.0)
+## [2.29.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.29.0) (2019-04-09)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.28.0...2.29.0)
 
 **Implemented enhancements:**
 
-- hash-based variant subpaths [\#583](https://github.com/nerdvegas/rez/issues/583)
+- hash-based variant subpaths [\#583](https://github.com/AcademySoftwareFoundation/rez/issues/583)
 
 **Closed issues:**
 
-- rez variant environment var during build [\#304](https://github.com/nerdvegas/rez/issues/304)
+- rez variant environment var during build [\#304](https://github.com/AcademySoftwareFoundation/rez/issues/304)
 
 
-## [2.28.0](https://github.com/nerdvegas/rez/tree/2.28.0) (2019-03-15)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.27.1...2.28.0)
+## [2.28.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.28.0) (2019-03-15)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.27.1...2.28.0)
 
 **Fixed bugs:**
 
-- nargs errors for logging_.print_* functions [\#580](https://github.com/nerdvegas/rez/issues/580)
+- nargs errors for logging_.print_* functions [\#580](https://github.com/AcademySoftwareFoundation/rez/issues/580)
 
 **Merged pull requests:**
 
-- Ignore versions if .ignore file exists [\#453](https://github.com/nerdvegas/rez/pull/453) ([Pixomondo](https://github.com/Pixomondo))
-- Fix/logging print nargs [\#581](https://github.com/nerdvegas/rez/pull/581) ([wwfxuk](https://github.com/wwfxuk))
-- package_test.py: fix rez-test header command with % [\#572](https://github.com/nerdvegas/rez/pull/572) ([rodeofx](https://github.com/rodeofx))
-- Call the flush method every time a Printer instance is called [\#540](https://github.com/nerdvegas/rez/pull/540) ([rodeofx](https://github.com/rodeofx))
+- Ignore versions if .ignore file exists [\#453](https://github.com/AcademySoftwareFoundation/rez/pull/453) ([Pixomondo](https://github.com/Pixomondo))
+- Fix/logging print nargs [\#581](https://github.com/AcademySoftwareFoundation/rez/pull/581) ([wwfxuk](https://github.com/wwfxuk))
+- package_test.py: fix rez-test header command with % [\#572](https://github.com/AcademySoftwareFoundation/rez/pull/572) ([rodeofx](https://github.com/rodeofx))
+- Call the flush method every time a Printer instance is called [\#540](https://github.com/AcademySoftwareFoundation/rez/pull/540) ([rodeofx](https://github.com/rodeofx))
 
 
-## [2.27.1](https://github.com/nerdvegas/rez/tree/2.27.1) (2019-03-15)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.27.0...2.27.1)
+## [2.27.1](https://github.com/AcademySoftwareFoundation/rez/tree/2.27.1) (2019-03-15)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.27.0...2.27.1)
 
 **Merged pull requests:**
 
-- Delete old repository directory [\#576](https://github.com/nerdvegas/rez/pull/576) ([bpabel](https://github.com/bpabel))
+- Delete old repository directory [\#576](https://github.com/AcademySoftwareFoundation/rez/pull/576) ([bpabel](https://github.com/bpabel))
 
 
-## [2.27.0](https://github.com/nerdvegas/rez/tree/2.27.0) (2019-01-24)
-[Full Changelog](https://github.com/nerdvegas/rez/compare/2.26.4...2.27.0)
+## [2.27.0](https://github.com/AcademySoftwareFoundation/rez/tree/2.27.0) (2019-01-24)
+[Full Changelog](https://github.com/AcademySoftwareFoundation/rez/compare/2.26.4...2.27.0)
 
 **Implemented enhancements:**
 
-- facilitate variant install when target package is read-only [\#565](https://github.com/nerdvegas/rez/issues/565)
+- facilitate variant install when target package is read-only [\#565](https://github.com/AcademySoftwareFoundation/rez/issues/565)
 
 **Fixed bugs:**
 
-- timestamp override no working in package copy [\#568](https://github.com/nerdvegas/rez/issues/568)
-- shallow rez-cp can corrupt package if there are overlapping variants [\#563](https://github.com/nerdvegas/rez/issues/563)
+- timestamp override no working in package copy [\#568](https://github.com/AcademySoftwareFoundation/rez/issues/568)
+- shallow rez-cp can corrupt package if there are overlapping variants [\#563](https://github.com/AcademySoftwareFoundation/rez/issues/563)
 
 **Merged pull requests:**
 
-- Issue 568 [\#569](https://github.com/nerdvegas/rez/pull/569) ([nerdvegas](https://github.com/nerdvegas))
-- Issue 565 [\#567](https://github.com/nerdvegas/rez/pull/567) ([nerdvegas](https://github.com/nerdvegas))
-- Issue 563 [\#566](https://github.com/nerdvegas/rez/pull/566) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 568 [\#569](https://github.com/AcademySoftwareFoundation/rez/pull/569) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 565 [\#567](https://github.com/AcademySoftwareFoundation/rez/pull/567) ([nerdvegas](https://github.com/nerdvegas))
+- Issue 563 [\#566](https://github.com/AcademySoftwareFoundation/rez/pull/566) ([nerdvegas](https://github.com/nerdvegas))
 
 
-## 2.26.4 [[#562](https://github.com/nerdvegas/rez/pull/562)] Fixed Regression in 2.24.0
-
-#### Addressed Issues
-
-* [#561](https://github.com/nerdvegas/rez/issues/561) timestamp not written to installed package
-
-
-## 2.26.3 [[#560](https://github.com/nerdvegas/rez/pull/560)] Package.py permissions issue
+## 2.26.4 [[#562](https://github.com/AcademySoftwareFoundation/rez/pull/562)] Fixed Regression in 2.24.0
 
 #### Addressed Issues
 
-* [#559](https://github.com/nerdvegas/rez/issues/559) package.py permissions issue
+* [#561](https://github.com/AcademySoftwareFoundation/rez/issues/561) timestamp not written to installed package
+
+
+## 2.26.3 [[#560](https://github.com/AcademySoftwareFoundation/rez/pull/560)] Package.py permissions issue
+
+#### Addressed Issues
+
+* [#559](https://github.com/AcademySoftwareFoundation/rez/issues/559) package.py permissions issue
 
 #### Notes
 
 Fixes issue where installed `package.py` can be set to r/w for only the current user.
 
 
-## 2.26.2 [[#557](https://github.com/nerdvegas/rez/pull/557)] Package Copy Fixes For Non-Varianted Packages
+## 2.26.2 [[#557](https://github.com/AcademySoftwareFoundation/rez/pull/557)] Package Copy Fixes For Non-Varianted Packages
 
 #### Addressed Issues
 
-* [#556](https://github.com/nerdvegas/rez/issues/556) rez-cp briefly copies original package definition in non-varianted packages
-* [#555](https://github.com/nerdvegas/rez/issues/555) rez-cp inconsistent symlinking when --shallow=true
-* [#554](https://github.com/nerdvegas/rez/issues/554) rez-cp doesn't keep file metadata in some cases
+* [#556](https://github.com/AcademySoftwareFoundation/rez/issues/556) rez-cp briefly copies original package definition in non-varianted packages
+* [#555](https://github.com/AcademySoftwareFoundation/rez/issues/555) rez-cp inconsistent symlinking when --shallow=true
+* [#554](https://github.com/AcademySoftwareFoundation/rez/issues/554) rez-cp doesn't keep file metadata in some cases
 
 #### Notes
 
 There were various minor issues related to copying non-varianted packages.
 
 
-## 2.26.1 [[#552](https://github.com/nerdvegas/rez/pull/552)] Bugfix in Package Copy
+## 2.26.1 [[#552](https://github.com/AcademySoftwareFoundation/rez/pull/552)] Bugfix in Package Copy
 
 #### Addressed Issues
 
-* [#551](https://github.com/nerdvegas/rez/issues/551) package copy fails if symlinks in root dir
+* [#551](https://github.com/AcademySoftwareFoundation/rez/issues/551) package copy fails if symlinks in root dir
 
 #### Notes
 
@@ -2261,11 +2261,11 @@ This was failing when symlinks were present within a non-varianted package being
 symlinks are retained in the target package, unless `--follow-symlinks` is specified.
 
 
-## 2.26.0 [[#550](https://github.com/nerdvegas/rez/pull/550)] Build System Detection Fixes
+## 2.26.0 [[#550](https://github.com/AcademySoftwareFoundation/rez/pull/550)] Build System Detection Fixes
 
 #### Addressed Issues
 
-* [#549](https://github.com/nerdvegas/rez/issues/549) '--build-system' rez-build option not always
+* [#549](https://github.com/AcademySoftwareFoundation/rez/issues/549) '--build-system' rez-build option not always
   available
 
 #### Notes
@@ -2273,7 +2273,7 @@ symlinks are retained in the target package, unless `--follow-symlinks` is speci
 To fix this issue:
 * The '--build-system' rez-build option is now always present.
 * To provide further control over the build system type, the package itself can now specify its build
-  system - see https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide#build_system
+  system - see https://github.com/AcademySoftwareFoundation/rez/wiki/Package-Definition-Guide#build_system
 
 #### COMPATIBILITY ISSUE!
 
@@ -2283,15 +2283,15 @@ one valid build system was present for a given package working directory. **This
 changed to '--cmake-build-system'**.
 
 
-## 2.25.0 [[#548](https://github.com/nerdvegas/rez/pull/548)] Various Build-related issues
+## 2.25.0 [[#548](https://github.com/AcademySoftwareFoundation/rez/pull/548)] Various Build-related issues
 
 #### Addressed Issues
 
-* [#433](https://github.com/nerdvegas/rez/issues/433): "package_definition_build_python_paths" defined
+* [#433](https://github.com/AcademySoftwareFoundation/rez/issues/433): "package_definition_build_python_paths" defined
   paths are not available from top level in package.py
-* [#442](https://github.com/nerdvegas/rez/issues/442): "rez-depends" and "private_build_requires"
-* [#416](https://github.com/nerdvegas/rez/issues/416): Need currently-building-variant build variables
-* [#547](https://github.com/nerdvegas/rez/issues/547): rez-cp follows symlinks within package payload
+* [#442](https://github.com/AcademySoftwareFoundation/rez/issues/442): "rez-depends" and "private_build_requires"
+* [#416](https://github.com/AcademySoftwareFoundation/rez/issues/416): Need currently-building-variant build variables
+* [#547](https://github.com/AcademySoftwareFoundation/rez/issues/547): rez-cp follows symlinks within package payload
 
 #### Notes
 
@@ -2300,7 +2300,7 @@ building, build_variant_index and build_variant_requires. This allows you to do 
 different private_build_requires per-variant, or a requires that is different at runtime than it is
 at build time. In order to get this to work, a package.py is now re-evaluated multiple times when a
 build occurs - once pre-build (where 'building' is set to False), and once per variant build. Please
-see the updated wiki for more details: https://github.com/nerdvegas/rez/wiki/Package-Definition-Guide#available-objects
+see the updated wiki for more details: https://github.com/AcademySoftwareFoundation/rez/wiki/Package-Definition-Guide#available-objects
 
 A new build-time env-var, REZ_BUILD_VARIANT_REQUIRES, has been added. This mirrors the new
 build_variant_requires var mentioned above.
@@ -2346,7 +2346,7 @@ another, with optional renaming/reversioning. The associated API can be found in
 
 #### Notes
 
-Bug was introduced in: https://github.com/nerdvegas/rez/releases/tag/2.20.0
+Bug was introduced in: https://github.com/AcademySoftwareFoundation/rez/releases/tag/2.20.0
 
 
 ## 2.23.0: Package Usage Tracking, Better Config Overrides
@@ -2367,7 +2367,7 @@ package_filter.
 
 Track context creation and sourcing via AMQP. Messages are published (on a separate thread) to the
 nominated broker/exchange/routing_key. You have control over what parts of the context are published.
-For more details: https://github.com/nerdvegas/rez/blob/master/src/rez/rezconfig.py#L414
+For more details: https://github.com/AcademySoftwareFoundation/rez/blob/master/src/rez/rezconfig.py#L414
 
 The embedded simplejson lib was removed. The native json lib is used instead, and for cases where loads-without-unicoding-everything is needed, utils/json.py now addresses that instead.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Release](https://shields.io/github/v/release/nerdvegas/rez)](https://github.com/nerdvegas/rez/releases)
+[![Release](https://shields.io/github/v/release/AcademySoftwareFoundation/rez)](https://github.com/AcademySoftwareFoundation/rez/releases)
 [![Pypy Release](https://shields.io/pypi/v/rez)](https://pypi.org/project/rez)<br>
-[![Core](https://github.com/nerdvegas/rez/workflows/core/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3Acore+branch%3Amaster)
-[![Ubuntu](https://github.com/nerdvegas/rez/workflows/ubuntu/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3Aubuntu+branch%3Amaster)
-[![Mac](https://github.com/nerdvegas/rez/workflows/mac/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3Amac+branch%3Amaster)
-[![Windows](https://github.com/nerdvegas/rez/workflows/windows/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3AWindows+branch%3Amaster)<br>
-[![Installation](https://github.com/nerdvegas/rez/workflows/installation/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3Ainstallation+branch%3Amaster)
-[![Flake8](https://github.com/nerdvegas/rez/workflows/flake8/badge.svg?branch=master)](https://github.com/nerdvegas/rez/actions?query=workflow%3Aflake8+branch%3Amaster)
-[![Wiki](https://github.com/nerdvegas/rez/workflows/wiki/badge.svg)](https://github.com/nerdvegas/rez/actions?query=workflow%3Awiki+event%3Arelease)
-[![Pypi](https://github.com/nerdvegas/rez/workflows/pypi/badge.svg)](https://github.com/nerdvegas/rez/actions?query=workflow%3Apypi+event%3Arelease)
-[![Benchmark](https://github.com/nerdvegas/rez/workflows/benchmark/badge.svg)](https://github.com/nerdvegas/rez/actions?query=workflow%3Abenchmark+event%3Arelease)<br>
+[![Core](https://github.com/AcademySoftwareFoundation/rez/workflows/core/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Acore+branch%3Amaster)
+[![Ubuntu](https://github.com/AcademySoftwareFoundation/rez/workflows/ubuntu/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Aubuntu+branch%3Amaster)
+[![Mac](https://github.com/AcademySoftwareFoundation/rez/workflows/mac/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Amac+branch%3Amaster)
+[![Windows](https://github.com/AcademySoftwareFoundation/rez/workflows/windows/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3AWindows+branch%3Amaster)<br>
+[![Installation](https://github.com/AcademySoftwareFoundation/rez/workflows/installation/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Ainstallation+branch%3Amaster)
+[![Flake8](https://github.com/AcademySoftwareFoundation/rez/workflows/flake8/badge.svg?branch=master)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Aflake8+branch%3Amaster)
+[![Wiki](https://github.com/AcademySoftwareFoundation/rez/workflows/wiki/badge.svg)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Awiki+event%3Arelease)
+[![Pypi](https://github.com/AcademySoftwareFoundation/rez/workflows/pypi/badge.svg)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Apypi+event%3Arelease)
+[![Benchmark](https://github.com/AcademySoftwareFoundation/rez/workflows/benchmark/badge.svg)](https://github.com/AcademySoftwareFoundation/rez/actions?query=workflow%3Abenchmark+event%3Arelease)<br>
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=nerdvegas_rez&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=nerdvegas_rez)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=nerdvegas_rez&metric=bugs)](https://sonarcloud.io/summary/new_code?id=nerdvegas_rez)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=nerdvegas_rez&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=nerdvegas_rez)
@@ -35,18 +35,18 @@ environments reference these existing packages. This means that configured envir
 are lightweight, and very fast to create, often taking just a few seconds to configure
 despite containing hundreds of packages.
 
-See [the wiki](https://github.com/nerdvegas/rez/wiki) for full documentation.
+See [the wiki](https://github.com/AcademySoftwareFoundation/rez/wiki) for full documentation.
 
 <p align="center">
-<a href="https://github.com/nerdvegas/rez/wiki/media/other_pkg_mgr.png">
-<img src="https://github.com/nerdvegas/rez/wiki/media/other_pkg_mgr.png"></a>
+<a href="https://github.com/AcademySoftwareFoundation/rez/wiki/media/other_pkg_mgr.png">
+<img src="https://github.com/AcademySoftwareFoundation/rez/wiki/media/other_pkg_mgr.png"></a>
 <br><i>Typical package managers install packages into an environment</i>
 </p>
 
 <br>
 <p align="center">
-<a href="https://github.com/nerdvegas/rez/wiki/media/rez_pkg_mgr.png">
-<img src="https://github.com/nerdvegas/rez/wiki/media/rez_pkg_mgr.png"></a>
+<a href="https://github.com/AcademySoftwareFoundation/rez/wiki/media/rez_pkg_mgr.png">
+<img src="https://github.com/AcademySoftwareFoundation/rez/wiki/media/rez_pkg_mgr.png"></a>
 <br><i>Rez installs packages once, and configures environments dynamically</i>
 </p>
 
@@ -90,7 +90,7 @@ and when re-evaluated later will reconstruct the same environment once more.
 ## Examples
 
 This example places the user into a resolved shell containing the requested packages,
-using the [rez-env](https://github.com/nerdvegas/rez/wiki/Command-Line-Tools#rez-env) tool:
+using the [rez-env](https://github.com/AcademySoftwareFoundation/rez/wiki/Command-Line-Tools#rez-env) tool:
 
     ]$ rez-env requests-2.2+ python-2.6 'pymongo-0+<2.7'
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     long_description_content_type='text/markdown',
     url="https://github.com/AcademySoftwareFoundation/rez",
     author="Allan Johns",
-    author_email="nerdvegas@gmail.com",
+    author_email="rez-discussion@lists.aswf.io",
     license="Apache License 2.0",
     entry_points={
         "console_scripts": get_specifications().values()

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -129,7 +129,7 @@ def _run_command(args):
     cmd_str = ' '.join(quote(x) for x in args)
     log("running: %s" % cmd_str)
 
-    # https://github.com/nerdvegas/rez/pull/659
+    # https://github.com/AcademySoftwareFoundation/rez/pull/659
     use_shell = ("Windows" in platform.system())
 
     p = Popen(

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -158,7 +158,7 @@ class RezPluginType(object):
                     print_debug("loading %s plugin at %s: %s..."
                                 % (self.type_name, path, modname))
                 try:
-                    # https://github.com/nerdvegas/rez/pull/218
+                    # https://github.com/AcademySoftwareFoundation/rez/pull/218
                     # load_module will force reload the module if it's
                     # already loaded, so check for that
                     plugin_module = sys.modules.get(modname)

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -1033,7 +1033,7 @@ disable_rez_1_compatibility = False
 ###############################################################################
 
 # Where Rez's own documentation is hosted
-documentation_url = "https://github.com/nerdvegas/rez/wiki"
+documentation_url = "https://github.com/AcademySoftwareFoundation/rez/wiki"
 
 
 ###############################################################################

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -480,7 +480,7 @@ class TestRex(TestBase):
 
         request = RequirementsBinding([])
         bar_on = intersects(request.get("foo.bar", "foo.bar-0"), "1")
-        self.assertFalse(bar_on)  # workaround, see https://github.com/nerdvegas/rez/pull/1030
+        self.assertFalse(bar_on)  # workaround, see https://github.com/AcademySoftwareFoundation/rez/pull/1030
 
         # request.get_range
         request = RequirementsBinding([Requirement("foo.bar-1")])
@@ -516,7 +516,7 @@ class TestRex(TestBase):
 
         ephemerals = EphemeralsBinding([])
         bar_on = intersects(ephemerals.get("foo.bar", "foo.bar-0"), "1")
-        self.assertFalse(bar_on)  # workaround, see https://github.com/nerdvegas/rez/pull/1030
+        self.assertFalse(bar_on)  # workaround, see https://github.com/AcademySoftwareFoundation/rez/pull/1030
 
         ephemerals = EphemeralsBinding([])
         self.assertRaises(RuntimeError,  # no default

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -231,7 +231,7 @@ class TestShells(TestBase, TempdirMixin):
             os.remove(path)
 
     # TODO fix cmd shell command string escape
-    # as per https://github.com/nerdvegas/rez/pull/1130, then remove this
+    # as per https://github.com/AcademySoftwareFoundation/rez/pull/1130, then remove this
     # exclusion
     #
     @per_available_shell(exclude=["cmd"])

--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -59,7 +59,7 @@ class Popen(_PopenBase):
             try:
                 file_no = sys.stdin.fileno()
 
-            # https://github.com/nerdvegas/rez/pull/966
+            # https://github.com/AcademySoftwareFoundation/rez/pull/966
             except (AttributeError, io.UnsupportedOperation):
                 file_no = None
 
@@ -140,7 +140,7 @@ def create_executable_script(filepath, body, program=None, py_script_mode=None):
     program = program or "python"
     py_script_mode = py_script_mode or config.create_executable_script_mode
 
-    # https://github.com/nerdvegas/rez/pull/968
+    # https://github.com/AcademySoftwareFoundation/rez/pull/968
     is_forwarding_script_on_windows = (
         program == "_rez_fwd"
         and platform_.name == "windows"

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -330,7 +330,7 @@ def make_tmp_name(name):
     path, base = os.path.split(name)
 
     # there's a reason this isn't a hidden file:
-    # https://github.com/nerdvegas/rez/pull/1088
+    # https://github.com/AcademySoftwareFoundation/rez/pull/1088
     #
     tmp_base = "_tmp-%s-%s" % (base, uuid4().hex)
 

--- a/src/rez/vendor/distlib/util.py
+++ b/src/rez/vendor/distlib/util.py
@@ -216,7 +216,7 @@ def parse_requirement(req):
                             break
                         ver_remaining = ver_remaining[1:].lstrip()
 
-                        # https://github.com/nerdvegas/rez/pull/1092
+                        # https://github.com/AcademySoftwareFoundation/rez/pull/1092
                         # Some packages have a trailing comma which would break the matching
                         if not ver_remaining:
                             break

--- a/src/rezgui/__init__.py
+++ b/src/rezgui/__init__.py
@@ -2,5 +2,5 @@
 # Copyright Contributors to the Rez Project
 
 
-organisation_name = "nerdvegas"
+organisation_name = "AcademySoftwareFoundation"
 application_name = "rez-gui"

--- a/src/rezgui/dialogs/AboutDialog.py
+++ b/src/rezgui/dialogs/AboutDialog.py
@@ -38,4 +38,4 @@ class AboutDialog(QtWidgets.QDialog):
 
     def _goto_github(self):
         import webbrowser
-        webbrowser.open_new("https://github.com/nerdvegas/rez")
+        webbrowser.open_new("https://github.com/AcademySoftwareFoundation/rez")

--- a/src/rezplugins/build_system/rezconfig
+++ b/src/rezplugins/build_system/rezconfig
@@ -1,4 +1,4 @@
-# TODO remove this file in PR for https://github.com/nerdvegas/rez/issues/525,
+# TODO remove this file in PR for https://github.com/AcademySoftwareFoundation/rez/issues/525,
 # it is unused
 
 cmake:

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -819,7 +819,7 @@ class FileSystemPackageRepository(PackageRepository):
             # repo location even though they are the same path (different
             # mounts). We account for that here.
             #
-            # https://github.com/nerdvegas/rez/pull/957
+            # https://github.com/AcademySoftwareFoundation/rez/pull/957
             #
             if location != self.location:
                 location = canonical_path(location, platform_)

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -309,7 +309,7 @@ class CMD(Shell):
     @classmethod
     def join(cls, command):
         # TODO: This needs to be properly fixed, see other shell impls
-        # at https://github.com/nerdvegas/rez/pull/1130
+        # at https://github.com/AcademySoftwareFoundation/rez/pull/1130
         #
         # TODO: This may disappear in future [1]
         # [1] https://bugs.python.org/issue10838

--- a/src/support/shotgun_toolkit/README.md
+++ b/src/support/shotgun_toolkit/README.md
@@ -2,9 +2,9 @@
 
 ...but where did it all go?
 
-After `nerdvegas/rez` issues [822] and PR [823], the Shotgun hooks have
+After `AcademySoftwareFoundation/rez` issues [822] and PR [823], the Shotgun hooks have
 been moved to https://github.com/nerdvegas/rez-shotgun
 
 
-[822]: https://github.com/nerdvegas/rez/issues/822
-[823]: https://github.com/nerdvegas/rez/pull/823
+[822]: https://github.com/AcademySoftwareFoundation/rez/issues/822
+[823]: https://github.com/AcademySoftwareFoundation/rez/pull/823

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,7 +1,7 @@
 # rez-wiki
 
 This directory holds the content used to produce the Rez Wiki documentation
-found [here](https://github.com/nerdvegas/rez/wiki). The wiki is updated by the
+found [here](https://github.com/AcademySoftwareFoundation/rez/wiki). The wiki is updated by the
 `Wiki` Github workflow, on release.
 
 You should include relevant wiki updates with your code PRs.


### PR DESCRIPTION
This is almost, but not quite closing:
https://github.com/AcademySoftwareFoundation/rez/issues/1205

The remaining items to evaluate or potentially change are:
`src/rezgui/__init__.py:5:organisation_name = "nerdvegas"`
`setup.py:65:    author_email="nerdvegas@gmail.com",`
and sonarcloud project refs, that have a separate ticket I don't have permissions to address.

please note: references to the "author" `nerdvegas`, or the project `nerdvegas/rez-shotgun` have been retained. Anything that currently properly forwards to the ASWF repo has been updated, including changelog entries, as potentially unnecessary as it might be.

Nothing else should need scrubbing, apart from the 3 items mentioned above, potentially.