### PR TITLE
Fix incorrect string operations on bytes output of 'ps' subprocess

### DIFF
--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -86,9 +86,17 @@ class System(object):
                 # print an error message: "process ID out of range".
                 try:
                     args = ['ps', '-o', 'args=', '-p', str(parent_pid)]
-                    proc = sp.Popen(args, stdout=sp.PIPE)
-                    output = proc.communicate()[0]
-                    shell = os.path.basename(output.strip().split()[0]).replace('-', '')
+                    finished_proc = sp.run(
+                        args,
+                        capture_output=True,
+                        check=True,
+                        text=True,
+                    )
+                    output = finished_proc.stdout
+                    shell = os.path.basename(
+                        output.strip().split()[0]).replace(
+                        '-', ''
+                    )
                 except Exception:
                     pass
 

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -86,17 +86,9 @@ class System(object):
                 # print an error message: "process ID out of range".
                 try:
                     args = ['ps', '-o', 'args=', '-p', str(parent_pid)]
-                    finished_proc = sp.run(
-                        args,
-                        capture_output=True,
-                        check=True,
-                        text=True,
-                    )
-                    output = finished_proc.stdout
-                    shell = os.path.basename(
-                        output.strip().split()[0]).replace(
-                        '-', ''
-                    )
+                    proc = sp.Popen(args, stdout=sp.PIPE, text=True)
+                    output = proc.communicate()[0]
+                    shell = os.path.basename(output.strip().split()[0]).replace('-', '')
                 except Exception:
                     pass
 

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -4,4 +4,4 @@
 
 # Update this value to version up Rez. Do not place anything else in this file.
 # Using .devN allows us to run becnmarks and create proper benchmark reports on PRs.
-_rez_version = "3.1.2"
+_rez_version = "3.1.1"

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -4,4 +4,4 @@
 
 # Update this value to version up Rez. Do not place anything else in this file.
 # Using .devN allows us to run becnmarks and create proper benchmark reports on PRs.
-_rez_version = "3.1.1"
+_rez_version = "3.1.2"


### PR DESCRIPTION
The subprocess to get the current shell name would always return a bytes output. The subsequent string operations on 
that output would always fail with a TypeError.

~Using subprocess.run() along with its text flag will fix the issue at hand as well as bring the code in-line with python's
recommendation of using run for all use cases it can handle. The current use case does not warrant a use for subprocess.communicate()~.

Closes #1754 