### PR TITLE
Improve install docs by mentioning how to actually download rez

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,9 +5,14 @@ Installation
 Installation Script
 ===================
 
-To install rez, download the source by either cloning the `repository <https://github.com/AcademySoftwareFoundation/rez>`_
-with git or downloading it from the `latest release <https://github.com/AcademySoftwareFoundation/rez/releases/latest>`_.
-If you download rez from the release page on GitHub, don't forget to unpack the downloaded archive.
+To install rez, you will need:
+
+1. Python 3.7 or above. We support 3.7, 3.8, 3.9, 3.10 and 3.11.
+   The pythoon interpreter you use to run the install script will be the interpreter
+   used by rez itself.
+2. The source code. You can get it by either cloning the `repository <https://github.com/AcademySoftwareFoundation/rez>`_
+   with git or downloading it from the `latest release <https://github.com/AcademySoftwareFoundation/rez/releases/latest>`_.
+   If you download rez from the release page on GitHub, don't forget to unpack the downloaded archive.
 
 Then from the root directory, run::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,7 +16,7 @@ Then from the root directory, run::
 
    ]$ python ./install.py
 
-This installs rez to ``/opt/rez``. See ``install.py -h`` to see the different install options.
+This installs rez to ``/opt/rez``. Use ``install.py -h`` to see the different install options.
 
 Once the installation is complete, a message tells you how to run it::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,7 +8,7 @@ Installation Script
 To install rez, you will need:
 
 1. Python 3.7 or above. We support 3.7, 3.8, 3.9, 3.10 and 3.11.
-   The pythoon interpreter you use to run the install script will be the interpreter
+   The python interpreter you use to run the install script will be the interpreter
    used by rez itself.
 2. The source code. You can get it by either cloning the `repository <https://github.com/AcademySoftwareFoundation/rez>`_
    with git or downloading it from the `latest release <https://github.com/AcademySoftwareFoundation/rez/releases/latest>`_.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,12 +8,15 @@ Installation Script
 .. warning::
    The install script only supports Python 3.7+.
 
-To install rez, download the source. Then from the root directory, run::
+To install rez, download the source by either cloning the `repository <https://github.com/AcademySoftwareFoundation/rez>`_
+with git or downloading it from the `latest release <https://github.com/AcademySoftwareFoundation/rez/releases/latest>`_.
+If you download rez from the release page on GitHub, don't forget to unpack the downloaded archive.
+
+Then from the root directory, run::
 
    ]$ python ./install.py
 
-This installs rez to ``/opt/rez``. See ```install.py -h``` for how to install to a
-different location.
+This installs rez to ``/opt/rez``. See ``install.py -h`` to see the different install options.
 
 Once the installation is complete, a message tells you how to run it::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,9 +5,6 @@ Installation
 Installation Script
 ===================
 
-.. warning::
-   The install script only supports Python 3.7+.
-
 To install rez, download the source by either cloning the `repository <https://github.com/AcademySoftwareFoundation/rez>`_
 with git or downloading it from the `latest release <https://github.com/AcademySoftwareFoundation/rez/releases/latest>`_.
 If you download rez from the release page on GitHub, don't forget to unpack the downloaded archive.


### PR DESCRIPTION
Related to https://www.bestpractices.dev/en/projects/8389#interact.

I noticed that the docs were not very clear on how rez could be download.