### PR TITLE
remove nerdvegas from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,33 +5,33 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Admin
-/ASWF/                  @nerdvegas @AcademySoftwareFoundation/rez-tsc
-CODEOWNERS              @nerdvegas @AcademySoftwareFoundation/rez-tsc
-LICENSE                 @nerdvegas @AcademySoftwareFoundation/rez-tsc
-NOTICE                  @nerdvegas @AcademySoftwareFoundation/rez-tsc
-*.md                    @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/ASWF/                  @AcademySoftwareFoundation/rez-tsc
+CODEOWNERS              @AcademySoftwareFoundation/rez-tsc
+LICENSE                 @AcademySoftwareFoundation/rez-tsc
+NOTICE                  @AcademySoftwareFoundation/rez-tsc
+*.md                    @AcademySoftwareFoundation/rez-tsc
 
 # CI
-/.github/               @nerdvegas @AcademySoftwareFoundation/rez-tsc
-.sonarcloud.properties  @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/tests/         @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/data/          @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/.github/               @AcademySoftwareFoundation/rez-tsc
+.sonarcloud.properties  @AcademySoftwareFoundation/rez-tsc
+/src/rez/tests/         @AcademySoftwareFoundation/rez-tsc
+/src/rez/data/          @AcademySoftwareFoundation/rez-tsc
 
 # Docs
-/wiki/                  @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/wiki/                  @AcademySoftwareFoundation/rez-tsc
 
 # Core
-/src/rez/backport       @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/bind           @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/cli            @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/utils          @nerdvegas @AcademySoftwareFoundation/rez-tsc
-/src/rez/*.py           @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/src/rez/backport       @AcademySoftwareFoundation/rez-tsc
+/src/rez/bind           @AcademySoftwareFoundation/rez-tsc
+/src/rez/cli            @AcademySoftwareFoundation/rez-tsc
+/src/rez/utils          @AcademySoftwareFoundation/rez-tsc
+/src/rez/*.py           @AcademySoftwareFoundation/rez-tsc
 
 # Embedded packages
-/src/rez/vendor         @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/src/rez/vendor         @AcademySoftwareFoundation/rez-tsc
 
 # Plugins
-/src/rezplugins/        @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/src/rezplugins/        @AcademySoftwareFoundation/rez-tsc
 
 # Gui
-/src/rezgui/            @nerdvegas @AcademySoftwareFoundation/rez-tsc
+/src/rezgui/            @AcademySoftwareFoundation/rez-tsc


### PR DESCRIPTION
nerdvegas is currently in rez-tsc group so this commit has no effect other than preventing nerdvegas from from showing up separately as a reviewer on every PR.