### PR TITLE
Add releasing packages documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 # Build instructions
 
-To build the docs you must use Python 3.11.
+To build the docs you must install the following requirements:
+
+- GNU Make
+- Python 3.11
 
 To create a build environment run the following commands:
 ```python

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 To build the docs you must install the following requirements:
 
-- GNU Make
+- GNU Make (Linux + Mac only)
 - Python 3.11
 
 To create a build environment run the following commands:
@@ -12,7 +12,7 @@ source .venv/bin/activate
 pip install -r docs/requirements.txt
 
 cd docs
-make html
+make html # .\make html on Windows
 ```
 
 # Example Headers

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Welcome to rez's documentation!
    getting_started
    basic_concepts
    building_packages
+   releasing_packages
    context
    variants
    guides/index
@@ -28,7 +29,6 @@ Welcome to rez's documentation!
    context_bundles
    suites
    managing_packages
-   releasing_packages
    caching
    pip
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Welcome to rez's documentation!
    context_bundles
    suites
    managing_packages
+   releasing_packages
    caching
    pip
 

--- a/docs/source/releasing_packages.rst
+++ b/docs/source/releasing_packages.rst
@@ -7,12 +7,12 @@ using the :ref:`rez-release` tool. This tool performs the following actions:
 
 * All :doc:`actions <building_packages>` that the ``rez-build`` tool performs.
 * Executes all configured :data:`release_hooks`.
-* Executes all configured `release_vcs`.
+* Executes all configured :gh-rez:`src/rezplugins/release_vcs` plugins.
 
 When to release vs build
 ============================
 Packages *can* be installed to the :data:`release_packages_path` manually
-by running ``rez-build <release_packages_path>``, so why would you use
+by running :option:`rez-build -i --prefix /path/to/repo <rez-build --prefix>`, so why would you use
 ``rez-release``?
 
 Well, here are a few benefits of ``rez-release``:
@@ -21,7 +21,7 @@ Well, here are a few benefits of ``rez-release``:
 * Tests being run by with the :ref:`rez-test` tool can run specifically prior to release, ensuring that releases pass any configured tests first.
 * Automatic sanity checks to ensure local repo is ready for release.
 * Automatic VCS tagging.
-* Many :ref:`helpful package attributes <release-package-attributes>` added to the released `package.py` at build time.
+* Many :ref:`helpful package attributes <release-package-attributes>` are automatically added to the released package definition file.
 
 If you're working locally, it these additional steps and checks may slow you
 down, so it may be better to stick with :ref:`rez-build`.

--- a/docs/source/releasing_packages.rst
+++ b/docs/source/releasing_packages.rst
@@ -1,0 +1,13 @@
+==================
+Releasing packages
+==================
+
+Rez packages can be built and deployed to the :data:`release_packages_path`
+using the :ref:`rez-release` tool. This tool performs the following actions:
+
+* All :doc:`actions <building_packages>` that the `rez-build` tool performs.
+* Executes all configured :data:`release_hooks`.
+* Executes all configured `release_vcs`.
+
+This tool generally runs the same as :ref:`rez-build` otherwise. For more
+information, see the :doc:`Building Packages <building_packages>` documentation.

--- a/docs/source/releasing_packages.rst
+++ b/docs/source/releasing_packages.rst
@@ -5,9 +5,23 @@ Releasing packages
 Rez packages can be built and deployed to the :data:`release_packages_path`
 using the :ref:`rez-release` tool. This tool performs the following actions:
 
-* All :doc:`actions <building_packages>` that the `rez-build` tool performs.
+* All :doc:`actions <building_packages>` that the ``rez-build`` tool performs.
 * Executes all configured :data:`release_hooks`.
 * Executes all configured `release_vcs`.
 
-This tool generally runs the same as :ref:`rez-build` otherwise. For more
-information, see the :doc:`Building Packages <building_packages>` documentation.
+When to release vs build
+============================
+Packages *can* be installed to the :data:`release_packages_path` manually
+by running ``rez-build <release_packages_path>``, so why would you use
+``rez-release``?
+
+Well, here are a few benefits of ``rez-release``:
+
+* The package will automatically go to the configured :data:`release_packages_path`, whereas :ref:`rez-build` will go to the :data:`local_packages_path` by default.
+* Tests being run by with the :ref:`rez-test` tool can run specifically prior to release, ensuring that releases pass any configured tests first.
+* Automatic sanity checks to ensure local repo is ready for release.
+* Automatic VCS tagging.
+* Many :ref:`helpful package attributes <release-package-attributes>` added to the released `package.py` at build time.
+
+If you're working locally, it these additional steps and checks may slow you
+down, so it may be better to stick with :ref:`rez-build`.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -824,7 +824,7 @@ build_thread_count = "physical_cores"
 # a plugin listed here is not present, a warning message is printed. Note that a
 # release hook plugin being loaded does not mean it will run. It needs to be
 # listed here as well. Several built-in release hooks are available, see
-# rezplugins/release_hook.
+# :gh-rez:`src/rezplugins/release_hook`.
 release_hooks = []
 
 # Prompt for release message using an editor. If set to False, there will be


### PR DESCRIPTION
Added a new page for releasing packages since there doesn't seem to be any for the `rez-release` workflow yet.