### PR TITLE
Fix missing path in GitBash warning message

### DIFF
--- a/src/rezplugins/shell/gitbash.py
+++ b/src/rezplugins/shell/gitbash.py
@@ -44,7 +44,7 @@ class GitBash(Bash):
                 "Git-bash executable has been detected at %s, but this is "
                 "probably not correct (google Windows Subsystem for Linux). "
                 "Consider adjusting your searchpath, or use rez config setting "
-                "plugins.shell.gitbash.executable_fullpath."
+                "plugins.shell.gitbash.executable_fullpath." % exepath
             )
 
         return exepath


### PR DESCRIPTION
When testing out Gitbash, I noticed there was a print that was not being formatted. This fixes the issue.