### PR TITLE
Add new use_canonical_path option in rezconfig.py

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -400,6 +400,7 @@ config_schema = Schema({
     "alias_back":                                   OptionalStr,
     "package_preprocess_function":                  OptionalStrOrFunction,
     "package_preprocess_mode":                      PreprocessMode_,
+    "use_canonical_path":                           OptionalBool,
     "context_tracking_host":                        OptionalStr,
     "variant_shortlinks_dirname":                   OptionalStr,
     "build_thread_count":                           BuildThreadCount_,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -657,6 +657,10 @@ package_preprocess_function = None
 # - "override": Package's preprocess function completely overrides the global preprocess.
 package_preprocess_mode = "override"
 
+# Defines if we want to use canonical path in our context resolution
+# This is useful when you want to have a consistent path for your context
+# and avoid resolution of mapped drive on Windows.
+use_canonical_path = True
 
 ###############################################################################
 # Context Tracking

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -495,9 +495,10 @@ class FileSystemPackageRepository(PackageRepository):
             disable_pkg_ignore (bool): If True, .ignore* files have no effect
         """
 
-        # ensure that differing case doesn't get interpreted as different repos
-        # on case-insensitive platforms (eg windows)
-        location = canonical_path(location, platform_)
+        if config.use_canonical_path:
+            # ensure that differing case doesn't get interpreted as different repos
+            # on case-insensitive platforms (eg windows)
+            location = canonical_path(location, platform_)
 
         super(FileSystemPackageRepository, self).__init__(location, resource_pool)
 


### PR DESCRIPTION
## Context:
It's because on windows, we can map some drive letter, to UNC network path.
To centralize packages but also software binaries.

## Problem:
Some softwares like substance, vscode or RV, cannot be run on UNC path and will crash or freeze.

## Solution:
Map a new drive letter on windows, using `new-smbmapping` for example, to avoid usage of unc path in PATH environment variable.
But, rez resolution plugin, use os.path.realpath directly in `__init__` because of that, the path is convert back from our mapped drive letter to full unc path, so some binaries cannot be launched anymore.

Another solution, can be the usage of rez cache, but i found this solution not efficient rather than just execution of binary from network.

## Final details:
It's why, i have created a new parameter in the rezconfig, to have an option to bypass the convertion of canonical path on resolution process, in case of mapped letter drive in packages_paths.

Obviously, by default i have set it to True, to not alterate the current behavior of rez resolution plugin.

## Test:
- I have locally reinstall rez with theses modifications, then i have set the property `use_canonical_path` to False in the rezconfig.py to test and here the result i got:
```
PS C:\Users\oargentieri> rez env vscode-1.82

You are now in a rez-configured environment.

resolved by oargentieri@<hostname> on Thu Sep 28 10:50:16 2023, using Rez v2.113.0

requested packages:
vscode-1.82
~platform==windows  (implicit)
~arch==AMD64        (implicit)
~os==windows-10.0   (implicit)

resolved packages:
platform-windows  X:\rez_package\platform\windows
vscode-1.82.2     X:\rez_package\vscode\1.82.2\platform-windows
```

And now vscode can be launched using `rez env vscode -- code --disable-chromium-sandbox`

## Issue:
- #1541 

Also linked to [this discussion](https://github.com/AcademySoftwareFoundation/rez/discussions/1540) 