### PR TITLE
Restrict permissions in GHA workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     name: run_benchmark

--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -10,6 +10,9 @@ on:
       - '!**.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Enforce copyright notices

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -19,6 +19,9 @@ on:
       - '!src/rez/vendor/**'
       - '!src/rez/backport/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linter

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -22,6 +22,9 @@ on:
       - '!**.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: ${{ matrix.os }} - ${{ matrix.python-version }} - ${{ matrix.method }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,6 +3,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to PyPI
@@ -11,6 +14,8 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      # Not sure if it's needed here since it's defined at the top level.
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-notice.yaml
+++ b/.github/workflows/release-notice.yaml
@@ -6,6 +6,9 @@ on:
       # published should cover both 'released' and 'prereleased'
       - published
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   core:
     name: Tests


### PR DESCRIPTION
Restrict permissions in GHA workflows to fix scorecard warnings like this one: https://github.com/AcademySoftwareFoundation/rez/security/code-scanning/33.