### PR TITLE
Move winreg import to local import to avoid import errors on non-windows systems

### DIFF
--- a/src/rezplugins/shell/_utils/windows.py
+++ b/src/rezplugins/shell/_utils/windows.py
@@ -4,7 +4,6 @@
 
 import os
 import re
-import winreg
 
 
 _drive_start_regex = re.compile(r"^([A-Za-z]):\\")
@@ -47,6 +46,9 @@ def to_windows_path(path):
 
 
 def get_syspaths_from_registry():
+    # Local import to avoid import errors on non-windows systems.
+    import winreg
+
     paths = []
 
     path_query_keys = (


### PR DESCRIPTION
Follow-up for #1780. #1780 introduced an import error while loading the pwsh plugin on non-windows systems which caused the plugin to never be loaded. See https://github.com/AcademySoftwareFoundation/rez/actions/runs/11317037020/job/31504575012#step:8:363.