### PR TITLE
Handle race condition caused by AppleDouble files when removing a directory tree

### DIFF
--- a/install.py
+++ b/install.py
@@ -29,6 +29,7 @@ sys.path.insert(0, src_path)
 # though rez is not yet built.
 #
 from rez.utils._version import _rez_version  # noqa: E402
+from rez.utils.filesystem import safe_rmtree
 from rez.utils.which import which  # noqa: E402
 from rez.cli._entry_points import get_specifications  # noqa: E402
 from rez.vendor.distlib.scripts import ScriptMaker  # noqa: E402
@@ -106,7 +107,7 @@ def patch_rez_binaries(dest_dir):
     # we don't want resolved envs accidentally getting the virtualenv's 'python'.
     dest_bin_path = os.path.join(virtualenv_bin_path, "rez")
     if os.path.exists(dest_bin_path):
-        shutil.rmtree(dest_bin_path)
+        safe_rmtree(dest_bin_path)
     os.makedirs(dest_bin_path)
 
     maker = ScriptMaker(
@@ -140,7 +141,7 @@ def copy_completion_scripts(dest_dir):
     if completion_path:
         dest_path = os.path.join(dest_dir, "completion")
         if os.path.exists(dest_path):
-            shutil.rmtree(dest_path)
+            safe_rmtree(dest_path)
         shutil.copytree(completion_path, dest_path)
         return dest_path
 
@@ -263,7 +264,7 @@ def install_as_rez_package(repo_path):
     finally:
         # cleanup temp install
         try:
-            shutil.rmtree(tmpdir)
+            safe_rmtree(tmpdir)
         except:
             pass
 

--- a/src/rez/bind/hello_world.py
+++ b/src/rez/bind/hello_world.py
@@ -13,10 +13,10 @@ from rez.package_maker import make_package
 from rez.version import Version
 from rez.utils.lint_helper import env
 from rez.utils.execution import create_executable_script, ExecutableScriptMode
+from rez.utils.filesystem import safe_rmtree
 from rez.vendor.distlib.scripts import ScriptMaker
 from rez.bind._utils import make_dirs, check_version
 import os.path
-import shutil
 
 
 def commands() -> None:
@@ -60,14 +60,14 @@ def bind(path, version_range=None, opts=None, parser=None):
             py_script_mode=ExecutableScriptMode.single,
         )
 
-        # We want to use ScriptMaker on all platofrms. This allows us to
+        # We want to use ScriptMaker on all platforms. This allows us to
         # correctly setup the script to work everywhere, even on Windows.
         # create_executable_script should be fixed to use ScriptMaker
         # instead.
         maker = ScriptMaker(binpathtmp, make_dirs(binpath))
         maker.make("hello_world")
         maker.make("hello_world_gui")
-        shutil.rmtree(binpathtmp)
+        safe_rmtree(binpathtmp)
 
     with make_package("hello_world", path, make_root=make_root) as pkg:
         pkg.version = version

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -11,7 +11,7 @@ import os
 import sys
 import inspect
 import argparse
-import shutil
+from rez.utils.filesystem import safe_rmtree
 from pkgutil import iter_modules
 
 try:
@@ -104,7 +104,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
         else:
             run_unittest(module_tests, opts.tests, opts.verbose)
     finally:
-        shutil.rmtree(repo)
+        safe_rmtree(repo)
 
 
 def run_unittest(module_tests, tests, verbosity) -> None:

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -11,6 +11,7 @@ from rez.vendor.packaging.version import Version as PackagingVersion
 from rez.vendor.packaging.specifiers import Specifier
 from rez.resolved_context import ResolvedContext
 from rez.utils.execution import Popen
+from rez.utils.filesystem import safe_rmtree
 from rez.utils.pip import get_rez_requirements, pip_to_rez_package_name, \
     pip_to_rez_version
 from rez.utils.logging_ import print_debug, print_info, print_error, \
@@ -462,7 +463,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
         log_append_pkg_variants(pkg)
 
     # cleanup
-    shutil.rmtree(targetpath)
+    safe_rmtree(targetpath)
 
     # print summary
     #

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -8,6 +8,7 @@ from rez.utils.execution import create_forwarding_script
 from rez.exceptions import SuiteError, ResolvedContextError
 from rez.resolved_context import ResolvedContext
 from rez.utils.data_utils import cached_property
+from rez.utils.filesystem import safe_rmtree
 from rez.utils.formatting import columnise, PackageRequest
 from rez.utils.colorize import warning, critical, Printer, alias as alias_col
 from rez.vendor import yaml
@@ -17,7 +18,6 @@ from collections import defaultdict
 from typing import cast, TYPE_CHECKING, Any, NoReturn, TypedDict
 import os
 import os.path
-import shutil
 import sys
 
 if TYPE_CHECKING:
@@ -465,7 +465,7 @@ class Suite(object):
                     print("saving over previous suite...")
                 for context_name in self.context_names:
                     self.context(context_name)  # load before dir deleted
-                shutil.rmtree(path)
+                safe_rmtree(path)
             else:
                 raise SuiteError("Cannot save, path exists: %r" % path)
 

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -6,13 +6,28 @@
 unit tests for 'rez.utils.filesystem' module
 """
 import os.path
+import sys
 import tempfile
 
 from rez.tests.util import TestBase
 from rez.tests.util import TempdirMixin
 from rez.utils import filesystem
 from rez.utils.platform_ import platform_
-import unittest
+import unittest.mock
+
+
+def rmtree_file_not_found_error(path, onerror):
+    try:
+        raise FileNotFoundError("File not found", path)
+    except:
+        onerror(None, path, sys.exc_info())
+
+
+def rmtree_permission_error(path, onerror):
+    try:
+        raise PermissionError("Permission denied", path)
+    except:
+        onerror(None, path, sys.exc_info())
 
 
 class TestFileSystem(TestBase, TempdirMixin):
@@ -86,3 +101,28 @@ class TestFileSystem(TestBase, TempdirMixin):
         filesystem.rename(src, dst)
         self.assertTrue(os.path.exists(dst))
         self.assertFalse(os.path.exists(src))
+
+    def test_safe_rmtree_with_file_not_found(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
+            with self.assertRaises(FileNotFoundError):
+                filesystem.safe_rmtree("path")
+
+    def test_safe_rmtree_with_other_error(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error) as mock_rmtree:
+            with self.assertRaises(PermissionError):
+                filesystem.safe_rmtree("path")
+
+    def test_safe_rmtree_with_file_not_found_and_apple_double(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
+            if platform_.name == 'osx':
+                filesystem.safe_rmtree("._path")
+                mock_rmtree.assert_called_once_with("._path", onerror=unittest.mock.ANY)
+            else:
+                with self.assertRaises(FileNotFoundError):
+                    filesystem.safe_rmtree("._path")
+
+    def test_safe_rmtree_with_other_error_and_apple_double(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error) as mock_rmtree:
+            with self.assertRaises(PermissionError):
+                filesystem.safe_rmtree("._path")
+

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -103,12 +103,12 @@ class TestFileSystem(TestBase, TempdirMixin):
         self.assertFalse(os.path.exists(src))
 
     def test_safe_rmtree_with_file_not_found(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error):
             with self.assertRaises(FileNotFoundError):
                 filesystem.safe_rmtree("path")
 
     def test_safe_rmtree_with_other_error(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error) as mock_rmtree:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
             with self.assertRaises(PermissionError):
                 filesystem.safe_rmtree("path")
 
@@ -122,7 +122,6 @@ class TestFileSystem(TestBase, TempdirMixin):
                     filesystem.safe_rmtree("._path")
 
     def test_safe_rmtree_with_other_error_and_apple_double(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error) as mock_rmtree:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
             with self.assertRaises(PermissionError):
                 filesystem.safe_rmtree("._path")
-

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -247,7 +247,7 @@ def safe_rmtree(path) -> None:
 
     def _on_error(_func, path, exc_info):
         if not is_mac or exc_info[0] is not FileNotFoundError or not os.path.basename(path).startswith("._"):
-            raise
+            raise exc_info[1].with_traceback(exc_info[2])
 
     shutil.rmtree(path, onerror=_on_error)
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -29,6 +29,7 @@ from rez.util import which
 from rez.utils.execution import Popen
 
 is_windows = platform.system() == "Windows"
+is_mac = platform.system() == "Darwin"
 
 
 class TempDirs(object):
@@ -71,7 +72,7 @@ class TempDirs(object):
 
         for path in dirs:
             if os.path.exists(path) and not os.getenv("REZ_KEEP_TMPDIRS"):
-                shutil.rmtree(path)
+                safe_rmtree(path)
 
     @classmethod
     def clear_all(cls) -> None:
@@ -185,7 +186,7 @@ def safe_remove(path):
 
     try:
         if os.path.isdir(path) and not os.path.islink(path):
-            shutil.rmtree(path)
+            safe_rmtree(path)
         else:
             os.remove(path)
     except OSError:
@@ -202,9 +203,15 @@ def forceful_rmtree(path) -> None:
     Also handled:
         * path length over 259 char (on Windows)
         * unicode path
+        * AppleDouble resource forks
     """
 
     def _on_error(func, path, exc_info) -> None:
+        if is_mac and exc_info[0] is FileNotFoundError and os.path.basename(path).startswith("._"):
+            # Assume if we are on a mac and the file starts with a "._" it is a resource fork and the
+            # corresponding data fork has been removed.  Since we are removing the whole directory tree
+            # it should not be a problem.
+            return
         try:
             if is_windows:
                 path = windows_long_path(path)
@@ -223,6 +230,24 @@ def forceful_rmtree(path) -> None:
             pass
 
         func(path)
+
+    shutil.rmtree(path, onerror=_on_error)
+
+
+def safe_rmtree(path) -> None:
+    """Like shutil.rmtree, but handles race condition caused by AppleDouble files.
+
+    On Mac OSX files may consist of a data fork and a resource fork.  On a foreign file system these files
+    are stored as AppleDouble files.  The data fork is stored as "filename" and the resource fork is stored
+    as "._filename".  When the data fork is removed the corresponding resource fork is also removed.  This
+    results in a FileNotFoundError when `shutil.rmtree` tries to remove the resource fork.  This is addressed
+    in Python 13.3 for another situation not related to AppleDouble files
+    (https://github.com/python/cpython/pull/14064)
+    """
+
+    def _on_error(_func, path, exc_info):
+        if not is_mac or exc_info[0] is not FileNotFoundError or not os.path.basename(path).startswith("._"):
+            raise
 
     shutil.rmtree(path, onerror=_on_error)
 
@@ -466,7 +491,7 @@ def movetree(src: str, dst: str) -> None:
         shutil.move(src, dst)
     except:
         copytree(src, dst, symlinks=True, hardlinks=True)
-        shutil.rmtree(src)
+        safe_rmtree(src)
 
 
 def safe_chmod(path: str, mode) -> None:

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -13,7 +13,6 @@ import os.path
 import os
 import stat
 import time
-import shutil
 
 from rez.package_repository import PackageRepository
 from rez.package_resources import PackageFamilyResource, VariantResourceHelper, \
@@ -30,7 +29,7 @@ from rez.utils.resources import cached_property
 from rez.utils.logging_ import print_warning, print_info
 from rez.utils.memcached import memcached, pool_memcached_connections
 from rez.utils.filesystem import make_path_writable, \
-    canonical_path, is_subdirectory
+    canonical_path, is_subdirectory, safe_rmtree
 from rez.utils.platform_ import platform_
 from rez.utils.yaml import load_yaml
 from rez.config import config
@@ -733,7 +732,7 @@ class FileSystemPackageRepository(PackageRepository):
 
         # delete the payload
         pkg_dir = os.path.join(self.location, pkg_name, str(pkg_version))
-        shutil.rmtree(pkg_dir)
+        safe_rmtree(pkg_dir)
 
         # unignore (just so the .ignore{ver} file is removed)
         self.unignore_package(pkg_name, pkg_version)
@@ -765,7 +764,7 @@ class FileSystemPackageRepository(PackageRepository):
 
         # delete the fam dir
         fam_dir = os.path.join(self.location, pkg_name)
-        shutil.rmtree(fam_dir)
+        safe_rmtree(fam_dir)
 
         self._on_changed(pkg_name)
         return True


### PR DESCRIPTION
Handle race condition caused by AppleDouble files when removing a directory tree