### PR TITLE
Allow user to pass extra arguments to underlying rez test command (REP-001 part 3).

### DIFF
--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -59,7 +59,9 @@ subcommands = {
     },
     "status": {},
     "suite": {},
-    "test": {},
+    "test": {
+        "arg_mode": "grouped"
+    },
     "view": {},
     "yaml2py": {},
     "bundle": {},

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -64,6 +64,14 @@ def command(opts, parser, extra_arg_groups=None):
         pkg_paths = opts.paths.split(os.pathsep)
         pkg_paths = [os.path.expanduser(x) for x in pkg_paths if x]
 
+    if extra_arg_groups:
+        if not opts.TEST or len(opts.TEST) > 1:
+            parser.error(
+                "You can only pass extra arguments to a single, specified test. "
+                "Please rerun the command and specify a single test to run."
+            )
+        extra_arg_groups = extra_arg_groups[0]
+
     # run test(s)
     runner = PackageTestRunner(
         package_request=opts.PKG,
@@ -107,7 +115,7 @@ def command(opts, parser, extra_arg_groups=None):
 
     for test_name in run_test_names:
         if not runner.stopped_on_fail:
-            ret = runner.run_test(test_name)
+            ret = runner.run_test(test_name, extra_test_args=extra_arg_groups)
             if ret and not exitcode:
                 exitcode = ret
 

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -232,7 +232,7 @@ class PackageTestRunner(object):
         """
         return self.test_results.num_skipped
 
-    def run_test(self, test_name):
+    def run_test(self, test_name, extra_test_args=None):
         """Run a test.
 
         Runs the test in its correct environment. Note that if tests share the
@@ -240,12 +240,16 @@ class PackageTestRunner(object):
 
         Args:
             test_name (str): Name of test to run.
+            extra_test_args (list of str): Any extra arguments that we want to
+                pass to the test command.
 
         Returns:
             int: Exit code of first failed test, or 0 if none failed. If the first
                 test to fail did so because it was not able to run (eg its
                 environment could not be configured), -1 is returned.
         """
+        if extra_test_args is None:
+            extra_test_args = []
         package = self.get_package()
         exitcode = 0
 
@@ -393,6 +397,12 @@ class PackageTestRunner(object):
                 command = variant.format(command)
             else:
                 command = map(variant.format, command)
+
+            if extra_test_args:
+                if isinstance(command, basestring):
+                    command = "{} {}".format(command, " ".join(map(quote, extra_test_args)))
+                else:
+                    command = list(map(quote, command)) + list(map(quote, extra_test_args))
 
             # run the test in the context
             if self.verbose:


### PR DESCRIPTION
This addresses point 3 of https://github.com/AcademySoftwareFoundation/rez/issues/665, as discussed on the aswf rez slack channel recently, allowing users to pass arguments from invocation of `rez test` down to the underlying test command that gets run. 