### PR TITLE
PowerShell alias calling non-existent command returns 0 exit code failing test

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -591,6 +591,22 @@ class TestShells(TestBase, TempdirMixin):
         out, _ = p.communicate()
         self.assertEqual(0, p.returncode)
 
+    @per_available_shell()
+    def test_alias_non_existent_command_return_code(self, shell):
+        """Ensure return codes are correct while using aliases."""
+        config.override("default_shell", shell)
+
+        def _make_alias(ex):
+            ex.alias('my_alias', 'a_non_existent_executable')
+
+        r = self._create_context([])
+        p = r.execute_shell(command='my_alias',
+                            actions_callback=_make_alias,
+                            stdout=subprocess.PIPE)
+
+        out, _ = p.communicate()
+        self.assertNotEqual(0, p.returncode)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds failing test for #1800.

After digging into this there are three important Powershell [automatic variables](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1#error) to take note of.

- `$LASTEXITCODE`
- `$?`
- `$ERROR`

The first two, `$LASTEXITCODE` and `$?` are used in [the code](https://github.com/AcademySoftwareFoundation/rez/blob/main/src/rezplugins/shell/_utils/powershell_base.py#L176) currently. 

However, after testing the issue in PowerShell directly, it seems that the issue stems from an issue stemming from PowerShell itself. 

When using aliases in PowerShell, if the command being called is not found, and error is printed to stderr, but neither the `$LASTEXITCODE` or `$?` variables are filled out correct to represent this.

For example, in PowerShell I ran:
```
PS C:\Users\bryce.gattis> hython
hython : The term 'hython' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ hython
+ ~~~~~~
    + CategoryInfo          : ObjectNotFound: (hython:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
PS C:\Users\bryce.gattis> $?
False
PS C:\Users\bryce.gattis> $LASTEXITCODE
```

Then I ran the following that does the same thing but using aliases:
```
PS C:\Users\bryce.gattis> function python() { hython @args }
PS C:\Users\bryce.gattis> python
hython : The term 'hython' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:21
+ function python() { hython @args }
+                     ~~~~~~
    + CategoryInfo          : ObjectNotFound: (hython:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
PS C:\Users\bryce.gattis> $?
True
PS C:\Users\bryce.gattis> $LASTEXITCODE
```

Interestingly, it seems like the `$ERROR` automatic variable, correctly captures the error message in both cases.
```
PS C:\Users\bryce.gattis> $ERROR
hython : The term 'hython' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:21
+ function python() { hython @args }
+                     ~~~~~~
    + CategoryInfo          : ObjectNotFound: (hython:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

Not sure what the implications would be of _additionally_ relying on the presence of an error in the `$ERROR` variable, but seems to be something that is slipping through the cracks right now. Perhaps there's a better fix for this?