### PR TITLE
Powershell alias return correct exit codes

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -597,10 +597,10 @@ class TestShells(TestBase, TempdirMixin):
         config.override("default_shell", shell)
 
         def _make_alias(ex):
-            ex.alias('python_alias', 'python')
+            ex.alias('my_alias', 'hello_world -r 1')
 
-        r = self._create_context([])
-        p = r.execute_shell(command='python_alias -c raise',
+        r = self._create_context(["hello_world"])
+        p = r.execute_shell(command='my_alias',
                             actions_callback=_make_alias,
                             stdout=subprocess.PIPE)
 

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -591,6 +591,22 @@ class TestShells(TestBase, TempdirMixin):
         out, _ = p.communicate()
         self.assertEqual(0, p.returncode)
 
+    @per_available_shell()
+    def test_alias_return_code(self, shell):
+        """Ensure return codes are correct while using aliases."""
+        config.override("default_shell", shell)
+
+        def _make_alias(ex):
+            ex.alias('python_alias', 'python')
+
+        r = self._create_context([])
+        p = r.execute_shell(command='python_alias -c raise',
+                            actions_callback=_make_alias,
+                            stdout=subprocess.PIPE)
+
+        out, _ = p.communicate()
+        self.assertEqual(1, p.returncode)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -174,7 +174,7 @@ class PowerShellBase(Shell):
         # only the bool $? var is set.
         #
         executor.command(
-            "if(! $?) {\n"
+            "if(! $? -or $LASTEXITCODE) {\n"
             "  if ($LASTEXITCODE) {\n"
             "    exit $LASTEXITCODE\n"
             "  }\n"


### PR DESCRIPTION
Fixes issue where powershell plugins were not correctly capturing exit codes when aliased commands failed.

Closes #1776.