### PR TITLE
Add argcomplete vendored version to vendor README.md

### DIFF
--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -27,12 +27,12 @@ tested.
 <tr><td>
 argcomplete
 </td><td>
-?
+0.8.2 (Nov 3, 2014)
 </td><td>
 Apache 2.0
 </td><td>
 https://github.com/kislyuk/argcomplete<br>
-Our version seems patched.
+Our version is patched.
 </td></tr>
 
 <!-- ######################################################### -->

--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -27,7 +27,7 @@ tested.
 <tr><td>
 argcomplete
 </td><td>
-0.8.2 (Nov 3, 2014)
+6f943d76400d6755c2152deff4f2c5c5fa4d9e7c (Jul 20, 2014)
 </td><td>
 Apache 2.0
 </td><td>


### PR DESCRIPTION
Did some digging to find out which version of argcomplete we are using. Going to put the diff in a comment as well.