### PR TITLE
Remove Python2-related __future__ imports

### DIFF
--- a/.github/scripts/store_benchmark.py
+++ b/.github/scripts/store_benchmark.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import os.path
 import json

--- a/.github/scripts/validate_benchmark.py
+++ b/.github/scripts/validate_benchmark.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os.path
 import sys
 import json

--- a/example_extensions/hello_cmd/setup.py
+++ b/example_extensions/hello_cmd/setup.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function, with_statement
 from setuptools import setup
 
 

--- a/install.py
+++ b/install.py
@@ -6,8 +6,6 @@
 This script uses venv/virtualenv to create a standalone, production-ready Rez
 installation in the specified directory.
 """
-from __future__ import print_function
-
 import argparse
 import os
 import sys

--- a/release-rez.py
+++ b/release-rez.py
@@ -7,7 +7,6 @@ Release a new version of rez.
 
 Read RELEASE.md before using this utility.
 """
-from __future__ import print_function
 import argparse
 import os
 from datetime import date

--- a/repository/hello_world_py/1.0.0/python/hello_world.py
+++ b/repository/hello_world_py/1.0.0/python/hello_world.py
@@ -1,5 +1,2 @@
-from __future__ import print_function
-
-
 def hello():
     print("Hello world!")

--- a/repository/tbb/4.3/install.py
+++ b/repository/tbb/4.3/install.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import shutil
 import os

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function, with_statement
-
 import fnmatch
 import os
 import os.path

--- a/src/build_utils/license/change_copyright
+++ b/src/build_utils/license/change_copyright
@@ -2,7 +2,6 @@
 #
 # dumb script to update copyright notice in a py sourcefile
 #
-from __future__ import print_function
 import argparse
 import sys
 import os

--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.utils._version import _rez_version
 import rez.deprecations
 import sys

--- a/src/rez/backport/zipfile.py
+++ b/src/rez/backport/zipfile.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from zipfile import *

--- a/src/rez/bind/PyQt.py
+++ b/src/rez/bind/PyQt.py
@@ -5,7 +5,6 @@
 """
 Binds the python PyQt module as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind import _pymodule
 from rez.bind._utils import get_version_in_python
 

--- a/src/rez/bind/PySide.py
+++ b/src/rez/bind/PySide.py
@@ -5,7 +5,6 @@
 """
 Binds the python PySide module as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind import _pymodule
 
 

--- a/src/rez/bind/_pymodule.py
+++ b/src/rez/bind/_pymodule.py
@@ -9,8 +9,6 @@ Note that we subproc out to python at various points here because we can't use
 the current python interpreter - this is rez's, inside its installation
 virtualenv.
 """
-from __future__ import absolute_import, print_function
-
 from rez.bind._utils import check_version, find_exe, make_dirs, \
     get_version_in_python, run_python_command, log
 from rez.package_maker import make_package

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -5,7 +5,6 @@
 """
 Utility functions for bind modules.
 """
-from __future__ import absolute_import
 from rez.version import Version
 from rez.exceptions import RezBindError
 from rez.config import config

--- a/src/rez/bind/arch.py
+++ b/src/rez/bind/arch.py
@@ -5,7 +5,6 @@
 """
 Creates the system architecture package.
 """
-from __future__ import absolute_import
 from rez.package_maker import make_package
 from rez.version import Version
 from rez.bind._utils import check_version

--- a/src/rez/bind/cmake.py
+++ b/src/rez/bind/cmake.py
@@ -5,7 +5,6 @@
 """
 Binds a cmake executable as a rez package.
 """
-from __future__ import absolute_import
 from rez.package_maker import make_package
 from rez.bind._utils import check_version, find_exe, extract_version, make_dirs
 from rez.utils.platform_ import platform_

--- a/src/rez/bind/gcc.py
+++ b/src/rez/bind/gcc.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import absolute_import
 from rez.bind._utils import find_exe, extract_version, make_dirs, log
 from rez.package_maker import make_package
 from rez.utils.lint_helper import env

--- a/src/rez/bind/hello_world.py
+++ b/src/rez/bind/hello_world.py
@@ -9,8 +9,6 @@ Note: Even though this is a python-based package, it does not list python as a
 requirement. This is not typical! This package is intended as a very simple test
 case, and for that reason we do not want any dependencies.
 """
-from __future__ import absolute_import, print_function
-
 from rez.package_maker import make_package
 from rez.version import Version
 from rez.utils.lint_helper import env

--- a/src/rez/bind/os.py
+++ b/src/rez/bind/os.py
@@ -5,7 +5,6 @@
 """
 Creates the operating system package.
 """
-from __future__ import absolute_import
 from rez.package_maker import make_package
 from rez.version import Version
 from rez.bind._utils import check_version

--- a/src/rez/bind/pip.py
+++ b/src/rez/bind/pip.py
@@ -5,7 +5,6 @@
 """
 Binds the python pip module as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind import _pymodule
 
 

--- a/src/rez/bind/platform.py
+++ b/src/rez/bind/platform.py
@@ -5,7 +5,6 @@
 """
 Creates the system platform package.
 """
-from __future__ import absolute_import
 from rez.package_maker import make_package
 from rez.version import Version
 from rez.bind._utils import check_version

--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -5,7 +5,6 @@
 """
 Binds a python executable as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind._utils import check_version, find_exe, extract_version, \
     make_dirs, log, run_python_command
 from rez.package_maker import make_package

--- a/src/rez/bind/rez.py
+++ b/src/rez/bind/rez.py
@@ -5,7 +5,6 @@
 """
 Binds rez itself as a rez package.
 """
-from __future__ import absolute_import
 import rez
 from rez.package_maker import make_package
 from rez.bind._utils import check_version

--- a/src/rez/bind/rezgui.py
+++ b/src/rez/bind/rezgui.py
@@ -5,7 +5,6 @@
 """
 Binds rez-gui as a rez package.
 """
-from __future__ import absolute_import
 import rez
 from rez.package_maker import make_package
 from rez.bind._utils import check_version, make_dirs

--- a/src/rez/bind/setuptools.py
+++ b/src/rez/bind/setuptools.py
@@ -5,7 +5,6 @@
 """
 Binds the python setuptools module as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind import _pymodule
 
 

--- a/src/rez/bind/sip.py
+++ b/src/rez/bind/sip.py
@@ -5,7 +5,6 @@
 """
 Binds the python PyQt module as a rez package.
 """
-from __future__ import absolute_import
 from rez.bind import _pymodule
 from rez.bind._utils import get_version_in_python
 

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.packages import iter_packages
 from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseHookCancellingError, RezError, ReleaseError, BuildError, \

--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -5,8 +5,6 @@
 """
 The main command-line entry point.
 """
-from __future__ import print_function
-
 import sys
 import importlib
 from argparse import _StoreTrueAction, SUPPRESS

--- a/src/rez/cli/_util.py
+++ b/src/rez/cli/_util.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import os
 import sys
 import signal

--- a/src/rez/cli/benchmark.py
+++ b/src/rez/cli/benchmark.py
@@ -5,8 +5,6 @@
 '''
 Run a benchmarking suite for runtime resolves.
 '''
-from __future__ import print_function
-
 import json
 import os
 import os.path

--- a/src/rez/cli/bind.py
+++ b/src/rez/cli/bind.py
@@ -5,8 +5,6 @@
 '''
 Create a Rez package for existing software.
 '''
-from __future__ import print_function
-
 import argparse
 
 

--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -5,8 +5,6 @@
 '''
 Build a package from source.
 '''
-from __future__ import print_function
-
 import os
 
 

--- a/src/rez/cli/bundle.py
+++ b/src/rez/cli/bundle.py
@@ -5,8 +5,6 @@
 '''
 Bundle a context and its packages into a relocatable dir.
 '''
-from __future__ import print_function
-
 import os
 import os.path
 import sys

--- a/src/rez/cli/complete.py
+++ b/src/rez/cli/complete.py
@@ -5,8 +5,6 @@
 """
 Prints package completion strings.
 """
-from __future__ import print_function
-
 import argparse
 
 

--- a/src/rez/cli/config.py
+++ b/src/rez/cli/config.py
@@ -5,8 +5,6 @@
 '''
 Print current rez settings.
 '''
-from __future__ import print_function
-
 import json
 
 

--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -5,8 +5,6 @@
 '''
 Print information about the current rez context, or a given context file.
 '''
-from __future__ import print_function
-
 # Disable the following:
 # - context tracking
 # - package caching

--- a/src/rez/cli/cp.py
+++ b/src/rez/cli/cp.py
@@ -5,7 +5,6 @@
 '''
 Copy a package from one repository to another.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/depends.py
+++ b/src/rez/cli/depends.py
@@ -5,7 +5,6 @@
 """
 Perform a reverse package dependency lookup.
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -5,7 +5,6 @@
 '''
 Open a rez-configured shell, possibly interactive.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/help.py
+++ b/src/rez/cli/help.py
@@ -5,7 +5,6 @@
 """
 Utility for displaying help for the given package.
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -5,7 +5,6 @@
 '''
 Execute some Rex code and print the interpreted result.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/memcache.py
+++ b/src/rez/cli/memcache.py
@@ -5,7 +5,6 @@
 """
 Manage and query memcache server(s).
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/mv.py
+++ b/src/rez/cli/mv.py
@@ -5,7 +5,6 @@
 '''
 Move a package from one repository to another.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/pip.py
+++ b/src/rez/cli/pip.py
@@ -5,7 +5,6 @@
 """
 Install a pip-compatible python package, and its dependencies, as rez packages.
 """
-from __future__ import print_function
 from argparse import REMAINDER
 import logging
 

--- a/src/rez/cli/pkg-cache.py
+++ b/src/rez/cli/pkg-cache.py
@@ -5,7 +5,6 @@
 '''
 Manipulate a package cache.
 '''
-from __future__ import print_function
 from argparse import SUPPRESS
 import os.path
 import sys

--- a/src/rez/cli/pkg-ignore.py
+++ b/src/rez/cli/pkg-ignore.py
@@ -5,7 +5,6 @@
 '''
 Disable a package so it is hidden from resolves.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/plugins.py
+++ b/src/rez/cli/plugins.py
@@ -5,7 +5,6 @@
 """
 Get a list of a package's plugins.
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -5,8 +5,6 @@
 '''
 Build a package from source and deploy it.
 '''
-from __future__ import print_function
-
 import os
 import sys
 from subprocess import call

--- a/src/rez/cli/rm.py
+++ b/src/rez/cli/rm.py
@@ -5,7 +5,6 @@
 '''
 Remove package(s) from a repository.
 '''
-from __future__ import print_function
 import sys
 
 

--- a/src/rez/cli/search.py
+++ b/src/rez/cli/search.py
@@ -5,8 +5,6 @@
 """
 Search for packages
 """
-from __future__ import print_function
-
 import os
 import sys
 

--- a/src/rez/cli/suite.py
+++ b/src/rez/cli/suite.py
@@ -5,7 +5,6 @@
 '''
 Manage a suite or print information about an existing suite.
 '''
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -6,6 +6,7 @@
 Run tests listed in a package's definition file.
 '''
 
+
 def setup_parser(parser, completions=False):
     parser.add_argument(
         "-l", "--list", action="store_true",

--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -5,8 +5,6 @@
 '''
 Run tests listed in a package's definition file.
 '''
-from __future__ import print_function
-
 
 def setup_parser(parser, completions=False):
     parser.add_argument(

--- a/src/rez/cli/view.py
+++ b/src/rez/cli/view.py
@@ -5,7 +5,6 @@
 """
 View the contents of a package.
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/cli/yaml2py.py
+++ b/src/rez/cli/yaml2py.py
@@ -5,7 +5,6 @@
 """
 Print a package.yaml file in package.py format.
 """
-from __future__ import print_function
 
 
 def setup_parser(parser, completions=False):

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import absolute_import
 from rez import __version__
 from rez.utils.data_utils import AttrDictWrapper, RO_AttrDictWrapper, \
     convert_dicts, cached_property, cached_class_property, LazyAttributeMeta, \

--- a/src/rez/data/tests/builds/packages/anti/1.0.0/build.py
+++ b/src/rez/data/tests/builds/packages/anti/1.0.0/build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from build_util import build_directory_recurse, check_visible
 
 def build(source_path, build_path, install_path, targets):

--- a/src/rez/data/tests/builds/packages/bah/2.1/build.py
+++ b/src/rez/data/tests/builds/packages/bah/2.1/build.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 from build_util import build_directory_recurse, check_visible

--- a/src/rez/data/tests/builds/packages/build_util/1/build.py
+++ b/src/rez/data/tests/builds/packages/build_util/1/build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import shutil
 import os.path
 

--- a/src/rez/data/tests/builds/packages/build_util/1/build_util/__init__.py
+++ b/src/rez/data/tests/builds/packages/build_util/1/build_util/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import shutil
 import os.path
 

--- a/src/rez/data/tests/builds/packages/foo/1.0.0/build.py
+++ b/src/rez/data/tests/builds/packages/foo/1.0.0/build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from build_util import build_directory_recurse, check_visible
 import os.path
 import os

--- a/src/rez/data/tests/builds/packages/foo/1.1.0/build.py
+++ b/src/rez/data/tests/builds/packages/foo/1.1.0/build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from build_util import build_directory_recurse, check_visible
 import os.path
 

--- a/src/rez/data/tests/release/build.py
+++ b/src/rez/data/tests/release/build.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import shutil
 import os.path
 import os

--- a/src/rez/package_bind.py
+++ b/src/rez/package_bind.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.exceptions import RezBindError, _NeverError
 from rez import module_root_path
 from rez.util import get_close_pkgs

--- a/src/rez/package_help.py
+++ b/src/rez/package_help.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.packages import iter_packages
 from rez.config import config
 from rez.rex_bindings import VersionBinding

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.serialise import FileFormat
 from rez.package_resources import help_schema, late_bound
 from rez.vendor.schema.schema import Schema, Optional, And, Or, Use

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function, absolute_import
-
 from rez.packages import get_latest_package
 from rez.version import Version
 from rez.vendor.distlib.database import DistributionPath

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez import __version__, module_root_path
 from rez.package_repository import package_repository_manager
 from rez.solver import SolverCallbackReturn

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import os
 import sys
 import re

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -11,8 +11,6 @@ with a faster resolve.
 
 See SOLVER.md for an in-depth description of how this module works.
 """
-from __future__ import print_function
-
 from rez.config import config
 from rez.packages import iter_packages
 from rez.package_repository import package_repo_stats

--- a/src/rez/status.py
+++ b/src/rez/status.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import sys
 import os
 import os.path

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.utils.execution import create_forwarding_script
 from rez.exceptions import SuiteError, ResolvedContextError
 from rez.resolved_context import ResolvedContext

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -5,8 +5,6 @@
 """
 test shell invocation
 """
-from __future__ import print_function
-
 from rez.system import system
 from rez.shells import create_shell, get_shell_types, get_shell_class
 from rez.resolved_context import ResolvedContext

--- a/src/rez/tests/test_solver.py
+++ b/src/rez/tests/test_solver.py
@@ -5,8 +5,6 @@
 """
 test dependency resolving algorithm
 """
-from __future__ import print_function
-
 import rez.exceptions
 from rez.version import Requirement
 from rez.solver import Solver, Cycle, SolverStatus

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import unittest
 from rez import module_root_path
 from rez.config import config, _create_locked_config

--- a/src/rez/utils/colorize.py
+++ b/src/rez/utils/colorize.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import sys
 import logging
 from rez.vendor import colorama

--- a/src/rez/utils/diff_packages.py
+++ b/src/rez/utils/diff_packages.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.packages import iter_packages
 from rez.config import config
 from rez.plugin_managers import plugin_manager

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -5,8 +5,6 @@
 """
 Filesystem-related utilities.
 """
-from __future__ import print_function
-
 from threading import Lock
 from tempfile import mkdtemp
 from contextlib import contextmanager

--- a/src/rez/utils/formatting.py
+++ b/src/rez/utils/formatting.py
@@ -5,8 +5,6 @@
 """
 Utilities related to formatting output or translating input.
 """
-from __future__ import absolute_import
-
 from string import Formatter
 from rez.vendor.enum import Enum
 from rez.version import Requirement

--- a/src/rez/utils/graph_utils.py
+++ b/src/rez/utils/graph_utils.py
@@ -5,8 +5,6 @@
 """
 Functions for manipulating dot-based resolve graphs.
 """
-from __future__ import print_function
-
 import os.path
 import sys
 import tempfile

--- a/src/rez/utils/installer.py
+++ b/src/rez/utils/installer.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 import rez
 from rez.package_maker import make_package
 from rez.system import system

--- a/src/rez/utils/json.py
+++ b/src/rez/utils/json.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import absolute_import
 import json
 from json import dumps  # noqa (forwarded)
 import sys

--- a/src/rez/utils/logging_.py
+++ b/src/rez/utils/logging_.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
 from contextlib import contextmanager
 import logging
 import time

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.config import config
 from rez.vendor.memcache.memcache import Client as Client_, \
     SERVER_MAX_KEY_LENGTH, __version__ as memcache_client_version

--- a/src/rez/utils/py_dist.py
+++ b/src/rez/utils/py_dist.py
@@ -5,8 +5,6 @@
 """
 Functions for converting python distributions to rez packages.
 """
-from __future__ import print_function
-
 from rez.exceptions import RezSystemError
 import pkg_resources
 import shutil

--- a/src/rez/utils/scope.py
+++ b/src/rez/utils/scope.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.utils.formatting import StringFormatMixin, StringFormatType
 from collections import UserDict
 import sys

--- a/src/rez/version/_version.py
+++ b/src/rez/version/_version.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
 from rez.version._util import VersionError, ParseException, _Common, \
     dedup
 from bisect import bisect_left

--- a/src/rez/wrapper.py
+++ b/src/rez/wrapper.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from rez.resolved_context import ResolvedContext
 from rez.utils.colorize import heading, local, critical, Printer
 from rez.utils.data_utils import cached_property

--- a/src/rezgui/dialogs/ProcessDialog.py
+++ b/src/rezgui/dialogs/ProcessDialog.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from Qt import QtCore, QtWidgets
 from rezgui.util import create_pane
 from rezgui.mixins.StoreSizeMixin import StoreSizeMixin

--- a/src/rezgui/objects/ResolveThread.py
+++ b/src/rezgui/objects/ResolveThread.py
@@ -2,8 +2,6 @@
 # Copyright Contributors to the Rez Project
 
 
-from __future__ import print_function
-
 from Qt import QtCore
 from rez.exceptions import RezError
 

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -5,8 +5,6 @@
 """
 CMake-based build system
 """
-from __future__ import print_function
-
 from rez.build_system import BuildSystem
 from rez.build_process import BuildType
 from rez.resolved_context import ResolvedContext

--- a/src/rezplugins/release_hook/amqp.py
+++ b/src/rezplugins/release_hook/amqp.py
@@ -5,8 +5,6 @@
 """
 Publishes a message to the broker.
 """
-from __future__ import print_function
-
 from rez.release_hook import ReleaseHook
 from rez.utils.logging_ import print_error, print_debug
 from rez.utils.amqp import publish_message

--- a/src/rezplugins/release_hook/command.py
+++ b/src/rezplugins/release_hook/command.py
@@ -5,8 +5,6 @@
 """
 Executes pre- and post-release shell commands
 """
-from __future__ import print_function
-
 import getpass
 import sys
 import os

--- a/src/rezplugins/release_hook/emailer.py
+++ b/src/rezplugins/release_hook/emailer.py
@@ -5,8 +5,6 @@
 """
 Sends a post-release email
 """
-from __future__ import print_function
-
 from rez.release_hook import ReleaseHook
 from rez.system import system
 from email.mime.text import MIMEText

--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -5,8 +5,6 @@
 """
 Git version control
 """
-from __future__ import print_function
-
 from rez.release_vcs import ReleaseVCS
 from rez.utils.logging_ import print_error, print_debug
 from rez.exceptions import ReleaseVCSError

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -5,8 +5,6 @@
 """
 Mercurial version control
 """
-from __future__ import print_function
-
 from rez.release_vcs import ReleaseVCS
 from rez.exceptions import ReleaseVCSError
 from rez.utils.logging_ import print_debug, print_error

--- a/src/rezplugins/release_vcs/stub.py
+++ b/src/rezplugins/release_vcs/stub.py
@@ -5,8 +5,6 @@
 """
 Stub version control system, for testing purposes
 """
-from __future__ import print_function
-
 from rez.release_vcs import ReleaseVCS
 from rez.utils.logging_ import print_warning
 from rez.utils.yaml import dump_yaml

--- a/src/rezplugins/release_vcs/svn.py
+++ b/src/rezplugins/release_vcs/svn.py
@@ -5,8 +5,6 @@
 """
 Svn version control
 """
-from __future__ import print_function
-
 from rez.release_vcs import ReleaseVCS
 from rez.exceptions import ReleaseVCSError
 import os.path


### PR DESCRIPTION
Closes #1636

Removes every `from __future__ import print_function` outside of the vendor directory.

Also removes other Python2-related imports, such as:
* `from __future__ import with_statement`
* `from __future__ import absolute_import`

