### PR TITLE
Add more logic in the shell detection code to handle a case where the parent PID is zero

### DIFF
--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -79,14 +79,18 @@ class System(object):
             import subprocess as sp
             shell = None
 
-            # check parent process via ps
-            try:
-                args = ['ps', '-o', 'args=', '-p', str(os.getppid())]
-                proc = sp.Popen(args, stdout=sp.PIPE)
-                output = proc.communicate()[0]
-                shell = os.path.basename(output.strip().split()[0]).replace('-', '')
-            except Exception:
-                pass
+            parent_pid = os.getppid()
+            if parent_pid != 0:
+                # When run from inside docker without an interactive shell,
+                # the parent pid will be 0, which will cause "ps" to
+                # print an error message: "process ID out of range".
+                try:
+                    args = ['ps', '-o', 'args=', '-p', str(parent_pid)]
+                    proc = sp.Popen(args, stdout=sp.PIPE)
+                    output = proc.communicate()[0]
+                    shell = os.path.basename(output.strip().split()[0]).replace('-', '')
+                except Exception:
+                    pass
 
             # check $SHELL
             if shell not in shells:
@@ -94,7 +98,7 @@ class System(object):
 
             # traverse parent procs via /proc/(pid)/status
             if shell not in shells:
-                pid = str(os.getppid())
+                pid = str(parent_pid)
                 found = False
 
                 while not found:


### PR DESCRIPTION
Fixes #1732 

Add more logic in the shell detection code to handle a case where the parent PID is zero. This can happen when run from within a docker container with a non-interactive shell.

This was not necessarily a hard error. rez would just print an annoying error.

Before:
```
$ docker run --rm -it rocky_rez rez-env python -- python --version
os.getpid() 0
error: process ID out of range

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
Python 3.9.18
```

After:
```
$ docker run --rm -it rocky_rez rez-env python -- python --version
Python 3.9.18
```