### PR TITLE
Adjust python requirement of rez bound package

### DIFF
--- a/src/rez/bind/rez.py
+++ b/src/rez/bind/rez.py
@@ -34,7 +34,7 @@ def bind(path, version_range=None, opts=None, parser=None):
     with make_package("rez", path, make_root=make_root) as pkg:
         pkg.version = version
         pkg.commands = commands
-        pkg.requires = ["python-2.7+<4"]
+        pkg.requires = ["python-3.7+<3.12"]
         pkg.variants = [system.variant]
 
     return pkg.installed_variants


### PR DESCRIPTION
Fixes #1844

Adjust python requirement of rez bound package to reflect the currently supported python versions.