### PR TITLE
Add wiki paragraph describing supported Rez config file types

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+# Example Headers
+
 ============
 page section
 ============

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,17 @@
+# Build instructions
+
+To build the docs you must use Python 3.11.
+
+To create a build environment run the following commands:
+```python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r docs/requirements.txt
+
+cd docs
+make html
+```
+
 # Example Headers
 
 ============

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -28,6 +28,12 @@ variable :envvar:`REZ_CONFIG_FILE` is then set to for all your users.
 
 .. _configuring-rez-settings-merge-rules:
 
+Supported Configuration File Types
+====================
+
+Rez supports both YAML configuration files and Python configuration files. You may prefer Python files if you need vary
+and of your configuration settings based on your current platform.
+
 Settings Merge Rules
 ====================
 

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -26,8 +26,8 @@ variable :envvar:`REZ_CONFIG_FILE` is then set to for all your users.
    You do not need to provide a copy of all settings in this file. Just provide those
    that are changed from the defaults.
 
-Supported Configuration File Types
-====================
+Supported Configuration File Formats
+====================================
 
 Rez supports both YAML configuration files and Python configuration files.
 

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -31,8 +31,10 @@ variable :envvar:`REZ_CONFIG_FILE` is then set to for all your users.
 Supported Configuration File Types
 ====================
 
-Rez supports both YAML configuration files and Python configuration files. You may prefer Python files if you need vary
-and of your configuration settings based on your current platform.
+Rez supports both YAML configuration files and Python configuration files.
+
+You may prefer a Python based configuration file if you need to vary your configuration settings based on your
+current platform.
 
 Settings Merge Rules
 ====================

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -26,8 +26,6 @@ variable :envvar:`REZ_CONFIG_FILE` is then set to for all your users.
    You do not need to provide a copy of all settings in this file. Just provide those
    that are changed from the defaults.
 
-.. _configuring-rez-settings-merge-rules:
-
 Supported Configuration File Types
 ====================
 
@@ -35,6 +33,8 @@ Rez supports both YAML configuration files and Python configuration files.
 
 You may prefer a Python based configuration file if you need to vary your configuration settings based on your
 current platform.
+
+.. _configuring-rez-settings-merge-rules:
 
 Settings Merge Rules
 ====================


### PR DESCRIPTION
Built the docs with Python 3.11.6.