### PR TITLE
Update TSC chair after Allan Johns stepped down

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -105,11 +105,15 @@ from other TSC members on a short or long-term basis.
 Members of the TSC contribute to rez independent of their employer and
 their employer is listed purely for transparency purposes.
 
-* Allan Johns (chair, author) - NVIDIA
 * Brendan Abel - Walt Disney Imagineering
-* Jean-Christophe Morin - Anaconda
-* Stephen Mackenzie - NVIDIA
+* Jean-Christophe Morin (co-chair) - Anaconda
+* Stephen Mackenzie (co-chair) - NVIDIA
 * Thorsten Kaufmann - Accenture Song Content
+
+
+### Former TSC Members
+
+* Allan Johns (author and initial chair)
 
 ### TSC Meetings
 


### PR DESCRIPTION
This PR simply updates the governance document to reflect that @nerdvegas stepped down from his chair role and from the TSC.

@JeanChristopheMorinPerso (myself) and @maxnbk are now co-chairs.

I want to take the occasion to thank @nerdvegas for giving us such a great project, working hard for all these years on making rez what it is today and trusting us in the whole process and trusting us in maintaining and improving rez from now on.