### PR TITLE
Improve clarify of early binding functions documentation

### DIFF
--- a/docs/source/building_packages.rst
+++ b/docs/source/building_packages.rst
@@ -23,6 +23,8 @@ package with two python-based variants might look like this:
 
 The current working directory is set to the *build path* during a build.
 
+.. _the-build-environment:
+
 The Build Environment
 =====================
 

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -121,8 +121,8 @@ removed**:
 Build Environment Variables
 ===========================
 
-These are variables that rez generates within a build environment, in addition
-to those listed :ref:`here <context-environment-variables>`.
+These are variables that rez generates within a :ref:`build environment <the-build-environment>`, in addition
+to context environment variables listed :ref:`here <context-environment-variables>`.
 
 .. glossary::
 

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -116,7 +116,7 @@ implicit :attr:`this` object:
 .. warning::
    Certain package attributes cannot be accessed inside of an early bound function such as this.root.
 
-   Additionally, :ref: `build environment variables <context-environment-variables>` cannot be accessed inside
+   Additionally, :ref:`build environment variables <context-environment-variables>` cannot be accessed inside
    of early bound functions.
 
 Early binding functions are a convenience. You can always use an arbitrary function instead, like so:

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -114,7 +114,7 @@ implicit :attr:`this` object:
    your early bound function. An error will be raised if you do.
 
 .. warning::
-   Certain package attributes cannot be accessed inside of an early bound function such as this.root.
+   Certain package attributes cannot be accessed inside of an early bound function such as :attr:`this.root`.
 
    Additionally, :ref:`build environment variables <build-environment-variables>` cannot be accessed inside
    of early bound functions.

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -79,10 +79,10 @@ and *late binding* functions - and these are decorated using ``@early`` and ``@l
 Early Binding Functions
 +++++++++++++++++++++++
 
-Early binding functions use the ``@early`` decorator. They are evaluated at *build time*, hence the
-'early' in 'early binding' and their definition persists into the
-``package.py``. By 'build time', it is meant that they are evaluated before the
-resolve has occurred, and as such, before the
+Early binding functions use the ``@early`` decorator. They are evaluated at
+*build time*, hence the 'early' in 'early binding' and their definition persists
+in the installed ``package.py``. By 'build time', it is meant that they are
+evaluated before the resolve has occurred, and as such, before the
 :ref:`build environment <the-build-environment>` has been constructed. Therefore
 there are some important distinctions that set early-bound functions apart from
 other function attributes:

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -113,6 +113,12 @@ implicit :attr:`this` object:
    Do not reference other early bound or late bound attributes in
    your early bound function. An error will be raised if you do.
 
+.. warning::
+   Certain package attributes cannot be accessed inside of an early bound function such as this.root.
+
+   Additionally, :ref: `build environment variables <context-environment-variables>` cannot be accessed inside
+   of early bound functions.
+
 Early binding functions are a convenience. You can always use an arbitrary function instead, like so:
 
 .. code-block:: python

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -116,7 +116,7 @@ implicit :attr:`this` object:
 .. warning::
    Certain package attributes cannot be accessed inside of an early bound function such as this.root.
 
-   Additionally, :ref:`build environment variables <context-environment-variables>` cannot be accessed inside
+   Additionally, :ref:`build environment variables <build-environment-variables>` cannot be accessed inside
    of early bound functions.
 
 Early binding functions are a convenience. You can always use an arbitrary function instead, like so:

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -80,10 +80,15 @@ Early Binding Functions
 +++++++++++++++++++++++
 
 Early binding functions use the ``@early`` decorator. They are evaluated at *build time*, hence the
-'early' in 'early binding'. Any package attribute can be implemented as an early binding function.
+'early' in 'early binding'. By build time, we mean that they are evaluated before the resolve has happened and before
+the :ref:`build environment <the-build-environment>` is constructed. Therefore it's important to note a few important
+behaviors of early bound functions:
 
-Here is an example of an :attr:`authors` attribute that is automatically set to the contributors of the
-package's git project:
+- The :attr:`this` object only exposes package attributes and nothing else when used inside an early bound function.
+- No Rez-set :ref:`environment variables <environment-variables>` can be accessed inside an early bound function.
+
+Any package attribute can be implemented as an early binding function. Here is an example of an :attr:`authors`
+attribute that is automatically set to the contributors of the package's git project:
 
 .. code-block:: python
 
@@ -112,12 +117,6 @@ implicit :attr:`this` object:
 .. warning::
    Do not reference other early bound or late bound attributes in
    your early bound function. An error will be raised if you do.
-
-.. warning::
-   Certain package attributes cannot be accessed inside of an early bound function such as :attr:`this.root`.
-
-   Additionally, :ref:`build environment variables <build-environment-variables>` cannot be accessed inside
-   of early bound functions.
 
 Early binding functions are a convenience. You can always use an arbitrary function instead, like so:
 

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -80,12 +80,15 @@ Early Binding Functions
 +++++++++++++++++++++++
 
 Early binding functions use the ``@early`` decorator. They are evaluated at *build time*, hence the
-'early' in 'early binding'. By build time, we mean that they are evaluated before the resolve has happened and before
-the :ref:`build environment <the-build-environment>` is constructed. Therefore it's important to note a few important
-behaviors of early bound functions:
+'early' in 'early binding' and their definition persists into the
+``package.py``. By 'build time', it is meant that they are evaluated before the
+resolve has occurred, and as such, before the
+:ref:`build environment <the-build-environment>` has been constructed. Therefore
+there are some important distinctions that set early-bound functions apart from
+other function attributes:
 
-- The :attr:`this` object only exposes package attributes and nothing else when used inside an early bound function.
-- No Rez-set :doc:`environment variables <environment>` can be accessed inside an early bound function.
+- The :attr:`this` object only exposes package attributes. Nothing else is accessible when inside an early-bound function.
+- No rez-set :doc:`environment variables <environment>` can be accessed inside an early bound function.
 
 Any package attribute can be implemented as an early binding function. Here is an example of an :attr:`authors`
 attribute that is automatically set to the contributors of the package's git project:

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -85,7 +85,7 @@ the :ref:`build environment <the-build-environment>` is constructed. Therefore i
 behaviors of early bound functions:
 
 - The :attr:`this` object only exposes package attributes and nothing else when used inside an early bound function.
-- No Rez-set :ref:`environment variables <environment-variables>` can be accessed inside an early bound function.
+- No Rez-set :doc:`environment variables <environment>` can be accessed inside an early bound function.
 
 Any package attribute can be implemented as an early binding function. Here is an example of an :attr:`authors`
 attribute that is automatically set to the contributors of the package's git project:


### PR DESCRIPTION
Added new information about accessible package attributes and environment variables. 

Looking for some help clarifying exactly what language we should use here and where everything should live.

 Just trying to clarify:
 
- What packages attributes can be used inside an early bound function.
- When environment variables can be read inside of packages and if there are certain situations where they cannot be read (ex. early bound functions).