### PR TITLE
Added REZ_BIN_PATH env for using both pip and production install for python pkg caching

### DIFF
--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -207,6 +207,8 @@ class System(object):
         # /<install>/(bin or Scripts)/rez/rez  <- rez executable
         #
         import rez
+        if os.path.exists(os.environ['REZ_BIN_PATH']):
+            return os.environ['REZ_BIN_PATH']
         module_path = rez.__path__[0]
 
         parts = module_path.split(os.path.sep)


### PR DESCRIPTION
I added this env var for Rez bin path to be able to use rez pkg caching function `pkg_cache.add_variants_async()` in python directly. 

