### PR TITLE
Added configuration option to skip invalid packages

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -435,6 +435,7 @@ config_schema = Schema({
     "package_preprocess_function":                  OptionalStrOrFunction,
     "package_preprocess_mode":                      PreprocessMode_,
     "error_on_missing_variant_requires":            Bool,
+    "skip_invalid_packages":                        Bool,
     "context_tracking_host":                        OptionalStr,
     "variant_shortlinks_dirname":                   OptionalStr,
     "build_thread_count":                           BuildThreadCount_,

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -396,7 +396,13 @@ class PackageResourceHelper(PackageResource):
         return self._convert_to_rex(self._post_commands)
 
     def iter_variants(self):
-        num_variants = len(self.variants or [])
+        try:
+            num_variants = len(self.variants or [])
+        except PackageMetadataError:
+            # Package has no package file.
+            if config.skip_invalid_packages:
+                return
+            raise
 
         if num_variants == 0:
             indexes = [None]

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -307,8 +307,14 @@ class Package(PackageBaseResourceWrapper):
         Returns:
             `Variant` iterator.
         """
-        for variant in self.repository.iter_variants(self.resource):
-            yield Variant(variant, context=self.context, parent=self)
+        try:
+            for variant in self.repository.iter_variants(self.resource):
+                yield Variant(variant, context=self.context, parent=self)
+        except ResourceError:
+            # Package has an invalid package file
+            if config.skip_invalid_packages:
+                return
+            raise
 
     def get_variant(self, index=None):
         """Get the variant with the associated index.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -313,7 +313,7 @@ implicit_packages = [
 # This is useful as Platform.os might show different
 # values depending on the availability of ``lsb-release`` on the system.
 # The map supports regular expression, e.g. to keep versions.
-# 
+#
 # .. note::
 #    The following examples are not necessarily recommendations.
 #
@@ -523,6 +523,12 @@ allow_unversioned_packages = True
 #    It expects that every user can access the same set of packages, which may cause incorrect resolves
 #    when this option is disabled.
 error_on_missing_variant_requires = True
+
+# Defines whether package files that cannot be read should cause an error.
+# This can be useful to enable if you have syntax in package files that is not readable by all
+# versions of python.  It can also be useful if a package file is missing entirely due to
+# checking out a new git branch not removing empty folders near package recipe locations.
+skip_invalid_packages = False
 
 ###############################################################################
 # Environment Resolution
@@ -1132,7 +1138,7 @@ documentation_url = "https://rez.readthedocs.io"
 
 # Enables/disables colorization globally.
 #
-# .. warning:: 
+# .. warning::
 #    Turned off for Windows currently as there seems to be a problem with the colorama module.
 #
 # May also set to the string ``force``, which will make rez output color styling


### PR DESCRIPTION
This PR adds a configuration option to continue solving if an invalid or missing package file is found within a package folder.

Missing package files can happen if the package file itself is in git and the branch is changed.  Changing branches does not remove empty directories without a clean operation.  This can cause rez to break for any resolve.

Similarly, if any package file contains syntax that is not parseable by your version of python, rez will not resolve any environment at all.  This can happen if your package files have f strings and you try to do a resolve in a python 2 environment, for example.