### PR TITLE
powershell: fix prepend for new variables and fix unsetenv for non-existing variables

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -419,6 +419,7 @@ class TestShells(TestBase, TempdirMixin):
             from rez.shells import create_shell
             sh = create_shell()
 
+            env.FOO.unset()
             env.FOO.append("hey")
             info(sh.get_key_token("FOO"))
             env.FOO.append(literal("$DAVE"))
@@ -433,6 +434,26 @@ class TestShells(TestBase, TempdirMixin):
         ]
 
         _execute_code(_rex_appending, expected_output)
+
+        def _rex_prepending():
+            from rez.shells import create_shell
+            sh = create_shell()
+
+            env.FOO.unset()
+            env.FOO.prepend("hey")
+            info(sh.get_key_token("FOO"))
+            env.FOO.prepend(literal("$DAVE"))
+            info(sh.get_key_token("FOO"))
+            env.FOO.prepend("Dave's not here man")
+            info(sh.get_key_token("FOO"))
+
+        expected_output = [
+            "hey",
+            sh.pathsep.join(["$DAVE", "hey"]),
+            sh.pathsep.join(["Dave's not here man", "$DAVE", "hey"])
+        ]
+
+        _execute_code(_rex_prepending, expected_output)
 
     @per_available_shell()
     def test_rex_code_alias(self, shell):

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -264,7 +264,7 @@ class PowerShellBase(Shell):
         # Be careful about ambiguous case in pwsh on Linux where pathsep is :
         # so that the ${ENV:VAR} form has to be used to not collide.
         self._addline(
-            'Set-Item -Path "Env:{0}" -Value ("{1}{2}" + (Get-ChildItem "Env:{0}").Value)'.format(
+            'Set-Item -Path "Env:{0}" -Value ("{1}{2}" + (Get-ChildItem -ErrorAction SilentlyContinue "Env:{0}").Value)'.format(
                 key, value, self.pathsep)
         )
 

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -264,8 +264,8 @@ class PowerShellBase(Shell):
         # Be careful about ambiguous case in pwsh on Linux where pathsep is :
         # so that the ${ENV:VAR} form has to be used to not collide.
         self._addline(
-            'Set-Item -Path "Env:{0}" -Value ("{1}{2}" + (Get-ChildItem -ErrorAction SilentlyContinue "Env:{0}").Value)'.format(
-                key, value, self.pathsep)
+            'Set-Item -Path "Env:{0}" -Value ("{1}{2}" + (Get-ChildItem -ErrorAction SilentlyContinue "Env:{0}").Value)'
+            .format(key, value, self.pathsep)
         )
 
     def appendenv(self, key, value):
@@ -281,7 +281,7 @@ class PowerShellBase(Shell):
 
     def unsetenv(self, key):
         self._addline(
-            'Remove-Item -ErrorAction -SilentlyContinue "Env:\{0}"'.format(key)
+            'Remove-Item -ErrorAction -SilentlyContinue "Env:{0}"'.format(key)
         )
 
     def resetenv(self, key, value, friends=None):

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -281,7 +281,7 @@ class PowerShellBase(Shell):
 
     def unsetenv(self, key):
         self._addline(
-            'Remove-Item -ErrorAction -SilentlyContinue "Env:{0}"'.format(key)
+            'Remove-Item -ErrorAction SilentlyContinue "Env:{0}"'.format(key)
         )
 
     def resetenv(self, key, value, friends=None):

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -280,7 +280,9 @@ class PowerShellBase(Shell):
             .format(key, os.path.pathsep, value))
 
     def unsetenv(self, key):
-        self._addline(r"Remove-Item Env:\%s" % key)
+        self._addline(
+            'Remove-Item -ErrorAction -SilentlyContinue "Env:\{0}"'.format(key)
+        )
 
     def resetenv(self, key, value, friends=None):
         self._addline(self.setenv(key, value))


### PR DESCRIPTION
Closes #1476
Supercedes PR by @SitiSchu on #1434 (but includes his commit cherrypicked to maintain history/credit)

The test, and commits, also address _the same issue_ but in the "unset" logic, because that too is a victim of this same issue, which is validated by the test, and was in fact the reason I came complaining to @instinct-vfx about not understanding something I was seeing, I just wasn't bright enough to understand it right away.