### PR TITLE
Run CI with macOS-11 (temporary)

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os-version:
-          - 'latest'
+          - '11'
         python-version:
           - '2.7'
           - '3.7'


### PR DESCRIPTION
Temporarily run macOS workflow using macOS-11 so that we have green builds for our next release.

CI is failing on macOS: https://github.com/AcademySoftwareFoundation/rez/actions/runs/3466633811.
I think it's unrelated to any recent changes. I think it has to do with an updated macOS version. For example 20 days ago it was working: https://github.com/AcademySoftwareFoundation/rez/actions/runs/3268002380/jobs/5373895764 while running on macOS 11.