### PR TITLE
Add new default_build_process setting to set the default build process

### DIFF
--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -36,7 +36,7 @@ def setup_parser_common(parser):
     process_types = get_build_process_types()
     parser.add_argument(
         "--process", type=str, choices=process_types,
-        default=config.build_process,
+        default=config.default_build_process,
         help="the build process to use (default: %(default)s).")
 
     # add build system choices valid for this package

--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -30,11 +30,13 @@ def setup_parser_common(parser):
     """Parser setup common to both rez-build and rez-release."""
     from rez.build_process import get_build_process_types
     from rez.build_system import get_valid_build_systems
+    from rez.config import config
     from rez.exceptions import PackageMetadataError
 
     process_types = get_build_process_types()
     parser.add_argument(
-        "--process", type=str, choices=process_types, default="local",
+        "--process", type=str, choices=process_types,
+        default=config.build_process,
         help="the build process to use (default: %(default)s).")
 
     # add build system choices valid for this package

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -397,6 +397,7 @@ config_schema = Schema({
     "release_packages_path":                        Str,
     "dot_image_format":                             Str,
     "build_directory":                              Str,
+    "build_process":                                Str,
     "documentation_url":                            Str,
     "suite_visibility":                             SuiteVisibility_,
     "rez_tools_visibility":                         RezToolsVisibility_,

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -397,7 +397,7 @@ config_schema = Schema({
     "release_packages_path":                        Str,
     "dot_image_format":                             Str,
     "build_directory":                              Str,
-    "build_process":                                Str,
+    "default_build_process":                        Str,
     "documentation_url":                            Str,
     "suite_visibility":                             SuiteVisibility_,
     "rez_tools_visibility":                         RezToolsVisibility_,

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -948,6 +948,9 @@ max_package_changelog_revisions = 0
 #       launched without extension from windows and other systems.
 create_executable_script_mode = "single"
 
+# Default build process to use during build/release
+build_process = "local"
+
 # Configurable pip extra arguments passed to the :ref:`rez-pip` install command.
 # Since the :ref:`rez-pip` install command already includes some pre-configured
 # arguments (``--target``, ``--use-pep517``) this setting can potentially override the

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -861,7 +861,9 @@ variant_shortlinks_dirname = "_v"
 # leave this True.
 use_variant_shortlinks = True
 
-# Default build process to use during build/release
+# Default build process to use during build/release.
+# Only 'local' build process is currently available,
+# see :gh-rez:`src/rezplugins/build_process`.
 default_build_process = "local"
 
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -949,7 +949,7 @@ max_package_changelog_revisions = 0
 create_executable_script_mode = "single"
 
 # Default build process to use during build/release
-build_process = "local"
+default_build_process = "local"
 
 # Configurable pip extra arguments passed to the :ref:`rez-pip` install command.
 # Since the :ref:`rez-pip` install command already includes some pre-configured

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -861,6 +861,9 @@ variant_shortlinks_dirname = "_v"
 # leave this True.
 use_variant_shortlinks = True
 
+# Default build process to use during build/release
+default_build_process = "local"
+
 
 ###############################################################################
 # Suites
@@ -947,9 +950,6 @@ max_package_changelog_revisions = 0
 #       Creates the requested file and a ``.py`` script so that scripts can be
 #       launched without extension from windows and other systems.
 create_executable_script_mode = "single"
-
-# Default build process to use during build/release
-default_build_process = "local"
 
 # Configurable pip extra arguments passed to the :ref:`rez-pip` install command.
 # Since the :ref:`rez-pip` install command already includes some pre-configured


### PR DESCRIPTION
This PR allows the user to define the name of the build process plugin to be used for build/release by defining it in the rezconfig or through an environment variable without having to specify it from the rez-build/rez-release command line tools.