### PR TITLE
Colorize: Granularly wrap each given stream with Colorama

### DIFF
--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -9,6 +9,13 @@ import logging
 from rez.vendor import colorama
 from rez.config import config
 
+# Important - we don't want to init Colorama at startup,
+# because colorama prints a RESET_ALL character at exit. This in turn adds
+# unexpected output when capturing the output of a command run in a
+# ResolvedContext, for example.
+# While we're not initializing colorama at all anymore, this comment is left
+# in case someone thought about putting it back: Make sure to do it lazily.
+
 
 def colorama_wrap(stream):
     """ Wrap the stream with colorama so that it can display colors on any OS """

--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -10,14 +10,9 @@ from rez.vendor import colorama
 from rez.config import config
 
 
-_initialised = False
-
-
-def _init_colorama():
-    global _initialised
-    if not _initialised:
-        colorama.init()
-        _initialised = True
+def colorama_wrap(stream):
+    """ Wrap the stream with colorama so that it can display colors on any OS """
+    return colorama.initialise.wrap_stream(stream, convert=None, strip=None, autoreset=False, wrap=True)
 
 
 def stream_is_tty(stream):
@@ -222,12 +217,6 @@ def _color(str_, fore_color=None, back_color=None, styles=None):
     if not config.get("color_enabled", False):
         return str_
 
-    # lazily init colorama. This is important - we don't want to init at startup,
-    # because colorama prints a RESET_ALL character atexit. This in turn adds
-    # unexpected output when capturing the output of a command run in a
-    # ResolvedContext, for example.
-    _init_colorama()
-
     colored = ""
     if not styles:
         styles = []
@@ -270,6 +259,10 @@ class ColorizedStreamHandler(logging.StreamHandler):
         10: debug,
         0: notset,
     }
+
+    def __init__(self, stream=None):
+        super(ColorizedStreamHandler, self).__init__(stream)
+        self.stream = colorama_wrap(self.stream)
 
     @property
     def is_tty(self):
@@ -315,11 +308,13 @@ class ColorizedStreamHandler(logging.StreamHandler):
 
 class Printer(object):
     def __init__(self, buf=sys.stdout):
-        self.buf = buf
         self.colorize = (
             config.get("color_enabled", False) == "force"
             or stream_is_tty(buf)
         )
+        if self.colorize:
+            buf = colorama_wrap(buf)
+        self.buf = buf
 
     def __call__(self, msg='', style=None):
         print(self.get(msg, style), file=self.buf)


### PR DESCRIPTION
Fixes #1245

One issue that became apparent while attempting to enable colors in Windows (powershell) was that not every stream was properly initialized. While some commands behaved nicely, others didn't escape properly:

![image](https://github.com/AcademySoftwareFoundation/rez/assets/1182452/69a39e5d-de86-41eb-931d-09e74a0716b9)

After this patch, the same command seems to colorize successfully.

![image](https://github.com/AcademySoftwareFoundation/rez/assets/1182452/0c9e40d3-5667-4a71-8f3f-37bbb191ae14)

The issue stemmed from 2 places:
1 - The ColorizedStreamHandler used for logging was never wrapped by colorama
2 - Buffers passed to Printer would only wrap if stout or stderr, and the first created Printer would not wrap because it would store self.buf before colorama init (which patches stdout and stderr).

This change never calls colorama init, so stderr and stdout are left untouched, instead each buffer is wrapped individually as part of the Printer instance, and only if colors are enabled.