### PR TITLE
Fix TypeError when running get_rpaths on rez.utils.elf module

### DIFF
--- a/src/rez/tests/test_utils_elf.py
+++ b/src/rez/tests/test_utils_elf.py
@@ -29,8 +29,10 @@ class TestElfUtils(TestBase):
     @program_dependent("readelf")
     def test_get_rpaths_raises_runtime_exception(self):
         """Tests that no TypeError from elf functions are raised."""
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as exc:
             get_rpaths("/path/to/elfpath")
+        self.assertIn("'/path/to/elfpath': No such file", str(exc.exception))
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as exc:
             patch_rpaths("/path/to/elfpath", ["$ORIGIN", "$ORIGINTEST"])
+        self.assertIn("'/path/to/elfpath': No such file", str(exc.exception))

--- a/src/rez/tests/test_utils_elf.py
+++ b/src/rez/tests/test_utils_elf.py
@@ -29,12 +29,8 @@ class TestElfUtils(TestBase):
     @program_dependent("readelf")
     def test_get_rpaths_raises_runtime_exception(self):
         """Tests that no TypeError from elf functions are raised."""
-        self.assertRaises(
-            RuntimeError,
+        with self.assertRaises(RuntimeError):
             get_rpaths("/path/to/elfpath")
-        )
 
-        self.assertRaises(
-            RuntimeError,
+        with self.assertRaises(RuntimeError):
             patch_rpaths("/path/to/elfpath", ["$ORIGIN", "$ORIGINTEST"])
-        )

--- a/src/rez/tests/test_utils_elf.py
+++ b/src/rez/tests/test_utils_elf.py
@@ -5,7 +5,10 @@
 """
 unit tests for 'rez.utils.elf' module
 """
-from rez.tests.util import TestBase
+import platform
+import unittest
+
+from rez.tests.util import TestBase, program_dependent
 from rez.utils.elf import get_rpaths, patch_rpaths
 
 
@@ -22,6 +25,8 @@ class TestElfUtils(TestBase):
     def tearDownClass(cls):
         super().tearDownClass()
 
+    @unittest.skipUnless(platform.system() == "Linux", "Linux only")
+    @program_dependent("readelf")
     def test_get_rpaths_raises_runtime_exception(self):
         """Tests that no TypeError from elf functions are raised."""
         self.assertRaises(

--- a/src/rez/tests/test_utils_elf.py
+++ b/src/rez/tests/test_utils_elf.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+unit tests for 'rez.utils.elf' module
+"""
+from rez.tests.util import TestBase
+from rez.utils.elf import get_rpaths, patch_rpaths
+
+
+class TestElfUtils(TestBase):
+
+    def __init__(self, *nargs, **kwargs):
+        super().__init__(*nargs, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+    def test_get_rpaths_raises_runtime_exception(self):
+        """Tests that no TypeError from elf functions are raised."""
+        self.assertRaises(
+            RuntimeError,
+            get_rpaths("/path/to/elfpath")
+        )
+
+        self.assertRaises(
+            RuntimeError,
+            patch_rpaths("/path/to/elfpath", ["$ORIGIN", "$ORIGINTEST"])
+        )

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -187,33 +187,12 @@ def find_file_in_path(to_find, path_str, pathsep=None, reverse=True):
 def program_dependent(program_name, *program_names):
     """Function decorator that skips the function if not all given programs are
     visible."""
-    import subprocess
-
-    program_tests = {
-        "cmake": ['cmake', '-h'],
-        "make": ['make', '-h'],
-        "g++": ["g++", "--help"]
-    }
-
-    # test if programs all exist
-    def _test(name):
-        command = program_tests[name]
-
-        with open(os.devnull, 'wb') as DEVNULL:
-            try:
-                subprocess.check_call(command, stdout=DEVNULL, stderr=DEVNULL)
-            except (OSError, IOError, subprocess.CalledProcessError):
-                return False
-            else:
-                return True
-
     names = [program_name] + list(program_names)
-    all_exist = all(_test(x) for x in names)
 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            if not all_exist:
+            if not all(shutil.which(x) for x in names):
                 self.skipTest(
                     "Requires all programs to be present and functioning: %s"
                     % names

--- a/src/rez/utils/elf.py
+++ b/src/rez/utils/elf.py
@@ -10,6 +10,7 @@ from shlex import quote
 import subprocess
 
 from rez.utils.filesystem import make_path_writable
+from rez.utils.execution import Popen
 
 
 def get_rpaths(elfpath):
@@ -54,10 +55,11 @@ def patch_rpaths(elfpath, rpaths):
 
 
 def _run(*nargs, **popen_kwargs):
-    proc = subprocess.Popen(
+    proc = Popen(
         nargs,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        text=True,
         **popen_kwargs
     )
 


### PR DESCRIPTION
Replaced the subprocess.Popen with  rez.utils.execution.Popen and added `text=True` to fix the TypeError when reading and parsing rpaths

Closes #1797 