### PR TITLE
Remove special error message for bez

### DIFF
--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -78,38 +78,6 @@ def create_build_system(working_dir, buildsys_type=None, package=None, opts=None
         clss = get_valid_build_systems(working_dir, package=package)
 
         if not clss:
-            # Special case - bez. This is an old deprecated build system,
-            # which expects a rezbuild.py file. Include info in error showing
-            # how to port to a custom build command.
-            #
-            if os.path.exists(os.path.join(working_dir, "rezbuild.py")):
-                msg = (
-                    "No build system is associated with the path %s.\n"
-                    "\n"
-                    "There is a rezbuild.py file present, suggesting you were "
-                    "using the deprecated bez build system. This functionality "
-                    "will be completely removed in rez 3.0.0.\n"
-                    "You need to use a custom build command instead. "
-                    "You can port your existing "
-                    "rezbuild.py like so:\n"
-                    "\n"
-                    "Add this line to package.py:\n"
-                    "\n"
-                    "    build_command = 'python {root}/rezbuild.py {install}'\n"
-                    "\n"
-                    "Add these lines to rezbuild.py:\n"
-                    "\n"
-                    "    if __name__ == '__main__':\n"
-                    "        import os, sys\n"
-                    "        build(\n"
-                    "            source_path=os.environ['REZ_BUILD_SOURCE_PATH'],\n"
-                    "            build_path=os.environ['REZ_BUILD_PATH'],\n"
-                    "            install_path=os.environ['REZ_BUILD_INSTALL_PATH'],\n"
-                    "            targets=sys.argv[1:]\n"
-                    "        )"
-                )
-                raise BuildSystemError(msg % working_dir)
-
             raise BuildSystemError(
                 "No build system is associated with the path %s" % working_dir)
 


### PR DESCRIPTION
Fixes #1561.

Bez has been removed from the code base a while ago. We can safely remove the special exception message when no build system is defined or found and an old `rezbuild.py` file is found.