### PR TITLE
Enable Google Analytics using an extension

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx >=7.0.0,<9.0.0
 furo
 myst-parser
+sphinxcontrib-googleanalytics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "myst_parser",
+    "sphinxcontrib.googleanalytics",
     # Rez custom extension
     'rez_sphinxext'
 ]
@@ -116,6 +117,19 @@ extlinks = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html
 
 todo_emit_warnings = False
+
+# -- Options for googleanalytics extension ----------------------------------
+# https://github.com/sphinx-contrib/googleanalytics
+
+# ReadTheDocs used to support Google Analytics natively. But they no more do
+# since July 2024. See https://github.com/readthedocs/readthedocs.org/issues/9530#issuecomment-2233541583
+
+if not os.environ.get("READTHEDOCS"):
+    # Don't activate if run locally
+    googleanalytics_enabled = False
+
+# https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-26436
+googleanalytics_id = "G-G11PX36QZS"
 
 
 # -- Custom -----------------------------------------------------------------


### PR DESCRIPTION
ReadTheDocs used to support Google Analytics natively. But they no more do since July 2024. See https://github.com/readthedocs/readthedocs.org/issues/9530#issuecomment-2233541583.

They suggest using the `sphinxcontrib-googleanalytics` extension instead.

This will fix our reports which currently show 0 views:
![image](https://github.com/user-attachments/assets/65c93021-e6fe-4569-8622-e35556ae7a41)
