### PR TITLE
Add slack release notification

### DIFF
--- a/.github/workflows/release-notice.yaml
+++ b/.github/workflows/release-notice.yaml
@@ -1,0 +1,21 @@
+name: slack-notification
+
+on:
+  release:
+    types:
+      # published should cover both 'released' and 'prereleased'
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Notify Slack
+      id: slack
+      with:
+        project_name: "rez"
+        slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel: "#release-announcements"
+        project_logo: "https://artwork.aswf.io/projects/rez/icon/black/rez-icon-black.png"
+      uses: jmertic/slack-release-notifier@main


### PR DESCRIPTION
Second attempt at adding a Slack notification. This time, it uses @jmertic's action. I copied the workflow from https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/.github/workflows/release-notice.yml and modified the logo URL and project name.