### PR TITLE
Remove the note about Python 2.7 compatibility from the docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,11 +37,6 @@ It is possible to install rez with pip, like so::
 
    ]$ pip install rez
 
-.. note::
-   While the ``install.py`` script only supports Python 3.7+,
-   rez is still usable with Python 2.7 when installed via pip. In other words, the API
-   is fully compatible with Python 2 and 3.
-
 However, this comes with a caveat. Rez command line tools **are not guaranteed
 to work correctly** once inside a rez environment (ie after using the :ref:`rez-env`
 command). The reasons are given in the next section.


### PR DESCRIPTION
Fixes #1628.

I was not able to find any other mentions of `python2`, `Python 2`, or `Python 2.7` in the docs.