### PR TITLE
Change rez.__license__ to Apache-2.0 and add back Allan as author

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,10 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url="https://github.com/AcademySoftwareFoundation/rez",
-    author="Contributors to the rez project",
-    author_email="rez-discussion@lists.aswf.io",
+    author="Allan Johns",
+    author_email="nerdvegas@gmail.com",
+    maintainer="Contributors to the rez project",
+    maintainer_email="rez-discussion@lists.aswf.io",
     license="Apache-2.0",
     license_files=["LICENSE"],
     entry_points={

--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -11,7 +11,7 @@ import os
 
 __version__ = _rez_version
 __author__ = "Allan Johns"
-__license__ = "LGPL"
+__license__ = "Apache-2.0"
 
 
 module_root_path = __path__[0]  # noqa

--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -215,7 +215,7 @@ Updated (July 2019) along with pydot to allow for packaging lib to be used.
 <tr><td>
 schema
 </td><td>
-0.3.1 (Apr 28, 2014)
+0.3.1 (Apr 28, 2014) (https://github.com/keleshev/schema/blob/916ba05e22b7b370b3586f97c40695e7b9e7fe33)
 </td><td>
 MIT
 </td><td>


### PR DESCRIPTION
Change `rez.__license__` to Apache-2.0 and add back Allan as author but mark the package as maintained by TSC.

I feel like it was a little bit unfaire to remove Allan as the author.