### PR TITLE
Fix `package_cache_async` missing from `ResolvedContext` dict round-trip

### DIFF
--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -134,7 +134,7 @@ class ResolvedContext(object):
     command within a configured python namespace, without spawning a child
     shell.
     """
-    serialize_version = (4, 7)
+    serialize_version = (4, 8)
     tmpdir_manager = TempDirs(config.context_tmpdir, prefix="rez_context_")
     context_tracking_payload = None
     context_tracking_lock = threading.Lock()
@@ -1560,6 +1560,7 @@ class ResolvedContext(object):
 
             append_sys_path=self.append_sys_path,
             package_caching=self.package_caching,
+            package_cache_async=self.package_cache_async,
 
             default_patch_lock=self.default_patch_lock.name,
 
@@ -1715,6 +1716,10 @@ class ResolvedContext(object):
         for eph_str in d.get("resolved_ephemerals", []):
             req = Requirement(eph_str)
             r._resolved_ephemerals.append(req)
+
+        # -- SINCE SERIALIZE VERSION 4.8
+
+        r.package_cache_async = d.get("package_cache_async", True)
 
         # <END SERIALIZATION>
 


### PR DESCRIPTION
This is a follow-up fix to https://github.com/AcademySoftwareFoundation/rez/pull/1679

The new `package_cache_async` attribute on the `ResolvedContext` class was not being round-tripped through the context serialization process. This leads to the following error after spawning a shell (when the `rezolve context` command runs):
```
17:44:39 ERROR    ResolvedContextError: Failed to load context from S:\Temp\rez_context_gsab2kwu\context.rxt: AttributeError: 'ResolvedContext' object has no attribute 'package_cache_async'
```

I will note that it seems a bit strange for `ResolvedContext.from_dict` to call `context._update_package_cache()` after creating a new instance, but I assume there are some historical reasons for this. However, given this pattern, if `package_cache_async` is set to `False`, `from_dict` could potentially block for a very long time.

CC @isohedronpipeline for visibility.