### PR TITLE
Update package_filter type hint on ResolvedContext

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -187,7 +187,7 @@ class ResolvedContext(object):
                 is used.
             package_paths (list[str]): List of paths to search for pkgs, defaults to
                 :data:`packages_path`.
-            package_filter (PackageFilterBase): Filter used to exclude certain
+            package_filter (PackageFilterList): Filter used to exclude certain
                 packages. Defaults to settings from :data:`package_filter`. Use
                 :data:`rez.package_filter.no_filter` to remove all filtering.
             package_orderers (list[PackageOrder]): Custom package ordering.


### PR DESCRIPTION
Closes #1581 

Updates type hint to be what is actually expected by ResolvedContext under the hood. 

As noted by #1581, ResolvedContext expects a `PackageFilterList` rather than a `PackageFilterBase` when deserializing from a dict, so this PR improves the documentation to match that.