### PR TITLE
Resolved context unit testing

### DIFF
--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -7,11 +7,13 @@ test resolved contexts
 """
 from rez.tests.util import restore_os_environ, restore_sys_path, TempdirMixin, \
     TestBase
-from rez.resolved_context import ResolvedContext
+from rez.resolved_context import get_lock_request, PatchLock, ResolvedContext
 from rez.bundle_context import bundle_context
 from rez.bind import hello_world
 from rez.utils.platform_ import platform_
 from rez.utils.filesystem import is_subdirectory
+from rez.utils.formatting import PackageRequest
+from rez.version import Version
 import unittest
 import subprocess
 import platform
@@ -249,6 +251,42 @@ class TestContext(TestBase, TempdirMixin):
         )
         resolved = [x.qualified_package_name for x in r.resolved_packages]
         self.assertEqual(resolved, ['python-2.7.0'])
+
+    def test_get_lock_request_1(self):
+        pkg = 'foo'
+        version = Version('1.2.1')
+        patch_lock = PatchLock.lock_3
+        expected_lock_request = PackageRequest('~foo-1.2')
+
+        lock_request = get_lock_request(pkg, version, patch_lock)
+        self.assertEqual(lock_request, expected_lock_request)
+
+    def test_get_lock_request_2(self):
+        pkg = 'foo'
+        version = Version('1.2.1')
+        patch_lock = PatchLock.lock_3
+        expected_lock_request = PackageRequest('foo-1.2')
+
+        lock_request = get_lock_request(pkg, version, patch_lock, weak=False)
+        self.assertEqual(lock_request, expected_lock_request)
+
+    def test_get_lock_request_3(self):
+        pkg = 'foo'
+        version = Version('1.2.1')
+        patch_lock = PatchLock.lock
+        expected_lock_request = PackageRequest('foo==1.2.1')
+
+        lock_request = get_lock_request(pkg, version, patch_lock, weak=False)
+        self.assertEqual(lock_request, expected_lock_request)
+
+    def test_get_lock_request_4(self):
+        pkg = 'foo'
+        version = Version('1.2.1')
+        patch_lock = PatchLock.no_lock
+        expected_lock_request = None
+
+        lock_request = get_lock_request(pkg, version, patch_lock)
+        self.assertEqual(lock_request, expected_lock_request)
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -283,6 +283,7 @@ class TestContext(TestBase, TempdirMixin):
 
         callback = ResolvedContext.Callback(max_fails=999, time_limit=0, callback=solver_callback, buf=sys.stdout)
         solve_state = SolverState(3, 1, None)
+        # TODO: Can't seem to get this mock to work for some reason.
         # Mock start time to be Jan 1, 1970.
         with unittest.mock.patch('rez.resolved_context.ResolvedContext.Callback.start_time',
                                         new_callable=unittest.mock.PropertyMock, return_value=0):


### PR DESCRIPTION
This PR adds some more unit testing coverage for `resolved_context.py`

# TODO:

- There's one ResolvedContext.Callback test that's failing because I can't seem to get the mocking to work as I expect.