### PR TITLE
Order pip requirements when converting to keep a constant hash

### DIFF
--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -425,7 +425,7 @@ def get_rez_requirements(installed_dist, python_version, name_casings=None):
     #
     # See: vendor/distlib/metadata.py#line-892
     #
-    requires = installed_dist.run_requires
+    requires = sorted(installed_dist.run_requires)
 
     # filter requirements
     for req_ in requires:


### PR DESCRIPTION
When using rez pip, the order of requirements collected from distributions may vary. This eventually changes the variants hash generated which leads to reinstalling a package already installed (with a different hash but identical requirements).

closes: https://github.com/AcademySoftwareFoundation/rez/issues/1414