### PR TITLE
Fix CMake build in Windows for `CMAKE_MODULE_PATH` force to use "/"

### DIFF
--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -256,6 +256,9 @@ class PowerShellBase(Shell):
 
     def setenv(self, key, value):
         value = self.escape_string(value, is_path=self._is_pathed_key(key))
+        if platform_.name == "windows" and key == "CMAKE_MODULE_PATH":
+            # Fix CMake build in Windows for `CMAKE_MODULE_PATH` force to use "/"
+            value = value.replace("\\", "/")
         self._addline('Set-Item -Path "Env:{0}" -Value "{1}"'.format(key, value))
 
     def prependenv(self, key, value):

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -255,6 +255,9 @@ class CMD(Shell):
 
     def setenv(self, key, value):
         value = self.escape_string(value, is_path=self._is_pathed_key(key))
+        if key == "CMAKE_MODULE_PATH":
+            # Fix CMake build in Windows for `CMAKE_MODULE_PATH` force to use "/"
+            value = value.replace("\\", "/")
         self._addline('set %s=%s' % (key, value))
 
     def unsetenv(self, key):


### PR DESCRIPTION
We get same issues with [#1321](https://github.com/AcademySoftwareFoundation/rez/issues/1321),  this PR should be fix this issue.
```
CMake Error at Z:/PycharmProjects/maya_cvwrap/.rez_build/platform-windows/maya-2023/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (set):
  Syntax error in cmake code at

    Z:/PycharmProjects/maya_cvwrap/.rez_build/platform-windows/maya-2023/CMakeFiles/CMakeTmp/CMakeLists.txt:2

  when parsing string

    G:\pkg\rez\2.113.0\platform-windows\rezplugins\build_system\cmake_files

  Invalid character escape '\r'.
  ```