### PR TITLE
Remove sphinx-autobuild to get rid of security vulnerabilities reported in LFX Security

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx >=7.0.0,<8.0.0
 furo
-sphinx-autobuild
 myst-parser


### PR DESCRIPTION
Remove sphinx-autobuild to get rid of security vulnerabilities reported in LFX Security. See https://security.lfx.linuxfoundation.org/#/a092M00001LkM0JQAV/vulnerabilities.