### PR TITLE
Fix test commands defined as list that result in an empty command

### DIFF
--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -854,13 +854,14 @@ the data type, and includes a code snippet.
 
       tests = {
          "unit": "python -m unittest discover -s {root}/python/tests",
+         "unit-as-list": ["python", "-m", "unittest", "discover", "-s", "{root}/python/tests"],
          "lint": {
                "command": "pylint mymodule",
                "requires": ["pylint"],
                "run_on": ["default", "pre_release"]
          },
          "maya_CI": {
-               "command": "python {root}/ci_tests/maya.py",
+               "command": ["python", "{root}/ci_tests/maya.py"],
                "on_variants": {
                   "type": "requires",
                   "value": ["maya"]

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -394,7 +394,9 @@ class PackageTestRunner(object):
             if isinstance(command, str):
                 command = variant.format(command)
             else:
-                command = map(variant.format, command)
+                # Note that we convert the iterator to a list to
+                # make sure that we can consume the variable more than once.
+                command = [x for x in map(variant.format, command)]
 
             if extra_test_args:
                 if isinstance(command, str):


### PR DESCRIPTION
Fixes #1525

Fix test commands defined as list that result in an empty command when verbosity is enabled.