### PR TITLE
Fix CI for Python 3.7 on macOS by only running these tests on macos-13

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         method: ['install' ,'pip']
 
         include:
@@ -49,6 +49,19 @@ jobs:
           REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:~/rez/bin/rez'
           REZ_INSTALL_COMMAND: python ./install.py ~/rez
         - os: macos-latest
+          method: pip
+          REZ_SET_PATH_COMMAND: 'export PATH="$PATH:~/rez/bin" PYTHONPATH=$PYTHONPATH:$HOME/rez'
+          REZ_INSTALL_COMMAND: pip install --target ~/rez .
+        # macOS
+        # Python 3.7 is not supported on Apple Silicon.
+        # macos-13 is the last macos runner image to run on Intel CPUs.
+        - os: macos-13
+          python-version: '3.7'
+          method: install
+          REZ_SET_PATH_COMMAND: 'export PATH=${PATH}:~/rez/bin/rez'
+          REZ_INSTALL_COMMAND: python ./install.py ~/rez
+        - os: macos-13
+          python-version: '3.7'
           method: pip
           REZ_SET_PATH_COMMAND: 'export PATH="$PATH:~/rez/bin" PYTHONPATH=$PYTHONPATH:$HOME/rez'
           REZ_INSTALL_COMMAND: pip install --target ~/rez .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
         - os: macos-latest
           shells: 'sh,csh,bash,tcsh,zsh,pwsh'
@@ -46,6 +46,12 @@ jobs:
         - os: windows-latest
           shells: 'cmd,pwsh,gitbash'
           rez-path: \installdir\Scripts\rez
+        # Python 3.7 is not supported on Apple Silicon.
+        # macos-13 is the last macos runner image to run on Intel CPUs.
+        - os: macos-13
+          shells: 'sh,csh,bash,tcsh,zsh,pwsh'
+          rez-path: /installdir/bin/rez
+          python-version: '3.7'
 
       fail-fast: false
 


### PR DESCRIPTION
GitHub rolled out `macos-14` and made it the latest (`macos-latest`). The `macos-14` image runs on Apple Silicon.

Tests for Python 3.7 on macOS were failing because Python 3.7 was not officially supported on M1s.

This PR changes our CI so that Python 3.7 tests run on `macos-13` (Intel CPUs).