### PR TITLE
Added small blurb for zsh users in getting started

### DIFF
--- a/wiki/pages/Getting-Started.md
+++ b/wiki/pages/Getting-Started.md
@@ -120,6 +120,8 @@ Now you are within the configured environment. The caret (>) prefixed to your pr
 telling you that you're within a rez-configured subshell. Rez does not update the currect environment,
 instead it configures a subshell and puts you within it.
 
+> __Note for `zsh` users__: If you have a `.zshenv` file defined you may experience [this issue](https://github.com/AcademySoftwareFoundation/rez/issues/837). One solution would be to paste `alias rez-env="rez-env --shell=bash"` in `~/.zshrc` to make sure you always run your rez contexts using `bash`. However, any logic that you run in your `.zshrc` won't be rerun by the rez context.
+
 Now you can run the *hello* tool in our *hello_world* package:
 
     > ]$ hello


### PR DESCRIPTION
Given #837, macOS default shell is `zsh` and that many dev tools add a `.zshenv` - it would be helpful to add a note in the getting started so new users don't have to lose a day debugging like I did (or get turned away at the start all together). 