### PR TITLE
Add back patch to fix memcached stats reset

### DIFF
--- a/src/rez/vendor/memcache/memcache.py
+++ b/src/rez/vendor/memcache/memcache.py
@@ -325,7 +325,8 @@ class Client(threading.local):
             readline = s.readline
             while 1:
                 line = readline()
-                if not line or line.decode('ascii').strip() == 'END':
+                # Rez: Patch for https://github.com/AcademySoftwareFoundation/rez/issues/1563.
+                if not line or line.decode('ascii').strip() in ('END', 'RESET'):
                     break
                 stats = line.decode('ascii').split(' ', 2)
                 serverData[stats[1]] = stats[2]


### PR DESCRIPTION
Fixes https://github.com/AcademySoftwareFoundation/rez/issues/1563.

Our vendored `python-memcache` module was updated from 1.53 to 1.58 in rez 2.44.0. The thing is that our vendored version had a custom patch. If I compare `src/rez/vendor/memcache/memcache.py` in rez 2.43.0 with the original from `python-memcache` 1.53, I get the following diff:

```diff
[jcmorin@arch01 python-memcached]$ git diff <(curl -s https://raw.githubusercontent.com/linsomniac/python-memcached/release-1.53/memcache.py) <(curl -s https://raw.githubusercontent.com/AcademySoftwareFoundation/rez/2.43.0/src/rez/vendor/memcache/memcache.py)
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -282,7 +282,8 @@ class Client(local):
             readline = s.readline
             while 1:
                 line = readline()
-                if not line or line.strip() == 'END': break
+                if not line or line.strip() in ('END', 'RESET'):
+                    break
                 stats = line.split(' ', 2)
                 serverData[stats[1]] = stats[2]
```

This custom patched was accidentally dropped during the last upgrade 4 years ago. See https://github.com/AcademySoftwareFoundation/rez/commit/e65bb2145ed543ffaa9fdb1639055777b24bffcd.

The custom patch was introduced in https://github.com/AcademySoftwareFoundation/rez/commit/b3a8e344ef8dcc56337027d6739026b60141b9aa#diff-f479f6b43fe6e341e5fdbd36b2ac6c5b21809957aec7b23553b782aa5829327f (in 2014) right in the middle of the rewrite that happened between rez 1 and 2.

This PR re-introduces the custom patch.