### PR TITLE
Upload test coverage even if tests fail

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,6 +89,7 @@ jobs:
       run: rez-python -m pip install pytest-cov parameterized
 
     - name: Run tests
+      id: tests
       run: rez-selftest -v -- --cov=rez --cov-report=xml:coverage.xml
       env:
         _REZ_ENSURE_TEST_SHELLS: ${{ matrix.shells }}
@@ -96,7 +97,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       # Run on both success and failure.
-      if: success() || failure()
+      if: steps.tests.outcome == 'success' || steps.tests.outcome == 'failure'
       with:
         slug: AcademySoftwareFoundation/rez
         files: 'coverage.xml'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,6 +95,8 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
+      # Run on both success and failure.
+      if: success() || failure()
       with:
         slug: AcademySoftwareFoundation/rez
         files: 'coverage.xml'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,8 +96,8 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
-      # Run on both success and failure.
-      if: steps.tests.outcome == 'success' || steps.tests.outcome == 'failure'
+      # Run on both success and failure, but only if coverage.xml exists.
+      if: ${{ hashFiles('coverage.xml') != '' && (steps.tests.outcome == 'success' || steps.tests.outcome == 'failure') }}
       with:
         slug: AcademySoftwareFoundation/rez
         files: 'coverage.xml'


### PR DESCRIPTION
I noticed that codecov doesn't report test coverage when the tests fail. THis PR fixes that by uploading the coverage even if the tests fail.