### PR TITLE
Fix exception when deprecated settings appear in a user config

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -1032,7 +1032,10 @@ def _load_config_from_filepaths(filepaths):
                 for key in data_:
                     if key in _deprecated_settings:
                         rez.deprecations.warn(
-                            _deprecated_settings[key].get_message(),
+                            _deprecated_settings[key].get_message(
+                                key,
+                                env_var=False,
+                            ),
                             rez.deprecations.RezDeprecationWarning,
                             pre_formatted=True,
                             filename=filepath_with_ext,

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -15,11 +15,13 @@ from rez.packages import get_developer_package
 from rez.vendor.six import six
 from rez.deprecations import RezDeprecationWarning
 import os
+import sys
 import os.path
 import subprocess
-import unittest.mock
 import functools
 import shutil
+if sys.version_info[:3] >= (3, 3):
+    import unittest.mock
 
 
 class TestConfig(TestBase):
@@ -297,6 +299,7 @@ class TestConfig(TestBase):
                 raise
 
 
+@unittest.skipIf(sys.version_info[0] < 3, "Skip on python 2")
 class TestDeprecations(TestBase, TempdirMixin):
     @classmethod
     def setUpClass(cls):

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -18,6 +18,7 @@ import os
 import functools
 import sys
 import json
+import copy
 from contextlib import contextmanager
 
 # https://pypi.org/project/parameterized
@@ -39,6 +40,11 @@ class TestBase(unittest.TestCase):
         cls.settings = {}
 
     def setUp(self):
+        # We have some tests that unfortunately don't clean themselves up
+        # after they are done. Store the origianl environment to be
+        # restored in tearDown
+        self.__environ = copy.deepcopy(os.environ)
+
         self.maxDiff = None
         os.environ["REZ_QUIET"] = "true"
 
@@ -56,6 +62,8 @@ class TestBase(unittest.TestCase):
 
     def tearDown(self):
         self.teardown_config()
+        self.assertNotEqual(os.environ, self.__environ)
+        os.environ = self.__environ
 
     @classmethod
     def data_path(cls, *dirs):

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -62,7 +62,6 @@ class TestBase(unittest.TestCase):
 
     def tearDown(self):
         self.teardown_config()
-        self.assertNotEqual(os.environ, self.__environ)
         os.environ = self.__environ
 
     @classmethod


### PR DESCRIPTION
Fixes #1594.

Added tests to cover both settings in custom files and settings from environment variables. These new tests are skipped on Python 2 because I'm tired of Python 2 and there is little value for me to spend time on making them compatible with python 2.