### PR TITLE
Update python for the flake8 workflow

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install Dependencies
         run: |

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -177,7 +177,7 @@ class PackageOrder(object):
         raise NotImplementedError
 
     def __eq__(self, other):
-        return type(self) == type(other) and str(self) == str(other)
+        return type(self) == type(other) and str(self) == str(other)  # noqa: E721
 
     def __ne__(self, other):
         return not self == other
@@ -204,7 +204,7 @@ class NullPackageOrder(PackageOrder):
         return "{}"
 
     def __eq__(self, other):
-        return type(self) == type(other)
+        return type(self) == type(other)  # noqa: E721
 
     def to_pod(self):
         """
@@ -250,7 +250,7 @@ class SortedOrder(PackageOrder):
         return str(self.descending)
 
     def __eq__(self, other):
-        return (
+        return (  # noqa: E721
             type(self) == type(other)
             and self.descending == other.descending
         )
@@ -327,7 +327,7 @@ class PerFamilyOrder(PackageOrder):
         return str((items, str(self.default_order)))
 
     def __eq__(self, other):
-        return (
+        return (  # noqa: E721
             type(other) == type(self)
             and self.order_dict == other.order_dict
             and self.default_order == other.default_order
@@ -419,7 +419,7 @@ class VersionSplitPackageOrder(PackageOrder):
         return str(self.first_version)
 
     def __eq__(self, other):
-        return (
+        return (  # noqa: E721
             type(other) == type(self)
             and self.first_version == other.first_version
         )
@@ -582,7 +582,7 @@ class TimestampPackageOrder(PackageOrder):
         return str((self.timestamp, self.rank))
 
     def __eq__(self, other):
-        return (
+        return (  # noqa: E721
             type(other) == type(self)
             and self.timestamp == other.timestamp
             and self.rank == other.rank

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -9,7 +9,7 @@ from rez.config import config
 from rez.build_process import create_build_process
 from rez.build_system import create_build_system
 from rez.resolved_context import ResolvedContext
-from rez.exceptions import BuildError, BuildContextResolveError,\
+from rez.exceptions import BuildError, BuildContextResolveError, \
     PackageFamilyNotFoundError
 import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -4,7 +4,6 @@
 
 import os
 import re
-from subprocess import PIPE
 
 from rez.config import config
 from rez.rex import RexExecutor, OutputStyle, EscapedString


### PR DESCRIPTION
GitHub continues to be hostile to users and dropped python 3.7 support in the `actions/setup-python` action. So this PR updates python to 3.11 for the flake8 workflow.

Other changes are related to newer flake8 versions.