### PR TITLE
Add `package_cache_async` flag.

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -419,6 +419,7 @@ config_schema = Schema({
     "package_cache_during_build":                   Bool,
     "package_cache_local":                          Bool,
     "package_cache_same_device":                    Bool,
+    "package_cache_async":                          Bool,
     "color_enabled":                                ForceOrBool,
     "resolve_caching":                              Bool,
     "cache_package_files":                          Bool,

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -371,21 +371,21 @@ class PackageCache(object):
 
         return self.VARIANT_REMOVED
 
-    def add_variants_async(self, variants, _async=True):
+    def add_variants(self, variants, _async=True):
         """Update the package cache by adding some or all of the given variants.
 
         This method is called when a context is created or sourced. Variants
         are then added to the cache in a separate process.
         """
 
-        # A prod install is necessary because add_variants_async works by
+        # A prod install is necessary because add_variants works by
         # starting a rez-pkg-cache proc, and this can only be done reliably in
         # a prod install. On non-windows we could fork instead, but there would
         # remain no good solution on windows.
         #
         if not system.is_production_rez_install:
             raise PackageCacheError(
-                "PackageCache.add_variants_async is only supported in a "
+                "PackageCache.add_variants is only supported in a "
                 "production rez installation."
             )
 
@@ -467,7 +467,7 @@ class PackageCache(object):
 
                 func = subprocess.Popen
 
-                # use subprocess.call if we are not running async since it is blocking
+                # use subprocess.call blocks where subprocess.Popen doesn't
                 if not _async:
                     func = subprocess.call
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -371,7 +371,7 @@ class PackageCache(object):
 
         return self.VARIANT_REMOVED
 
-    def add_variants_async(self, variants):
+    def add_variants_async(self, variants, _async=False):
         """Update the package cache by adding some or all of the given variants.
 
         This method is called when a context is created or sourced. Variants
@@ -465,8 +465,12 @@ class PackageCache(object):
                 else:
                     out_target = devnull
 
-                subprocess.Popen(
-                    [exe, "--daemon", self.path],
+                func = subprocess.Popen
+                if not _async:
+                    func = subprocess.call
+
+                func(
+                    args,
                     stdout=out_target,
                     stderr=out_target,
                     **kwargs

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -371,7 +371,7 @@ class PackageCache(object):
 
         return self.VARIANT_REMOVED
 
-    def add_variants_async(self, variants, _async=False):
+    def add_variants_async(self, variants, _async=True):
         """Update the package cache by adding some or all of the given variants.
 
         This method is called when a context is created or sourced. Variants
@@ -466,6 +466,8 @@ class PackageCache(object):
                     out_target = devnull
 
                 func = subprocess.Popen
+
+                # use subprocess.call if we are not running async since it is blocking
                 if not _async:
                     func = subprocess.call
 

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1832,13 +1832,13 @@ class ResolvedContext(object):
                 not self.success:
             return
 
-        # see PackageCache.add_variants_async
+        # see PackageCache.add_variants
         if not system.is_production_rez_install:
             return
 
         pkgcache = self._get_package_cache()
         if pkgcache:
-            pkgcache.add_variants_async(
+            pkgcache.add_variants(
                 self.resolved_packages,
                 config.package_cache_async
                 )

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1838,7 +1838,10 @@ class ResolvedContext(object):
 
         pkgcache = self._get_package_cache()
         if pkgcache:
-            pkgcache.add_variants_async(self.resolved_packages)
+            pkgcache.add_variants_async(
+                self.resolved_packages,
+                config.package_cache_async
+                )
 
     @classmethod
     def _init_context_tracking_payload_base(cls):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -269,6 +269,9 @@ package_cache_max_variant_days = 30
 # Enable package caching during a package build.
 package_cache_during_build = False
 
+# Enable package caching to run asynchronously during a resolve.
+package_cache_async = True 
+
 # Allow caching of local packages. You would only want to set this True for
 # testing purposes.
 package_cache_local = False


### PR DESCRIPTION
Fixes #1379.

Adds a `package_cachy_async` flag which allows users to run caching synchronously (blocking) or asynchronously from the config.

This setting is set to `True` by default in the rezconfig so that behavior should act as normal. Setting this to false will block the resolve until all packages have been cached successfully.