### PR TITLE
Update employer of Jean-Christophe Morin

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -107,7 +107,7 @@ their employer is listed purely for transparency purposes.
 
 * Allan Johns (chair, author) - NVIDIA
 * Brendan Abel - Walt Disney Imagineering
-* Jean-Christophe Morin - Signiant
+* Jean-Christophe Morin - Anaconda
 * Stephen Mackenzie - NVIDIA
 * Thorsten Kaufmann - Accenture Song Content
 


### PR DESCRIPTION
Simply updating my employer. As per our policy, we publicly disclose our employers
Also:
> Members of the TSC contribute to rez independent of their employer and
their employer is listed purely for transparency purposes.