### PR TITLE
Set default shell on Windows to "powershell"

### DIFF
--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -546,6 +546,9 @@ all_resetting_variables = False
 # The default shell type to use when creating resolved environments (eg when using
 # :ref:`rez-env`, or calling :meth:`.ResolvedContext.execute_shell`). If empty or None, the
 # current shell is used (for eg, "bash").
+#
+# .. versionchanged:: 3.0.0
+#    The default value on Windows was changed to "powershell".
 default_shell = ""
 
 # The command to use to launch a new Rez environment in a separate terminal (this

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -65,7 +65,8 @@ class System(object):
         """Get the current shell.
 
         Returns:
-            The current shell this process is running in (bash, tcsh, pwsh, etc).
+            The current shell this process is running in (bash, tcsh, pwsh, etc). On Windows,
+            the return value is always "powershell".
         """
         from rez.shells import get_shell_types
         shells = set(get_shell_types())

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -73,7 +73,7 @@ class System(object):
             raise RezSystemError("no shells available")
 
         if self.platform == "windows":
-            return "cmd"
+            return "powershell"
         else:
             import subprocess as sp
             shell = None


### PR DESCRIPTION
Fixes #1559.

Set default shell on Windows to "powershell".

Note that I'm not 100% sure if this is really how it should be done. I couldn't find a better way.