### PR TITLE
Clarify default install location per OS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,16 @@ To install rez, download the source. Then from the root directory, run:
 ]$ python ./install.py
 ```
 
-This installs rez to `/opt/rez`. See `install.py -h` for how to install to a
-different location.
+This installs rez to a default location depending on operating system. 
+
+```
+Linux: /opt/rez
+Windows: <Current shell drive letter>:/opt/rez
+Mac: /opt/rez
+```
+
+
+See `install.py -h` for how to install to a different location.
 
 Once the installation is complete, a message tells you how to run it:
 


### PR DESCRIPTION
Default install location read as a Unix path, so Windows users had no idea where default install went. This PR breaks down the default location further.