### PR TITLE
@include: Only include modules from the current package

### DIFF
--- a/src/rez/data/tests/python/include/utils_test_7cd3a335.py
+++ b/src/rez/data/tests/python/include/utils_test_7cd3a335.py
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright Contributors to the Rez Project
-
-
-# Empty test file for the py23.load_module_from_file tests

--- a/src/rez/data/tests/python/include/utils_test_7cd3a335.py
+++ b/src/rez/data/tests/python/include/utils_test_7cd3a335.py
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
 # Empty test file for the py23.load_module_from_file tests

--- a/src/rez/data/tests/python/include/utils_test_7cd3a335.py
+++ b/src/rez/data/tests/python/include/utils_test_7cd3a335.py
@@ -1,0 +1,1 @@
+# Empty test file for the py23.load_module_from_file tests

--- a/src/rez/tests/test_utils_py23.py
+++ b/src/rez/tests/test_utils_py23.py
@@ -7,21 +7,28 @@ unit tests for 'utils.py23' module
 """
 import os
 import sys
+import tempfile
 
-from rez.tests.util import TestBase
+from rez.tests.util import TestBase, TempdirMixin
 from rez.utils import py23
 
 
 class TestLoadModuleFromFile(TestBase):
     def test_load_module(self):
         """Ensure that the imported module does not show up in sys.modules"""
-        include_path = self.data_path('python', 'include')
         # Random chars are used in the module name to ensure that the module name is unique
         # and the test won't fail because some other module with the same name
         # shows up in sys.modules
         module = 'utils_test_7cd3a335'
+
+        filename = '{0}.py'.format(module)
+        tmpdir = tempfile.mkdtemp(prefix="rez_selftest_")
+
+        with open(os.path.join(tmpdir, filename), 'w') as fd:
+            fd.write('')
+
         py23.load_module_from_file(
             module,
-            os.path.join(include_path, '{}.py'.format(module))
+            os.path.join(tmpdir, filename)
         )
         self.assertEqual(sys.modules.get(module), None, msg='Module was found in sys.modules')

--- a/src/rez/tests/test_utils_py23.py
+++ b/src/rez/tests/test_utils_py23.py
@@ -9,7 +9,7 @@ import os
 import sys
 import tempfile
 
-from rez.tests.util import TestBase, TempdirMixin
+from rez.tests.util import TestBase
 from rez.utils import py23
 
 

--- a/src/rez/tests/test_utils_py23.py
+++ b/src/rez/tests/test_utils_py23.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+unit tests for 'utils.py23' module
+"""
+import os
+import sys
+
+from rez.tests.util import TestBase
+from rez.utils import py23
+
+
+class TestLoadModuleFromFile(TestBase):
+    def test_load_module(self):
+        """Ensure that the imported module does not show up in sys.modules"""
+        include_path = self.data_path('python', 'include')
+        # Random chars are used in the module name to ensure that the module name is unique
+        # and the test won't fail because some other module with the same name
+        # shows up in sys.modules
+        module = 'utils_test_7cd3a335'
+        py23.load_module_from_file(
+            module,
+            os.path.join(include_path, '{}.py'.format(module))
+        )
+        self.assertEqual(sys.modules.get(module), None, msg='Module was found in sys.modules')

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -41,5 +41,12 @@ def load_module_from_file(name, filepath):
             return imp.load_source(name, filepath, f)
 
     else:
-        from importlib.machinery import SourceFileLoader
-        return SourceFileLoader(name, filepath).load_module()
+        # The below code will import the module _without_ adding it to
+        # sys.modules. We want this otherwise we can't import multiple
+        # versions of the same module
+        # See: https://github.com/AcademySoftwareFoundation/rez/issues/1483
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(name, filepath)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -8,6 +8,8 @@ Custom py2/3 interoperability code.
 Put any code here that deals with py2/3 interoperability, beyond simple cases
 that use (for eg) the six module.
 """
+import sys
+
 from rez.vendor.six import six
 
 
@@ -38,7 +40,12 @@ def load_module_from_file(name, filepath):
     if six.PY2:
         import imp
         with open(filepath) as f:
-            return imp.load_source(name, filepath, f)
+            module = imp.load_source(name, filepath, f)
+            # Keep the module out of sys.modules. See comment in the `else:`
+            # for more info
+            if name in sys.modules:
+                del sys.modules[name]
+            return module
 
     else:
         # The below code will import the module _without_ adding it to


### PR DESCRIPTION
Fixes #1483

The previously used `SourceFileLoader(name, filepath).load_module()` adds the imported module to `sys.modules`. When a second module is imported with the same name, the previous module gets overwritten. In the case of #1483 this happened:

- Pkg A utils gets imported and added to the module cache with its hash
     - Module gets added to `sys.modules`
- Pkg B utils gets imported and added to the module cache with its hash.
     - This replaces A utils in `sys.modules` which causes the module cache to now have Pkg B's utils for all `utils` hashes
- Pkg C utils' hash is in the module cache from Pkg A, so it gets used from the cache. However, Pkg B utils replaced all `utils` modules so this returns Pkg B's utils.

Using [`importlib.util.module_from_spec`](https://docs.python.org/3.10/library/importlib.html#importlib.util.module_from_spec) avoids this by not adding imported modules to `sys.modules` so nothing gets overwritten even if modules with the same name get imported multiple times.

Since the `@include` functionality works by placing the module in the `globals` for `exec`, not having the module in `sys.modules` should be fine.