### PR TITLE
Draft: Escape special characters in cmd shell join method

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -229,12 +229,8 @@ class TestShells(TestBase, TempdirMixin):
                                 text=True)
             self.assertEqual(_stdout(p), "Hello Rez World!")
             os.remove(path)
-
-    # TODO fix cmd shell command string escape
-    # as per https://github.com/AcademySoftwareFoundation/rez/pull/1130, then remove this
-    # exclusion
-    #
-    @per_available_shell(exclude=["cmd"])
+            
+    @per_available_shell()
     @install_dependent()
     def test_rez_env_output(self, shell):
 

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -306,14 +306,10 @@ class CMD(Shell):
     def get_all_key_tokens(cls, key):
         return ["%{}%".format(key)]
 
-    @classmethod
-    def join(cls, command):
-        # TODO: This needs to be properly fixed, see other shell impls
-        # at https://github.com/AcademySoftwareFoundation/rez/pull/1130
-        #
+    def join(self, command):
         # TODO: This may disappear in future [1]
         # [1] https://bugs.python.org/issue10838
-        return subprocess.list2cmdline(command)
+        return self.escape_string(subprocess.list2cmdline(command))
 
     @classmethod
     def line_terminator(cls):


### PR DESCRIPTION
Ran into issues when running `rez env my_handler -- handle.py some-protocol://some-tool/?user_id=6560&user_login=eleroy&session_uuid=f49700b4-fa89-11ed-9b1c-0242ac110005&entity_type=Task&selected_ids=236123&ids=236123&server_hostname=server.shotgunstudio.com&title=Task%20236123`, as the rez cmd shell would not properly escape special character when writing the `rez-shell.bat`.

This tweak seems to fix it, but I haven't run all the unit tests, and the easiest way to run them seems to make this PR, so I'm making this draft PR to see if it passes tests.