### PR TITLE
Package Orderers now apply to variants

### DIFF
--- a/src/rez/data/tests/solver/packages/pyvariants/2/package.py
+++ b/src/rez/data/tests/solver/packages/pyvariants/2/package.py
@@ -1,4 +1,9 @@
 name = "pyvariants"
 version = "2"
 
-variants = [["python-2.7.0"], ["python-2.6.8", "nada"]]
+variants = [
+    ["python-2.7.0"],
+    ["python-2.6.8", "nada"],
+    ["python-2.6.8"],
+    ["nada"],
+]

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -150,7 +150,9 @@ class PackageOrder(object):
             version: (Version) the version object you wish to generate a key for
 
         Returns:
-            Comparable object
+            Sortable object
+                The returned object must be sortable, which means that it must implement __lt__.
+                The specific return type is not important.
         """
         raise NotImplementedError
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -636,7 +636,7 @@ class PackageOrderList(list):
 
     @staticmethod
     def _to_orderer(orderer: Union[dict, PackageOrder]) -> PackageOrder:
-        if not isinstance(orderer, PackageOrder):
+        if isinstance(orderer, dict):
             orderer = from_pod(orderer)
         return orderer
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -603,7 +603,7 @@ class TimestampPackageOrder(PackageOrder):
     @classmethod
     def from_pod(cls, data):
         return cls(
-            timestamp=data["timestamp"],
+            data["timestamp"],
             rank=data.get("rank", 0),
             packages=data.get("packages"),
         )

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -306,13 +306,14 @@ class PerFamilyOrder(PackageOrder):
     def sort_key_implementation(self, package_name, version):
         orderer = self.order_dict.get(package_name)
         if orderer is None:
-            if self.default_order is not None:
-                orderer = self.default_order
-            else:
+            
+            if self.default_order is None:
                 # shouldn't get here, because applies_to should protect us...
                 raise RuntimeError(
                     "package family orderer %r does not apply to package family %r",
                     (self, package_name))
+
+            orderer = self.default_order
 
         return orderer.sort_key_implementation(package_name, version)
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -4,10 +4,40 @@
 
 from inspect import isclass
 from hashlib import sha1
+from typing import Dict, Iterable, List, Optional, Union
 
 from rez.config import config
 from rez.utils.data_utils import cached_class_property
-from rez.version import Version
+from rez.version import Version, VersionRange
+from rez.version._version import _Comparable, _ReversedComparable, _LowerBound, _UpperBound, _Bound
+
+
+ALL_PACKAGES = "*"
+
+
+class FallbackComparable(_Comparable):
+    """First tries to compare objects using the main_comparable, but if that
+    fails, compares using the fallback_comparable object.
+    """
+
+    def __init__(self, main_comparable, fallback_comparable):
+        self.main_comparable = main_comparable
+        self.fallback_comparable = fallback_comparable
+
+    def __eq__(self, other):
+        try:
+            return self.main_comparable == other.main_comparable
+        except Exception:
+            return self.fallback_comparable == other.fallback_comparable
+
+    def __lt__(self, other):
+        try:
+            return self.main_comparable < other.main_comparable
+        except Exception:
+            return self.fallback_comparable < other.fallback_comparable
+
+    def __repr__(self):
+        return '%s(%r, %r)' % (type(self).__name__, self.main_comparable, self.fallback_comparable)
 
 
 class PackageOrder(object):
@@ -16,8 +46,32 @@ class PackageOrder(object):
     #: Orderer name
     name = None
 
-    def __init__(self):
-        pass
+    def __init__(self, packages: Optional[Iterable[str]] = None):
+        """
+        Args:
+            packages: If not provided, PackageOrder applies to all packages.
+        """
+        self.packages = packages
+
+    @property
+    def packages(self) -> List[str]:
+        """Returns an iterable over the list of package family names that this
+        order applies to
+
+        Returns:
+            (Iterable[str]) Package families that this orderer is used for
+        """
+        return self._packages
+
+    @packages.setter
+    def packages(self, packages: Union[str, Iterable[str]]):
+        if packages is None:
+            # Apply to all packages
+            self._packages = [ALL_PACKAGES]
+        elif isinstance(packages, str):
+            self._packages = [packages]
+        else:
+            self._packages = sorted(packages)
 
     def reorder(self, iterable, key=None):
         """Put packages into some order for consumption.
@@ -40,9 +94,69 @@ class PackageOrder(object):
         Returns:
             list: Reordered ``iterable``
         """
+        key = key or (lambda x: x)
+        package_name = self._get_package_name_from_iterable(iterable, key=key)
+        return sorted(iterable,
+                      key=lambda x: self.sort_key(package_name, key(x).version),
+                      reverse=True)
+
+    @staticmethod
+    def _get_package_name_from_iterable(iterable, key=None):
+        """Utility method for getting a package from an iterable"""
+        try:
+            item = next(iter(iterable))
+        except (TypeError, StopIteration):
+            return None
+
+        key = key or (lambda x: x)
+        return key(item).name
+
+    def sort_key(self, package_name, version_like):
+        """Returns a sort key usable for sorting packages within the same family
+
+        Args:
+            package_name: (str) The family name of the package we are sorting
+            version_like: (Version|_LowerBound|_UpperBound|_Bound|VersionRange)
+                the version-like object you wish to generate a key for
+
+        Returns:
+            Comparable object
+        """
+        if isinstance(version_like, VersionRange):
+            return tuple(self.sort_key(package_name, bound) for bound in version_like.bounds)
+        elif isinstance(version_like, _Bound):
+            return (self.sort_key(package_name, version_like.lower),
+                    self.sort_key(package_name, version_like.upper))
+        elif isinstance(version_like, _LowerBound):
+            inclusion_key = -2 if version_like.inclusive else -1
+            return self.sort_key(package_name, version_like.version), inclusion_key
+        elif isinstance(version_like, _UpperBound):
+            inclusion_key = 2 if version_like.inclusive else 1
+            return self.sort_key(package_name, version_like.version), inclusion_key
+        elif isinstance(version_like, Version):
+            # finally, the bit that we actually use the sort_key_implementation for.
+            return FallbackComparable(
+                self.sort_key_implementation(package_name, version_like), version_like)
+        else:
+            raise TypeError(version_like)
+
+    def sort_key_implementation(self, package_name, version):
+        """Returns a sort key usable for sorting these packages within the
+        same family
+        Args:
+            package_name: (str) The family name of the package we are sorting
+            version: (Version) the version object you wish to generate a key for
+
+        Returns:
+            Comparable object
+        """
         raise NotImplementedError
 
     def to_pod(self):
+        raise NotImplementedError
+
+    @classmethod
+    def from_pod(cls, data):
         raise NotImplementedError
 
     @property
@@ -53,7 +167,7 @@ class PackageOrder(object):
         raise NotImplementedError
 
     def __eq__(self, other):
-        raise NotImplementedError
+        return type(self) == type(other) and str(self) == str(other)
 
     def __ne__(self, other):
         return not self == other
@@ -71,8 +185,10 @@ class NullPackageOrder(PackageOrder):
     """
     name = "no_order"
 
-    def reorder(self, iterable, key=None):
-        return list(iterable)
+    def sort_key_implementation(self, package_name, version):
+        # python's sort will preserve the order of items that compare equal, so
+        # to not change anything, we just return the same object for all...
+        return 0
 
     def __str__(self):
         return "{}"
@@ -87,12 +203,15 @@ class NullPackageOrder(PackageOrder):
         .. code-block:: yaml
 
            type: no_order
+           packages: ["foo"]
         """
-        return {}
+        return {
+            "packages": self.packages,
+        }
 
     @classmethod
     def from_pod(cls, data):
-        return cls()
+        return cls(packages=data.get("packages"))
 
 
 class SortedOrder(PackageOrder):
@@ -100,13 +219,22 @@ class SortedOrder(PackageOrder):
     """
     name = "sorted"
 
-    def __init__(self, descending):
+    def __init__(self, descending, packages=None):
+        super().__init__(packages)
         self.descending = descending
 
-    def reorder(self, iterable, key=None):
-        key = key or (lambda x: x)
-        return sorted(iterable, key=lambda x: key(x).version,
-                      reverse=self.descending)
+    def sort_key_implementation(self, package_name, version):
+        # Note that the name "descending" can be slightly confusing - it
+        # indicates that the final ordering this Order gives should be
+        # version descending (ie, the default) - however, the sort_key itself
+        # returns its results in "normal" ascending order (because it needs to
+        # be used "alongside" normally-sorted objects like versions).
+        # when the key is passed to sort(), though, it is always invoked with
+        # reverse=True...
+        if self.descending:
+            return version
+        else:
+            return _ReversedComparable(version)
 
     def __str__(self):
         return str(self.descending)
@@ -125,12 +253,19 @@ class SortedOrder(PackageOrder):
 
            type: sorted
            descending: true
+           packages: ["foo"]
         """
-        return {"descending": self.descending}
+        return {
+            "descending": self.descending,
+            "packages": self.packages,
+        }
 
     @classmethod
     def from_pod(cls, data):
-        return cls(descending=data["descending"])
+        return cls(
+            descending=data["descending"],
+            packages=data.get("packages"),
+        )
 
 
 class PerFamilyOrder(PackageOrder):
@@ -147,25 +282,35 @@ class PerFamilyOrder(PackageOrder):
             default_order (PackageOrder): Orderer to apply to any packages
                 not specified in ``order_dict``.
         """
+        super().__init__(list(order_dict))
         self.order_dict = order_dict.copy()
         self.default_order = default_order
 
     def reorder(self, iterable, key=None):
-        try:
-            item = next(iter(iterable))
-        except:
+        package_name = self._get_package_name_from_iterable(iterable, key)
+        if package_name is None:
             return None
 
-        key = key or (lambda x: x)
-        package = key(item)
-
-        orderer = self.order_dict.get(package.name)
+        orderer = self.order_dict.get(package_name)
         if orderer is None:
             orderer = self.default_order
         if orderer is None:
             return None
 
         return orderer.reorder(iterable, key)
+
+    def sort_key_implementation(self, package_name, version):
+        orderer = self.order_dict.get(package_name)
+        if orderer is None:
+            if self.default_order is not None:
+                orderer = self.default_order
+            else:
+                # shouldn't get here, because applies_to should protect us...
+                raise RuntimeError(
+                    "package family orderer %r does not apply to package family %r",
+                    (self, package_name))
+
+        return orderer.sort_key_implementation(package_name, version)
 
     def __str__(self):
         items = sorted((x[0], str(x[1])) for x in self.order_dict.items())
@@ -247,35 +392,18 @@ class VersionSplitPackageOrder(PackageOrder):
     """
     name = "version_split"
 
-    def __init__(self, first_version):
+    def __init__(self, first_version, packages=None):
         """Create a reorderer.
 
         Args:
             first_version (Version): Start with versions <= this value.
         """
+        super().__init__(packages)
         self.first_version = first_version
 
-    def reorder(self, iterable, key=None):
-        key = key or (lambda x: x)
-
-        # sort by version descending
-        descending = sorted(iterable, key=lambda x: key(x).version, reverse=True)
-
-        above = []
-        below = []
-        is_above = True
-
-        for item in descending:
-            if is_above:
-                package = key(item)
-                is_above = (package.version > self.first_version)
-
-            if is_above:
-                above.append(item)
-            else:
-                below.append(item)
-
-        return below + above
+    def sort_key_implementation(self, package_name, version):
+        priority_key = 1 if version <= self.first_version else 0
+        return priority_key, version
 
     def __str__(self):
         return str(self.first_version)
@@ -294,12 +422,19 @@ class VersionSplitPackageOrder(PackageOrder):
 
            type: version_split
            first_version: "3.0.0"
+           packages: ["foo"]
         """
-        return dict(first_version=str(self.first_version))
+        return dict(
+            first_version=str(self.first_version),
+            packages=self.packages,
+        )
 
     @classmethod
     def from_pod(cls, data):
-        return cls(Version(data["first_version"]))
+        return cls(
+            first_version=Version(data["first_version"]),
+            packages=data.get("packages"),
+        )
 
 
 class TimestampPackageOrder(PackageOrder):
@@ -345,7 +480,7 @@ class TimestampPackageOrder(PackageOrder):
     """
     name = "soft_timestamp"
 
-    def __init__(self, timestamp, rank=0):
+    def __init__(self, timestamp, rank=0, packages=None):
         """Create a reorderer.
 
         Args:
@@ -354,73 +489,84 @@ class TimestampPackageOrder(PackageOrder):
             rank (int): If non-zero, allow version changes at this rank or above
                 past the timestamp.
         """
+        super().__init__(packages)
         self.timestamp = timestamp
         self.rank = rank
 
-    def reorder(self, iterable, key=None):
+        # dictionary mapping from package family to the first-version-after
+        # the given timestamp
+        self._cached_first_after = {}
+        self._cached_sort_key = {}
+
+    def _get_first_after(self, package_family):
+        """Get the first package version that is after the timestamp"""
+        first_after = self._cached_first_after.get(package_family, KeyError)
+        if first_after is KeyError:
+            first_after = self._calc_first_after(package_family)
+            self._cached_first_after[package_family] = first_after
+        return first_after
+
+    def _calc_first_after(self, package_family):
+        from rez.packages import iter_packages
+        descending = sorted(iter_packages(package_family),
+                            key=lambda p: p.version,
+                            reverse=True)
         first_after = None
-        key = key or (lambda x: x)
-
-        # sort by version descending
-        descending = sorted(iterable, key=lambda x: key(x).version, reverse=True)
-
-        for i, o in enumerate(descending):
-            package = key(o)
-            if package.timestamp:
-                if package.timestamp > self.timestamp:
-                    first_after = i
-                else:
-                    break
-
-        if first_after is None:  # all packages are before T
-            return None
-
-        before = descending[first_after + 1:]
-        after = list(reversed(descending[:first_after + 1]))
-
-        if not self.rank:  # simple case
-            return before + after
-
-        # include packages after timestamp but within rank
-        if before and after:
-            package = key(before[0])
-            first_prerank = package.version.trim(self.rank - 1)
-            found = False
-
-            for i, o in enumerate(after):
-                package = key(o)
-                prerank = package.version.trim(self.rank - 1)
-                if prerank != first_prerank:
-                    found = True
-                    break
-
-            if not found:
-                # highest version is also within rank, so result is just
-                # simple descending list
-                return descending
-
-            if i:
-                before = list(reversed(after[:i])) + before
-                after = after[i:]
-
-        # ascend below rank, but descend within
-        after_ = []
-        postrank = []
-        prerank = None
-
-        for o in after:
-            package = key(o)
-            prerank_ = package.version.trim(self.rank - 1)
-
-            if prerank_ == prerank:
-                postrank.append(o)
+        for i, package in enumerate(descending):
+            if not package.timestamp:
+                continue
+            if package.timestamp > self.timestamp:
+                first_after = package.version
             else:
-                after_.extend(reversed(postrank))
-                postrank = [o]
-                prerank = prerank_
+                break
 
-        after_.extend(reversed(postrank))
-        return before + after_
+        if not self.rank:
+            return first_after
+
+        # if we have rank, then we need to then go back UP the
+        # versions, until we find one whose trimmed version doesn't
+        # match.
+        # Note that we COULD do this by simply iterating through
+        # an ascending sequence, in which case we wouldn't have to
+        # "switch direction" after finding the first result after
+        # by timestamp... but we're making the assumption that the
+        # timestamp break will be closer to the higher end of the
+        # version, and that we'll therefore have to check fewer
+        # timestamps this way...
+        trimmed_version = package.version.trim(self.rank - 1)
+        first_after = None
+        for after_package in reversed(descending[:i]):
+            if after_package.version.trim(self.rank - 1) != trimmed_version:
+                return after_package.version
+
+        return first_after
+
+    def _calc_sort_key(self, package_name, version):
+        first_after = self._get_first_after(package_name)
+        if first_after is None:
+            # all packages are before T
+            is_before = True
+        else:
+            is_before = int(version < first_after)
+
+        if is_before:
+            return is_before, version
+
+        if self.rank:
+            return (is_before,
+                    _ReversedComparable(version.trim(self.rank - 1)),
+                    version.tokens[self.rank - 1:])
+
+        return is_before, _ReversedComparable(version)
+
+    def sort_key_implementation(self, package_name, version):
+        cache_key = (package_name, str(version))
+        result = self._cached_sort_key.get(cache_key)
+        if result is None:
+            result = self._calc_sort_key(package_name, version)
+            self._cached_sort_key[cache_key] = result
+
+        return result
 
     def __str__(self):
         return str((self.timestamp, self.rank))
@@ -441,23 +587,34 @@ class TimestampPackageOrder(PackageOrder):
            type: soft_timestamp
            timestamp: 1234567
            rank: 3
+           packages: ["foo"]
         """
-        return dict(timestamp=self.timestamp,
-                    rank=self.rank)
+        return dict(
+            timestamp=self.timestamp,
+            rank=self.rank,
+            packages=self.packages,
+        )
 
     @classmethod
     def from_pod(cls, data):
-        return cls(timestamp=data["timestamp"], rank=data.get("rank", 0))
+        return cls(
+            timestamp=data["timestamp"],
+            rank=data.get("rank", 0),
+            packages=data.get("packages"),
+        )
 
 
 class PackageOrderList(list):
     """A list of package orderer.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.by_package: Dict[str, PackageOrder] = {}
+        self.dirty = True
+
     def to_pod(self):
-        data = []
-        for f in self:
-            data.append(to_pod(f))
-        return data
+        return [to_pod(f) for f in self]
 
     @classmethod
     def from_pod(cls, data):
@@ -471,6 +628,58 @@ class PackageOrderList(list):
     def singleton(cls):
         """Filter list as configured by rezconfig.package_filter."""
         return cls.from_pod(config.package_orderers)
+
+    @staticmethod
+    def _to_orderer(orderer: Union[dict, PackageOrder]) -> PackageOrder:
+        if not isinstance(orderer, PackageOrder):
+            orderer = from_pod(orderer)
+        return orderer
+
+    def refresh(self) -> None:
+        """Update the internal order-by-package mapping"""
+        self.by_package = {}
+        for orderer in self:
+            orderer = self._to_orderer(orderer)
+            for package in orderer.packages:
+                # We allow duplicates (so we can have hierarchical configs,
+                # which can override each other) - earlier orderers win
+                if package in self.by_package:
+                    continue
+                self.by_package[package] = orderer
+
+    def append(self, *args, **kwargs):
+        self.dirty = True
+        return super().append(*args, **kwargs)
+
+    def extend(self, *args, **kwargs):
+        self.dirty = True
+        return super().extend(*args, **kwargs)
+
+    def pop(self, *args, **kwargs):
+        self.dirty = True
+        return super().pop(*args, **kwargs)
+
+    def remove(self, *args, **kwargs):
+        self.dirty = True
+        return super().remove(*args, **kwargs)
+
+    def clear(self, *args, **kwargs):
+        self.dirty = True
+        return super().clear(*args, **kwargs)
+
+    def insert(self, *args, **kwargs):
+        self.dirty = True
+        return super().insert(*args, **kwargs)
+
+    def get(self, key: str, default: Optional[PackageOrder] = None) -> PackageOrder:
+        """
+        Get an orderer that sorts a package by name.
+        """
+        if self.dirty:
+            self.refresh()
+            self.dirty = False
+        result = self.by_package.get(key, default)
+        return result
 
 
 def to_pod(orderer):
@@ -492,6 +701,18 @@ def from_pod(data):
         cls_name, data_ = data
         cls = _orderers[cls_name]
         return cls.from_pod(data_)
+
+
+def get_orderer(package_name, orderers=None):
+    if orderers is None:
+        orderers = PackageOrderList.singleton
+    orderer = orderers.get(package_name)
+    if orderer is None:
+        orderer = orderers.get(ALL_PACKAGES)
+    if orderer is None:
+        # default ordering is version descending
+        orderer = SortedOrder(descending=True)
+    return orderer
 
 
 def register_orderer(cls):

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -306,7 +306,6 @@ class PerFamilyOrder(PackageOrder):
     def sort_key_implementation(self, package_name, version):
         orderer = self.order_dict.get(package_name)
         if orderer is None:
-            
             if self.default_order is None:
                 # shouldn't get here, because applies_to should protect us...
                 raise RuntimeError(

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -437,7 +437,7 @@ class VersionSplitPackageOrder(PackageOrder):
     @classmethod
     def from_pod(cls, data):
         return cls(
-            first_version=Version(data["first_version"]),
+            Version(data["first_version"]),
             packages=data.get("packages"),
         )
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -267,7 +267,7 @@ class SortedOrder(PackageOrder):
     @classmethod
     def from_pod(cls, data):
         return cls(
-            descending=data["descending"],
+            data["descending"],
             packages=data.get("packages"),
         )
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -10,7 +10,7 @@ from rez.config import config
 from rez.utils.data_utils import cached_class_property
 from rez.version import Version, VersionRange
 from rez.version._version import _Comparable, _ReversedComparable, _LowerBound, _UpperBound, _Bound
-
+from rez.packages import iter_packages
 
 ALL_PACKAGES = "*"
 
@@ -120,7 +120,9 @@ class PackageOrder(object):
                 the version-like object you wish to generate a key for
 
         Returns:
-            Comparable object
+            Sortable object
+                The returned object must be sortable, which means that it must implement __lt__.
+                The specific return type is not important.
         """
         if isinstance(version_like, VersionRange):
             return tuple(self.sort_key(package_name, bound) for bound in version_like.bounds)
@@ -500,14 +502,14 @@ class TimestampPackageOrder(PackageOrder):
 
     def _get_first_after(self, package_family):
         """Get the first package version that is after the timestamp"""
-        first_after = self._cached_first_after.get(package_family, KeyError)
-        if first_after is KeyError:
+        try:
+            first_after = self._cached_first_after[package_family]
+        except KeyError:
             first_after = self._calc_first_after(package_family)
             self._cached_first_after[package_family] = first_after
         return first_after
 
     def _calc_first_after(self, package_family):
-        from rez.packages import iter_packages
         descending = sorted(iter_packages(package_family),
                             key=lambda p: p.version,
                             reverse=True)

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -233,7 +233,7 @@ class ResolvedContext(object):
         self.package_filter = (PackageFilterList.singleton if package_filter is None
                                else package_filter)
 
-        self.package_orderers = (
+        self.package_orderers = PackageOrderList(
             PackageOrderList.singleton if package_orderers is None
             else package_orderers
         )
@@ -1527,9 +1527,10 @@ class ResolvedContext(object):
             data["patch_locks"] = dict((k, v.name) for k, v in self.patch_locks)
 
         if _add("package_orderers"):
-            package_orderers = [package_order.to_pod(x)
-                                for x in (self.package_orderers or [])]
-            data["package_orderers"] = package_orderers or None
+            if self.package_orderers:
+                data["package_orderers"] = self.package_orderers.to_pod()
+            else:
+                data["package_orderers"] = None
 
         if _add("package_filter"):
             data["package_filter"] = self.package_filter.to_pod()

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -454,8 +454,8 @@ package_filter = None
 #
 #
 # Package orderers will also apply to variants of packages.
-# Consider a package called `pipeline-1.0` which has the following variants:
-# [["python-2.7.4", "python-2.7.16", "python-3.7.4"]]
+# Consider a package "pipeline-1.0" which has the following variants:
+# ``[["python-2.7.4", "python-2.7.16", "python-3.7.4"]]``
 #
 # ============================= ==========================
 # Example                       Result

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -423,7 +423,7 @@ package_filter = None
 # One or more "orderers" can be listed.
 # This will affect the order of version resolution.
 # This can be used to ensure that specific version have priority over others.
-# Higher versions can still be accessed if required.
+# Higher versions can still be accessed if explicitly requested.
 #
 # A common use case is to ease migration from python-2 to python-3:
 #
@@ -451,6 +451,19 @@ package_filter = None
 # rez-env python       python-2.7.16
 # rez-env python-3     python-3.7.4
 # ==================== =============
+#
+#
+# Package orderers will also apply to variants of packages.
+# Consider a package called `pipeline-1.0` which has the following variants:
+# [["python-2.7.4", "python-2.7.16", "python-3.7.4"]]
+#
+# ============================= ==========================
+# Example                       Result
+# ============================= ==========================
+# rez-env pipeline              pipeline-1.0 python-2.7.16
+# rez-env pipeline python-3     pipeline-1.0 python-3.7.4
+# ============================= ==========================
+#
 #
 # Here's another example, using another orderer: "soft_timestamp".
 # This orderer will prefer packages released before a provided timestamp.

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -428,7 +428,7 @@ class _PackageEntry(object):
                 if not request.conflict:
                     req = variant.requires_list.get(request.name)
                     if req is not None:
-                        orderer = get_orderer(req.name, self.solver.package_orderers or {})
+                        orderer = get_orderer(req.name, orderers=self.solver.package_orderers or {})
                         range_key = orderer.sort_key(req.name, req.range)
                         requested_key.append((-i, range_key))
                         names.add(req.name)
@@ -436,7 +436,7 @@ class _PackageEntry(object):
             additional_key = []
             for request in variant.requires_list:
                 if not request.conflict and request.name not in names:
-                    orderer = get_orderer(request.name, self.solver.package_orderers)
+                    orderer = get_orderer(request.name, orderers=self.solver.package_orderers)
                     range_key = orderer.sort_key(request.name, request.range)
                     additional_key.append((range_key, request.name))
 
@@ -843,7 +843,7 @@ class _PackageVariantSlice(_Common):
         if self.sorted:
             return
 
-        orderer = get_orderer(self.package_name, self.solver.package_orderers or {})
+        orderer = get_orderer(self.package_name, orderers=self.solver.package_orderers or {})
 
         def sort_key(entry):
             return orderer.sort_key(entry.package.name, entry.version)

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -415,6 +415,8 @@ class _PackageEntry(object):
             here as a safety measure so that sorting is guaranteed repeatable
             regardless.
         """
+        from rez.package_order import get_orderer
+
         if self.sorted:
             return
 
@@ -426,13 +428,17 @@ class _PackageEntry(object):
                 if not request.conflict:
                     req = variant.requires_list.get(request.name)
                     if req is not None:
-                        requested_key.append((-i, req.range))
+                        orderer = get_orderer(req.name, self.solver.package_orderers or {})
+                        range_key = orderer.sort_key(req.name, req.range)
+                        requested_key.append((-i, range_key))
                         names.add(req.name)
 
             additional_key = []
             for request in variant.requires_list:
                 if not request.conflict and request.name not in names:
-                    additional_key.append((request.range, request.name))
+                    orderer = get_orderer(request.name, self.solver.package_orderers)
+                    range_key = orderer.sort_key(request.name, request.range)
+                    additional_key.append((range_key, request.name))
 
             if (VariantSelectMode[config.variant_select_mode] == VariantSelectMode.version_priority):
                 k = (requested_key,
@@ -802,6 +808,7 @@ class _PackageVariantSlice(_Common):
 
         if not fams:
             # trivial case, split on first variant
+            self.entries[0].sort()
             return _split(0, 1)
 
         # find split point - first variant with no dependency shared with previous
@@ -831,25 +838,21 @@ class _PackageVariantSlice(_Common):
         The order is typically descending, but package order functions can
         change this.
         """
+        from rez.package_order import get_orderer
+
         if self.sorted:
             return
 
-        for orderer in (self.solver.package_orderers or []):
-            entries = orderer.reorder(self.entries, key=lambda x: x.package)
-            if entries is not None:
-                self.entries = entries
-                self.sorted = True
+        orderer = get_orderer(self.package_name, self.solver.package_orderers or {})
 
-                if self.pr:
-                    self.pr("sorted: %s packages: %s", self.package_name, repr(orderer))
-                return
+        def sort_key(entry):
+            return orderer.sort_key(entry.package.name, entry.version)
 
-        # default ordering is version descending
-        self.entries = sorted(self.entries, key=lambda x: x.version, reverse=True)
+        self.entries = sorted(self.entries, key=sort_key, reverse=True)
         self.sorted = True
 
         if self.pr:
-            self.pr("sorted: %s packages: version descending", self.package_name)
+            self.pr("sorted: %s packages: %s", self.package_name, repr(orderer))
 
     def dump(self):
         print(self.package_name)

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -215,7 +215,7 @@ class TestContext(TestBase, TempdirMixin):
 
     def test_orderer_package_argument(self):
         """Test that the packages argument to an orderer gives expected results."""
-        from rez.package_order import PackageOrderList, PerFamilyOrder, VersionSplitPackageOrder
+        from rez.package_order import VersionSplitPackageOrder
         from rez.version import Version
 
         packages_path = self.data_path("solver", "packages")

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -186,6 +186,70 @@ class TestContext(TestBase, TempdirMixin):
 
             _test_bundle(bundle_path3)
 
+    def test_orderer_variants(self):
+        """Test that package orderers apply to the variants of packages, not just requires."""
+        from rez.package_order import PerFamilyOrder, VersionSplitPackageOrder
+        from rez.version import Version
+
+        packages_path = self.data_path("solver", "packages")
+
+        # Verify that we get the latest python without an orderer
+        r = ResolvedContext(
+            ["pyvariants", "!nada"],
+            package_paths=[packages_path],
+        )
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ['python-2.7.0', 'pyvariants-2'])
+
+        # Now verify that we correctly get python-2.6.8 when the orderer demands it.
+        orderers = [PerFamilyOrder({
+            "python": VersionSplitPackageOrder(Version("2.6.8")),
+        })]
+        r = ResolvedContext(
+            ["pyvariants", "!nada"],
+            package_orderers=orderers,
+            package_paths=[packages_path],
+        )
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ['python-2.6.8', 'pyvariants-2'])
+
+    def test_orderer_package_argument(self):
+        """Test that the packages argument to an orderer gives expected results."""
+        from rez.package_order import PackageOrderList, PerFamilyOrder, VersionSplitPackageOrder
+        from rez.version import Version
+
+        packages_path = self.data_path("solver", "packages")
+
+        # Verify that the orderer applies to all packages.
+        orderers = [VersionSplitPackageOrder(Version("2.6.8"))]
+        r = ResolvedContext(
+            ["python"],
+            package_orderers=orderers,
+            package_paths=[packages_path],
+        )
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ['python-2.6.8'])
+
+        # Verify that the orderer applies to a specified package.
+        orderers = [VersionSplitPackageOrder(Version("2.6.8"), packages="python")]
+        r = ResolvedContext(
+            ["python"],
+            package_orderers=orderers,
+            package_paths=[packages_path],
+        )
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ['python-2.6.8'])
+
+        # Verify that the orderer does not apply to a packages that are not requested.
+        orderers = [VersionSplitPackageOrder(Version("2.6.8"), packages="pyfoo")]
+        r = ResolvedContext(
+            ["python"],
+            package_orderers=orderers,
+            package_paths=[packages_path],
+        )
+        resolved = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolved, ['python-2.7.0'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -53,11 +53,6 @@ class _BaseTestPackagesOrder(TestBase, TempdirMixin):
 class TestAbstractPackageOrder(TestBase):
     """Test case for the abstract PackageOrder class"""
 
-    def test_reorder(self):
-        """Validate reorder is not implemented"""
-        with self.assertRaises(NotImplementedError):
-            PackageOrder().reorder([])
-
     def test_to_pod(self):
         """Validate to_pod is not implemented"""
         self.assertRaises(NotImplementedError, PackageOrder().to_pod)

--- a/src/rez/version/_version.py
+++ b/src/rez/version/_version.py
@@ -44,7 +44,7 @@ class _ReversedComparable(_Common):
         return not self < other
 
     def __str__(self):
-        return "reverse(%r)" % self.value
+        return f"reverse({self.value!r})"
 
     def __repr__(self):
         return "reverse(%r)" % self.value

--- a/src/rez/version/_version.py
+++ b/src/rez/version/_version.py
@@ -28,8 +28,11 @@ class _ReversedComparable(_Common):
     def __init__(self, value):
         self.value = value
 
+    def __eq__(self, other):
+        return self.value == other.value
+
     def __lt__(self, other):
-        return not (self.value < other.value)
+        return self.value > other.value
 
     def __gt__(self, other):
         return not (self < other or self == other)
@@ -41,7 +44,7 @@ class _ReversedComparable(_Common):
         return not self < other
 
     def __str__(self):
-        return "reverse(%s)" % str(self.value)
+        return "reverse(%r)" % self.value
 
     def __repr__(self):
         return "reverse(%r)" % self.value


### PR DESCRIPTION
Fixes #369
Fixes #1683

This PR fixes this bug so that package orderers are applied to all packages and variants uniformly in all circumstances, for more expected results.

Carries on the work originally started by @pmolodo with #355 and #413.

Here is an example of how one might take advantage of package ordering applying to variants:
Consider a package `python` which has versions `['2.6.4', '2.7.16', '3.7.9', '3.9.6', '3.10.8']`
The default sorted package orderer would give us this sorted list:
`['3.10.8', '3.9.6',  '3.7.9', '2.7.16', '2.6.4']`
And we end up choosing the first possible option in the resolve: `3.10.8`

If we apply the following package order:
```python
package_orderers = [
    {
       "type": "per_family",
       "orderers": [
            {
                "packages": ["python"],
                "type": "version_split",
                "first_version": "2.7.16"
            }
        ]
    }
]
```
Then we would get packages ordered like this: `['2.7.16', '2.6.4', '3.10.8', '3.9.6',  '3.7.9']`, where we start at the version_split first version.
Which in turn would resolve to `2.7.16`.  So far so good.  This is the current behavior.

Now consider a package `pipeline` which has variants:
```python
[
    ["python-2.6.4"],
    ["python-2.7.16"],
    ["python-3.7.9"],
    ["python-3.9.6"],
]
```
If you do `rez env pipeline` we would get `python-3.9.6` in the resolve, **even if we have a package orderer specifically saying we want to prefer python 2.7.16**.  In order to get the correctly requested version of python, we must include it in the resolve: `rez env pipeline python-2.7.16`, which largely defeats the purpose of the package orderer, since the point of it is to inform the choices of packages for second order package requests.

@JeanChristopheMorinPerso and I have discussed the possible speed implications.  There should be neglible differences, even for very large repositories.

Variants were already being sorted, but this change just changes them to be sorted according to a sort key, in a uniform way to  first order requests, instead of simply by version.  The sort key for more complicated package orderers are cached anyway, so it really should be very quick.

Since this will change the way packages are resolved, there is a small danger of people no longer getting the same resolve they used to.  However, it is the belief of @JeanChristopheMorinPerso, @maxnbk, and I that anyone who is using package ordering would have expected this to be the correct result anyway, and the number of people using package orderers is small enough.