### PR TITLE
Add semantic versioning warning

### DIFF
--- a/docs/source/basic_concepts.rst
+++ b/docs/source/basic_concepts.rst
@@ -78,13 +78,11 @@ version than ``1.0``.
 .. note::
    No special importance is given to specific characters or letters in Rez version numbers.
    The terms ``alpha`` and ``beta`` for example have no special meaning. Similarly, the number of tokens in
-   a version number doesn't matter, you can have as many as you like. While you are encouraged to use
-   semantic versioning (see `<https://semver.org>`_), it is not enforced.
+   a version number doesn't matter, you can have as many as you like.
 
-.. note::
-   If you are using semantic versioning, please note that version ordering will NOT behave like described
-   in the semantic versioning 2.0.0 spec. Rez gives no special bearing to "pre release" identifiers (as defined by
-   semantic versioning).
+   While you are encouraged to use semantic versioning (see `<https://semver.org>`_), it is not enforced. Please note
+   that if you are using semantic versioning, version ordering will NOT behave like described in the semantic versioning
+   2.0.0 spec.
 
    Ex. foo-1.0.0 < foo-1.0.0-beta.1
 

--- a/docs/source/basic_concepts.rst
+++ b/docs/source/basic_concepts.rst
@@ -81,6 +81,13 @@ version than ``1.0``.
    a version number doesn't matter, you can have as many as you like. While you are encouraged to use
    semantic versioning (see `<https://semver.org>`_), it is not enforced.
 
+.. note::
+   If you are using semantic versioning, please note that version ordering will NOT behave like described
+   in the semantic versioning 2.0.0 spec. Rez gives no special bearing to "pre release" identifiers (as defined by
+   semantic versioning).
+
+   Ex. foo-1.0.0 < foo-1.0.0-beta.1
+
 .. _packages-concept:
 
 Packages


### PR DESCRIPTION
Add semantic versioning ordering warning based on [this Slack discussion](https://academysoftwarefdn.slack.com/archives/C0321B828FM/p1701468368919439) last month.

This adds a clear note that semantic version ordering differs from Rez version ordering.