### PR TITLE
Fix CI failures with Python 2.7

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -19,40 +19,15 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Set up Python ${{ inputs.python-version }} with conda
-      if: ${{ inputs.python-version == '2.7' }}
-      shell: bash
-      run: |
-        cd /tmp
-        if [[ "${{ inputs.os }}" = macos* ]]; then
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
-        else
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
-        fi
-
-        case "${{ inputs.os }}" in
-            macos*)
-                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
-                sh /tmp/miniconda.sh -b -p /opt/conda
-                ;;
-            ubuntu*)
-                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
-                sh /tmp/miniconda.sh -b -p /opt/conda
-                ;;
-            windows*)
-                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o /c/miniconda.sh
-                sh /tmp/miniconda.sh -b -p /c/conda
-                ;;
-        esac
-
+    # Conda comes pre-installed with the GitHub hosted runners.
     - name: Create conda environment
       if: ${{ inputs.python-version == '2.7' }}
       shell: bash
       run: |
         if [[ "${OSTYPE}" == "msys" ]]; then
-            eval "$(/c/conda/condabin/conda.bat shell.bash hook)"
+            eval "$(/c/Miniconda/condabin/conda.bat shell.bash hook)"
         else
-            source /opt/conda/bin/activate
+            eval "$(conda shell.bash hook)"
         fi
         conda create -n python python=2.7 setuptools wheel
 
@@ -62,7 +37,7 @@ runs:
       run: |
         set -ex
 
-        source /opt/conda/bin/activate
+        eval "$(conda shell.bash hook)"
         conda activate python
         conda info
 

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -1,0 +1,60 @@
+name: Setup python
+
+description: Setup python using either actions/setup-pythono or conda
+
+inputs:
+  python-version:
+    description: Python version to setup
+    required: true
+  os:
+    description: os
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python ${{ inputs.python-version }} with actions/setup-python
+      if: ${{ inputs.python-version != '2.7' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Python ${{ inputs.python-version }} with conda-incubator/setup-miniconda
+      if: ${{ inputs.python-version == '2.7' }}
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3
+
+    - name: Create conda environment
+      if: ${{ inputs.python-version == '2.7' }}
+      shell: bash
+      run: |
+        if [[ "${OSTYPE}" == "msys" ]]; then
+            eval "$(/c/Miniconda/condabin/conda.bat shell.bash hook)"
+        else
+            eval "$(conda shell.bash hook)"
+        fi
+        conda create -n python python=2.7 setuptools wheel
+
+    - name: Fix conda installed python
+      if: inputs.python-version == '2.7' && (startsWith(inputs.os, 'ubuntu') || startsWith(inputs.os, 'macos'))
+      shell: bash -el {0}
+      run: |
+        set -ex
+
+        eval "$(conda shell.bash hook)"
+        conda activate python
+        conda info
+
+        if [[ "${{ inputs.os }}" = macos* ]]; then
+            install_name_tool -change @rpath/libpython2.7.dylib $(dirname $(which python))/../lib/libpython2.7.dylib $(which python)
+        else
+            sudo apt-get install patchelf
+
+            # This will allow virtualenv to work correctly.
+            # Basically, Python provided by conda is "fully portable". Its default
+            # RPATH is "$ORIGIN/../lib". The problem is that once the virtualenv
+            # is created, the copied/symlinked interpreter in the venv won't be
+            # able to load lib sinec the lib folder isn't copied in the venv.
+            patchelf --set-rpath $(dirname $(which python))/../lib $(which python)
+        fi

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -19,20 +19,40 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Set up Python ${{ inputs.python-version }} with conda-incubator/setup-miniconda
+    - name: Set up Python ${{ inputs.python-version }} with conda
       if: ${{ inputs.python-version == '2.7' }}
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: 3
+      shell: bash
+      run: |
+        cd /tmp
+        if [[ "${{ inputs.os }}" = macos* ]]; then
+            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
+        else
+            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
+        fi
+
+        case "${{ inputs.os }}" in
+            macos*)
+                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda.sh
+                sh /tmp/miniconda.sh -b -p /opt/conda
+                ;;
+            ubuntu*)
+                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+                sh /tmp/miniconda.sh -b -p /opt/conda
+                ;;
+            windows*)
+                curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o /c/miniconda.sh
+                sh /tmp/miniconda.sh -b -p /c/conda
+                ;;
+        esac
 
     - name: Create conda environment
       if: ${{ inputs.python-version == '2.7' }}
       shell: bash
       run: |
         if [[ "${OSTYPE}" == "msys" ]]; then
-            eval "$(/c/Miniconda/condabin/conda.bat shell.bash hook)"
+            eval "$(/c/conda/condabin/conda.bat shell.bash hook)"
         else
-            eval "$(conda shell.bash hook)"
+            source /opt/conda/bin/activate
         fi
         conda create -n python python=2.7 setuptools wheel
 
@@ -42,7 +62,7 @@ runs:
       run: |
         set -ex
 
-        eval "$(conda shell.bash hook)"
+        source /opt/conda/bin/activate
         conda activate python
         conda info
 
@@ -55,6 +75,6 @@ runs:
             # Basically, Python provided by conda is "fully portable". Its default
             # RPATH is "$ORIGIN/../lib". The problem is that once the virtualenv
             # is created, the copied/symlinked interpreter in the venv won't be
-            # able to load lib sinec the lib folder isn't copied in the venv.
+            # able to load lib since the lib folder isn't copied in the venv.
             patchelf --set-rpath $(dirname $(which python))/../lib $(which python)
         fi

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,16 +25,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          os: ubuntu-latest
 
       - name: Install Rez
         run: |
           mkdir ./installdir
+
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
+
           python ./install.py ./installdir
 
       - name: Run Benchmark
@@ -46,9 +53,13 @@ jobs:
 
       - name: Validate Result
         run: |
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
           python ./.github/scripts/validate_benchmark.py
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "benchmark-result-${{ matrix.python-version }}"
           path: ./out
@@ -68,18 +79,19 @@ jobs:
       max-parallel: 1
 
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          os: ubuntu
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "benchmark-result-${{ matrix.python-version }}"
           path: .
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           path: src
@@ -102,6 +114,10 @@ jobs:
 
       - name: Store Benchmark Result
         run: |
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
           python ./.github/scripts/store_benchmark.py
         working-directory: src
 

--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 2.7
+          python-version: 3
 
       - name: Run copyright checker
         run: |

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -37,16 +37,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          os: ubuntu-latest
 
       - name: Install Rez
+        shell: bash
         run: |
+          set -ex
           mkdir ./installdir
+
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
+
           python ./install.py ./installdir
 
       - name: Install Rez test dependencies

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -52,7 +52,7 @@ jobs:
           mkdir ./installdir
 
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              eval "$(conda shell.bash hook)"
+              source /opt/conda/bin/activate
               conda activate python
           fi
 

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -52,10 +52,11 @@ jobs:
           mkdir ./installdir
 
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              source /opt/conda/bin/activate
+              eval "$(conda shell.bash hook)"
               conda activate python
           fi
 
+          python --version
           python ./install.py ./installdir
 
       - name: Install Rez test dependencies

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -19,10 +19,11 @@ jobs:
     name: ${{ matrix.os }} - ${{ matrix.python-version }} - ${{ matrix.method }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: 
           - ubuntu-latest
-          - macOS-latest
+          - macos-latest
           - windows-2019
         python-version:
           - '2.7'
@@ -34,48 +35,102 @@ jobs:
         include:
         # ubuntu
         - os: ubuntu-latest
-          method: install          
+          method: install
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:/opt/rez/bin/rez'
-          REZ_INSTALL_COMMAND: 'python ./install.py /opt/rez'
+          REZ_INSTALL_COMMAND: |
+            set -ex
+            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
+                eval "$(conda shell.bash hook)"
+                conda activate python
+            fi
+            python ./install.py /opt/rez
+
         - os: ubuntu-latest
           method: pip
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:/opt/rez/bin PYTHONPATH=${PYTHONPATH}:/opt/rez'
-          REZ_INSTALL_COMMAND: 'pip install --target /opt/rez .'
+          REZ_INSTALL_COMMAND: |
+            set -ex
+            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
+                eval "$(conda shell.bash hook)"
+                conda activate python
+            fi
+            pip install --target /opt/rez .
         # macOS
-        - os: macOS-latest
+        - os: macos-latest
           method: install
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:~/rez/bin/rez'
-          REZ_INSTALL_COMMAND: 'python ./install.py ~/rez'
-        - os: macOS-latest
+          REZ_INSTALL_COMMAND: |
+            set -e
+            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
+                eval "$(conda shell.bash hook)"
+                conda activate python
+
+                echo "otool -L $(which python)"
+                otool -L $(which python)
+                echo "otool -l $(which python)"
+                otool -l $(which python)
+                echo "otool -L $(dirname $(which python))/../lib/libpython2.7.dylib"
+                otool -L $(dirname $(which python))/../lib/libpython2.7.dylib
+                echo "otool -l $(dirname $(which python))/../lib/libpython2.7.dylib"
+                otool -l $(dirname $(which python))/../lib/libpython2.7.dylib
+            fi
+
+            python ./install.py ~/rez
+        - os: macos-latest
           method: pip
           REZ_SET_PATH_COMMAND: 'export PATH="$PATH:~/rez/bin" PYTHONPATH=$PYTHONPATH:$HOME/rez'
-          REZ_INSTALL_COMMAND: 'pip install --target ~/rez .'
+          REZ_INSTALL_COMMAND: |
+            set -ex
+            if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
+                eval "$(conda shell.bash hook)"
+                conda activate python
+            fi
+            pip install --target ~/rez .
         # windows
         - os: windows-2019
           method: install
           REZ_SET_PATH_COMMAND: '$env:PATH="$env:PATH;C:\ProgramData\rez\Scripts\rez"'
-          REZ_INSTALL_COMMAND: 'python ./install.py C:\ProgramData\rez'
+          REZ_INSTALL_COMMAND: |
+            if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
+                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
+                conda activate python
+            }
+            python ./install.py C:\ProgramData\rez
         - os: windows-2019
           method: pip
           REZ_SET_PATH_COMMAND: '[System.Environment]::SetEnvironmentVariable("PATH","$env:PATH;C:\ProgramData\rez\bin"); $env:PYTHONPATH="$env:PYTHONPATH;C:\ProgramData\rez"'
-          REZ_INSTALL_COMMAND: 'pip install --target C:\ProgramData\rez .'
-    
+          REZ_INSTALL_COMMAND: |
+            if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
+                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
+                conda activate python
+            }
+            pip install --target C:\ProgramData\rez .
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+
+    - name: Setup python ${{ matrix.python-version }}
+      uses: ./.github/actions/setup-python
       with:
         python-version: ${{ matrix.python-version }}
+        os: ${{ matrix.os }}
 
     - name: Install
+      env:
+        MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         ${{ matrix.REZ_INSTALL_COMMAND }}
 
     - name: Run rez-status
+      env:
+        MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         ${{ matrix.REZ_SET_PATH_COMMAND }}
         rez-status
 
     - name: Install rez with rez-pip
+      env:
+        MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         ${{ matrix.REZ_SET_PATH_COMMAND }}
         rez-pip --install .

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -40,7 +40,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
+                source /opt/conda/bin/activate
                 conda activate python
             fi
             python ./install.py /opt/rez
@@ -51,7 +51,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
+                source /opt/conda/bin/activate
                 conda activate python
             fi
             pip install --target /opt/rez .
@@ -62,13 +62,9 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -e
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
+                source /opt/conda/bin/activate
                 conda activate python
 
-                echo "otool -L $(which python)"
-                otool -L $(which python)
-                echo "otool -l $(which python)"
-                otool -l $(which python)
                 echo "otool -L $(dirname $(which python))/../lib/libpython2.7.dylib"
                 otool -L $(dirname $(which python))/../lib/libpython2.7.dylib
                 echo "otool -l $(dirname $(which python))/../lib/libpython2.7.dylib"
@@ -82,7 +78,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                eval "$(conda shell.bash hook)"
+                source /opt/conda/bin/activate
                 conda activate python
             fi
             pip install --target ~/rez .
@@ -92,7 +88,7 @@ jobs:
           REZ_SET_PATH_COMMAND: '$env:PATH="$env:PATH;C:\ProgramData\rez\Scripts\rez"'
           REZ_INSTALL_COMMAND: |
             if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
+                & 'C:\conda\shell\condabin\conda-hook.ps1'
                 conda activate python
             }
             python ./install.py C:\ProgramData\rez
@@ -101,7 +97,7 @@ jobs:
           REZ_SET_PATH_COMMAND: '[System.Environment]::SetEnvironmentVariable("PATH","$env:PATH;C:\ProgramData\rez\bin"); $env:PYTHONPATH="$env:PYTHONPATH;C:\ProgramData\rez"'
           REZ_INSTALL_COMMAND: |
             if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
+                & 'C:\conda\shell\condabin\conda-hook.ps1'
                 conda activate python
             }
             pip install --target C:\ProgramData\rez .

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -40,7 +40,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                source /opt/conda/bin/activate
+                eval "$(conda shell.bash hook)"
                 conda activate python
             fi
             python ./install.py /opt/rez
@@ -51,7 +51,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                source /opt/conda/bin/activate
+                eval "$(conda shell.bash hook)"
                 conda activate python
             fi
             pip install --target /opt/rez .
@@ -62,7 +62,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -e
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                source /opt/conda/bin/activate
+                eval "$(conda shell.bash hook)"
                 conda activate python
 
                 echo "otool -L $(dirname $(which python))/../lib/libpython2.7.dylib"
@@ -78,7 +78,7 @@ jobs:
           REZ_INSTALL_COMMAND: |
             set -ex
             if [[ "${MATRIX_PYTHON_VERSION}" == "2.7" ]]; then
-                source /opt/conda/bin/activate
+                eval "$(conda shell.bash hook)"
                 conda activate python
             fi
             pip install --target ~/rez .
@@ -88,7 +88,7 @@ jobs:
           REZ_SET_PATH_COMMAND: '$env:PATH="$env:PATH;C:\ProgramData\rez\Scripts\rez"'
           REZ_INSTALL_COMMAND: |
             if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\conda\shell\condabin\conda-hook.ps1'
+                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
                 conda activate python
             }
             python ./install.py C:\ProgramData\rez
@@ -97,7 +97,7 @@ jobs:
           REZ_SET_PATH_COMMAND: '[System.Environment]::SetEnvironmentVariable("PATH","$env:PATH;C:\ProgramData\rez\bin"); $env:PYTHONPATH="$env:PYTHONPATH;C:\ProgramData\rez"'
           REZ_INSTALL_COMMAND: |
             if ($env:MATRIX_PYTHON_VERSION -eq "2.7") {
-                & 'C:\conda\shell\condabin\conda-hook.ps1'
+                & 'C:\Miniconda\shell\condabin\conda-hook.ps1'
                 conda activate python
             }
             pip install --target C:\ProgramData\rez .

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Rez
         run: |
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              source /opt/conda/bin/activate
+              eval "$(conda shell.bash hook)"
               conda activate python
           fi
           mkdir ./installdir

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   main:
     name: main
-    runs-on: macOS-${{ matrix.os-version }}
+    runs-on: macos-${{ matrix.os-version }}
 
     strategy:
       matrix:
@@ -36,10 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          os: macos-latest
 
       - name: Verify cmake
         run: |
@@ -52,6 +53,10 @@ jobs:
       - name: Install Rez
         run: |
           mkdir ./installdir
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
           python ./install.py ./installdir
 
       - name: Install Rez test dependencies

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -52,11 +52,12 @@ jobs:
 
       - name: Install Rez
         run: |
-          mkdir ./installdir
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              eval "$(conda shell.bash hook)"
+              source /opt/conda/bin/activate
               conda activate python
           fi
+          mkdir ./installdir
+          python --version
           python ./install.py ./installdir
 
       - name: Install Rez test dependencies

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 2.7
+          python-version: 3
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -10,17 +10,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 2.7
+          python-version: 3.7
 
       - name: Sphinx Build
         run: python docs/build.py --no-docker
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: html-docs
           path: docs/_build
@@ -31,7 +31,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: html-docs
           path: .

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Rez
         run: |
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              eval "$(conda shell.bash hook)"
+              source /opt/conda/bin/activate
               conda activate python
           fi
           mkdir ./installdir

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Rez
         run: |
           if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
-              source /opt/conda/bin/activate
+              eval "$(conda shell.bash hook)"
               conda activate python
           fi
           mkdir ./installdir

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -35,12 +35,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Setup python ${{ matrix.python-version }}
+        uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          os: ubuntu
 
       - name: apt-get update
         run: |
@@ -68,7 +69,12 @@ jobs:
 
       - name: Install Rez
         run: |
+          if [[ "${{ matrix.python-version }}" == "2.7" ]]; then
+              eval "$(conda shell.bash hook)"
+              conda activate python
+          fi
           mkdir ./installdir
+          python --version
           python ./install.py ./installdir
 
       - name: Install Rez test dependencies

--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # required to generate credits list
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -29,7 +29,7 @@ jobs:
             --github-repo="${{ github.repository }}" \
             --out="${{ github.workspace }}/out"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wiki-markdown
           path: out
@@ -50,7 +50,7 @@ jobs:
         run: |
           git clone https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git .
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wiki-markdown
           path: .


### PR DESCRIPTION
Fixes #1502

This PR fixes the issues with Python 2.7 in CI. We now use conda to get and install Python 2.7. This is because GitHub decided that it was alright to completely delete their Python 2.7 interpreters from the internet and break the entire world. The funny thing is that they still compile and ship 3.1 and up :shrug:.

~Note that the csh tests are failing for some reasons. I'm really not sure why. I'm tempted to say that we could ditch csh entirely...~

Oh, and I also updated our actions to use more recent versions.