### PR TITLE
Publish to PyPI using https://docs.pypi.org/trusted-publishers/

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -5,8 +5,12 @@ on:
 
 jobs:
   publish:
-    name: Publish to PyPi
+    name: Publish to PyPI
     runs-on: ubuntu-latest
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
       - name: Checkout
@@ -15,18 +19,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3
+          python-version: 3.11
 
       - name: Install Dependencies
         run: |
-          pip install wheel
+          pip install build
 
       - name: Build rez
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel --outdir dist .
 
-      - name: Upload to PyPi
+      # Note that we don't need credentials.
+      # We rely on https://docs.pypi.org/trusted-publishers/.
+      - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: '${{ secrets.PYPI_API_TOKEN }}'
+          packages-dir: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Publish to PyPI using https://docs.pypi.org/trusted-publishers/. This will allow us to remove the PyPI token from GH Actions secrets.

Tested on my fork: https://github.com/JeanChristopheMorinPerso/rez/actions/runs/6916563285/job/18816799702