### PR TITLE
Add support for synchronous and asynchronous modes in package cache

### DIFF
--- a/src/rez/cli/pkg-cache.py
+++ b/src/rez/cli/pkg-cache.py
@@ -79,15 +79,15 @@ def add_variant(pkgcache, uri, opts):
         sys.exit(1)
 
     if opts.pkg_cache_mode == "async":
-        cache_mode = False
+        sync = False
     elif opts.pkg_cache_mode == "sync":
-        cache_mode = True
+        sync = True
     else:
-        cache_mode = not config.package_cache_async
+        sync = not config.package_cache_async
 
     destpath, status = pkgcache.add_variant(
         variant, force=opts.force,
-        wait_for_copying=cache_mode
+        wait_for_copying=sync
     )
 
     if status == PackageCache.VARIANT_FOUND:

--- a/src/rez/cli/pkg-cache.py
+++ b/src/rez/cli/pkg-cache.py
@@ -78,15 +78,17 @@ def add_variant(pkgcache, uri, opts):
         print("No such variant: %s" % uri, file=sys.stderr)
         sys.exit(1)
 
-    if opts.pkg_cache_mode is not None:
-        cache_mode = True if opts.pkg_cache_mode == "sync" else False
-        destpath, status = pkgcache.add_variant(
-            variant, force=opts.force,
-            wait_for_copying=cache_mode
-        )
-    # If no mode is specified, use the default behavior.
+    if opts.pkg_cache_mode == "async":
+        cache_mode = True
+    elif opts.pkg_cache_mode == "sync":
+        cache_mode = False
     else:
-        destpath, status = pkgcache.add_variant(variant, force=opts.force)
+        cache_mode = not config.package_cache_async
+
+    destpath, status = pkgcache.add_variant(
+        variant, force=opts.force,
+        wait_for_copying=cache_mode
+    )
 
     if status == PackageCache.VARIANT_FOUND:
         print_info("Already exists: %s", destpath)

--- a/src/rez/cli/pkg-cache.py
+++ b/src/rez/cli/pkg-cache.py
@@ -79,9 +79,9 @@ def add_variant(pkgcache, uri, opts):
         sys.exit(1)
 
     if opts.pkg_cache_mode == "async":
-        cache_mode = True
-    elif opts.pkg_cache_mode == "sync":
         cache_mode = False
+    elif opts.pkg_cache_mode == "sync":
+        cache_mode = True
     else:
         cache_mode = not config.package_cache_async
 

--- a/src/rez/cli/pkg-cache.py
+++ b/src/rez/cli/pkg-cache.py
@@ -67,6 +67,7 @@ def setup_parser(parser, completions=False):
 
 
 def add_variant(pkgcache, uri, opts):
+    from rez.config import config
     from rez.packages import get_variant_from_uri
     from rez.utils.logging_ import print_info, print_warning
     from rez.package_cache import PackageCache


### PR DESCRIPTION
- Introduced a new command-line argument `--pkg-cache-mode` to specify caching mode.
- Allows users to choose between 'sync' and 'async' modes, overriding the default configuration.
- Updated `add_variant` function to handle the new caching mode option.
- Ensures backward compatibility by maintaining default behavior when no mode is specified.