### PR TITLE
Add symlink locking for filesystems that do not support hardlinks

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -467,7 +467,7 @@ class FileSystemPackageRepository(PackageRepository):
     """
     schema_dict = {"file_lock_timeout": int,
                    "file_lock_dir": Or(None, str),
-                   "file_lock_type": Or("default", "link", "mkdir"),
+                   "file_lock_type": Or("default", "link", "mkdir", "symlink"),
                    "package_filenames": [str]}
 
     building_prefix = ".building"
@@ -973,6 +973,8 @@ class FileSystemPackageRepository(PackageRepository):
             from rez.vendor.lockfile.mkdirlockfile import MkdirLockFile as LockFile
         elif _settings.file_lock_type == 'link':
             from rez.vendor.lockfile.linklockfile import LinkLockFile as LockFile
+        elif _settings.file_lock_type == 'symlink':
+            from rez.vendor.lockfile.symlinklockfile import SymlinkLockFile as LockFile
 
         path = self.location
 

--- a/src/rezplugins/package_repository/rezconfig.py
+++ b/src/rezplugins/package_repository/rezconfig.py
@@ -4,7 +4,7 @@
 
 filesystem = {
     # The mechanism used to create the lockfile. If set to 'default', this will
-    # use hardlinks if the 'os.link' method is present, otherwise mkdir is used.
+    # use hardlinks (link) if the 'os.link' method is present, otherwise mkdir is used.
     # It can also be explicitly set to use only 'link', 'symlink', or only 'mkdir'.
     # Valid options are 'default', 'mkdir', 'link', or 'symlink'
     "file_lock_type": "default",

--- a/src/rezplugins/package_repository/rezconfig.py
+++ b/src/rezplugins/package_repository/rezconfig.py
@@ -5,8 +5,8 @@
 filesystem = {
     # The mechanism used to create the lockfile. If set to 'default', this will
     # use hardlinks if the 'os.link' method is present, otherwise mkdir is used.
-    # It can also be explicitly set to use only 'hardlink', or only 'mkdir'.
-    # Valid options are 'default', 'mkdir', or 'hardlink'
+    # It can also be explicitly set to use only 'link', 'symlink', or only 'mkdir'.
+    # Valid options are 'default', 'mkdir', 'link', or 'symlink'
     "file_lock_type": "default",
 
     # The timeout to use when creating file locks. This is done when a variant is

--- a/src/rezplugins/package_repository/rezconfig.py
+++ b/src/rezplugins/package_repository/rezconfig.py
@@ -5,7 +5,6 @@
 filesystem = {
     # The mechanism used to create the lockfile. If set to 'default', this will
     # use hardlinks (link) if the 'os.link' method is present, otherwise mkdir is used.
-    # It can also be explicitly set to use only 'link', 'symlink', or only 'mkdir'.
     # Valid options are 'default', 'mkdir', 'link', or 'symlink'
     "file_lock_type": "default",
 


### PR DESCRIPTION
In our environment we are using a StorNext file server over Samba on our Mac OSX machines.  Mounting over Samba does not allow creating hardlinks.  The work done in https://github.com/AcademySoftwareFoundation/rez/pull/903 adds the ability to explicitly use mkdir instead of hardlinks.  mkdir may not be an atomic operation on non-local filesystems.

See https://www.mail-archive.com/freebsd-hackers@freebsd.org/msg20456.html