### PR TITLE
Replace deprecated stdlib calls

### DIFF
--- a/release-rez.py
+++ b/release-rez.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import argparse
 import os
 from datetime import date
-from pipes import quote
+from rez.utils.py23 import quote
 import subprocess
 import sys
 

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -13,7 +13,7 @@ from rez.util import which
 from rez.utils.execution import Popen
 from rez.utils.logging_ import print_debug
 from rez.vendor.six import six
-from pipes import quote
+from rez.utils.py23 import quote
 import subprocess
 import os.path
 import os

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -16,7 +16,7 @@ from rez.resolver import ResolverStatus
 from rez.config import config
 from rez.vendor.enum import Enum
 from contextlib import contextmanager
-from pipes import quote
+from rez.utils.py23 import quote
 import getpass
 import os.path
 import sys

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -11,7 +11,7 @@ from rez.utils.colorize import heading, Printer
 from rez.utils.logging_ import print_info, print_warning, print_error
 from rez.vendor.six import six
 from rez.vendor.version.requirement import Requirement, RequirementList
-from pipes import quote
+from rez.utils.py23 import quote
 import time
 import sys
 import os

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -23,7 +23,7 @@ from rez.package_maker import make_package
 from rez.config import config
 
 import os
-from pipes import quote
+from rez.utils.py23 import quote
 from pprint import pformat
 import re
 import shutil

--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -8,7 +8,7 @@ from rez.util import which
 from rez.utils.execution import Popen
 from rez.utils.logging_ import print_debug
 from rez.utils.filesystem import walk_up_dirs
-from pipes import quote
+from rez.utils.py23 import quote
 import subprocess
 
 

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -17,7 +17,7 @@ from rez.config import config
 from rez.vendor.six import six
 import os
 import os.path
-import pipes
+from rez.utils.py23 import quote
 
 
 basestring = six.string_types[0]
@@ -507,7 +507,7 @@ class UnixShell(Shell):
         try:
             p = Popen(cmd, env=env, **Popen_args)
         except Exception as e:
-            cmd_str = ' '.join(map(pipes.quote, cmd))
+            cmd_str = ' '.join(map(quote, cmd))
             raise RezSystemError("Error running command:\n%s\n%s"
                                  % (cmd_str, str(e)))
         return p

--- a/src/rez/utils/elf.py
+++ b/src/rez/utils/elf.py
@@ -6,7 +6,7 @@
 Functions that wrap readelf/patchelf utils on linux.
 """
 import os
-import pipes
+from rez.utils.py23 import quote
 import subprocess
 
 from rez.utils.filesystem import make_path_writable
@@ -64,7 +64,7 @@ def _run(*nargs, **popen_kwargs):
     out, err = proc.communicate()
 
     if proc.returncode:
-        cmd_ = ' '.join(pipes.quote(x) for x in nargs)
+        cmd_ = ' '.join(quote(x) for x in nargs)
 
         raise RuntimeError(
             "Command %s - failed with exitcode %d: %s"

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -13,6 +13,12 @@ import sys
 from rez.vendor.six import six
 
 try:
+    from html import escape
+except ImportError:
+    # Python 2
+    from cgi import escape
+
+try:
     from shlex import quote
 except ImportError:
     # Python 2

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -12,6 +12,12 @@ import sys
 
 from rez.vendor.six import six
 
+try:
+    from shlex import quote
+except ImportError:
+    # Python 2
+    from pipes import quote
+
 
 def get_function_arg_names(func):
     """Get names of a function's args.

--- a/src/rez/utils/py23.py
+++ b/src/rez/utils/py23.py
@@ -13,16 +13,16 @@ import sys
 from rez.vendor.six import six
 
 try:
-    from html import escape
+    from html import escape  # noqa: F401
 except ImportError:
     # Python 2
-    from cgi import escape
+    from cgi import escape  # noqa: F401
 
 try:
-    from shlex import quote
+    from shlex import quote  # noqa: F401
 except ImportError:
     # Python 2
-    from pipes import quote
+    from pipes import quote  # noqa: F401
 
 
 def get_function_arg_names(func):

--- a/src/rezgui/widgets/ChangelogEdit.py
+++ b/src/rezgui/widgets/ChangelogEdit.py
@@ -3,11 +3,10 @@
 
 
 from Qt import QtCore, QtWidgets, QtGui
-import cgi
-
+import rez.utils.py23
 
 def plaintext_to_html(txt):
-    out = cgi.escape(txt)
+    out = rez.utils.py23.escape(txt)
     out = out.replace('\t', "    ")
     out = out.replace(' ', "&nbsp;")
     out = out.replace('\n', "<br>")

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -10,7 +10,7 @@ try:
     from builtins import map
 except ImportError:
     pass
-from pipes import quote
+from rez.utils.py23 import quote
 import functools
 import os.path
 import sys

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -5,7 +5,6 @@
 """
 CSH shell
 """
-import pipes
 import os.path
 import subprocess
 import re
@@ -16,6 +15,7 @@ from rez.utils.execution import Popen
 from rez.utils.platform_ import platform_
 from rez.shells import UnixShell
 from rez.rex import EscapedString
+from rez.utils.py23 import quote
 
 
 class CSH(UnixShell):
@@ -105,7 +105,7 @@ class CSH(UnixShell):
 
         for is_literal, txt in value.strings:
             if is_literal:
-                txt = pipes.quote(txt)
+                txt = quote(txt)
                 if not txt.startswith("'"):
                     txt = "'%s'" % txt
             else:

--- a/src/rezplugins/shell/sh.py
+++ b/src/rezplugins/shell/sh.py
@@ -7,13 +7,13 @@ SH shell
 """
 import os
 import os.path
-import pipes
 import subprocess
 from rez.config import config
 from rez.utils.execution import Popen
 from rez.utils.platform_ import platform_
 from rez.shells import UnixShell
 from rez.rex import EscapedString
+from rez.utils.py23 import quote
 
 
 class SH(UnixShell):
@@ -126,7 +126,7 @@ class SH(UnixShell):
 
         for is_literal, txt in value.strings:
             if is_literal:
-                txt = pipes.quote(txt)
+                txt = quote(txt)
                 if not txt.startswith("'"):
                     txt = "'%s'" % txt
             else:

--- a/src/rezplugins/shell/tcsh.py
+++ b/src/rezplugins/shell/tcsh.py
@@ -9,8 +9,8 @@ from rez.utils.platform_ import platform_
 from rezplugins.shell.csh import CSH
 from rez import module_root_path
 from rez.rex import EscapedString
+from rez.utils.py23 import quote
 import os.path
-import pipes
 
 
 class TCSH(CSH):
@@ -26,7 +26,7 @@ class TCSH(CSH):
 
         for is_literal, txt in value.strings:
             if is_literal:
-                txt = pipes.quote(txt)
+                txt = quote(txt)
                 if not txt.startswith("'"):
                     txt = "'%s'" % txt
             else:


### PR DESCRIPTION
Fixes #1463.

Replacing `pipes.quote` is safe since it was anyway pointing to `shlex.quote` under the hood (https://github.com/python/cpython/blob/3.5/Lib/pipes.py#L65).

Replace `cgi.escape` with `html.escape` is also safe.

This needs to go in 2.114.0 because we want 2.114.0 to be able to live as long as possible.