### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'src/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -17,6 +17,11 @@ on:
       - '.github/workflows/core.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/installation.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -12,6 +12,11 @@ on:
       - '.github/workflows/mac.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       matrix:
         os-version:
-          - '18.04'
           - '20.04'
+          - '22.04'
         python-version:
           - '2.7'
           - '3.7'

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -12,6 +12,11 @@ on:
       - '.github/workflows/ubuntu.yaml'
       - '!src/rez/utils/_version.py'
       - '!**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -34,6 +34,7 @@ on:
       - '.github/docker/rez-win-py/**'
       - '!src/rez/utils/_version.py'
       - '!**.md'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR "fixes" our CI. The Ubuntu 18.04 image is deprecated and it's pretty much gone at this point, which means the Unbuntu workflow would just sit there doing nothing, waiting for a VM that will never exist.

I also added a `workflow_dispatch` trigger on some workflows so that we can manually run them without committing any changes.