### PR TITLE
Add Execution Policy setting to Powershell based shell plugins

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -202,6 +202,12 @@ class PowerShellBase(Shell):
         # Suppresses copyright message of PowerShell and pwsh
         cmd += ["-NoLogo"]
 
+        # Powershell execution policy overrides
+        # Prevent injections/mistakes by ensuring policy value only contains letters.
+        execution_policy = self.settings.execution_policy
+        if execution_policy and execution_policy.isalpha():
+            cmd += ["-ExecutionPolicy", execution_policy]
+
         # Generic form of sourcing that works in powershell and pwsh
         cmd += ["-File", target_file]
 

--- a/src/rezplugins/shell/rezconfig
+++ b/src/rezplugins/shell/rezconfig
@@ -27,11 +27,13 @@ powershell:
     prompt: '> $ '
     additional_pathext: ['.PY']
     executable_fullpath: null
+    execution_policy: null
 
 pwsh:
     prompt: '> $ '
     additional_pathext: ['.PY']
     executable_fullpath: null
+    execution_policy: null
 
 gitbash:
     prompt: '>'


### PR DESCRIPTION
Closes #1504 

This is a simple implementation of what I was requesting in #1504

I considered a different approach which would have been a bit more generic such as `shell_args`, which could have included the `-NoLogo` which is currently being inserted all the time. However, after reviewing the other shell plugins, I couldn't see the case for shell args for all of them, so I kept it localized to only doing exactly what I needed.