### PR TITLE
Add API warning

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,6 +2,13 @@
 Python API
 ==========
 
+WARNING
+=============
+Please note the following warnings prior to using the Rez Python API:
+
+* We try our best to not break users, but there are no compatibility guarantees between different versions of Rez.
+* The Python API does not currently support rereading from configuration files, or changing to new configuration files after the Python API has initially been imported. If you need to support this functionality, prefer the CLI instead.
+
 .. autosummary::
    :toctree: api
    :recursive:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,8 +2,6 @@
 Python API
 ==========
 
-.. warning::
-
 WARNING
 =======
 Please note the following warnings prior to using the Rez Python API:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,12 +2,11 @@
 Python API
 ==========
 
-WARNING
-=======
-Please note the following warnings prior to using the Rez Python API:
+.. warning::
+   Please note the following warnings prior to using the Rez Python API:
 
-* We try our best to not break users, but there are no compatibility guarantees between different versions of Rez.
-* The Python API does not currently support rereading from configuration files, or changing to new configuration files after the Python API has initially been imported. If you need to support this functionality, prefer the CLI instead.
+   * We try our best to not break users, but there are no compatibility guarantees between different versions of Rez.
+   * The Python API does not currently support rereading from configuration files, or changing to new configuration files after the Python API has initially been imported. If you need to support this functionality, prefer the CLI instead.
 
 .. autosummary::
    :toctree: api

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,8 +2,10 @@
 Python API
 ==========
 
+.. warning::
+
 WARNING
-=============
+=======
 Please note the following warnings prior to using the Rez Python API:
 
 * We try our best to not break users, but there are no compatibility guarantees between different versions of Rez.


### PR DESCRIPTION
Adds info about API compatibility promises, as well as helpful info regarding when to use the Python API vs CLI.

From discussions in this [thread](https://academysoftwarefdn.slack.com/archives/C0321B828FM/p1704476316270719).

This should be discussed further in the upcoming 1/18/24 meeting, but wanted to start a PR for further discussion.
