### PR TITLE
Add wildcard support on rez test command

### DIFF
--- a/src/rez/cli/test.py
+++ b/src/rez/cli/test.py
@@ -96,19 +96,14 @@ def command(opts, parser, extra_arg_groups=None):
         print('\n'.join(test_names))
         sys.exit(0)
 
-    if opts.TEST:
-        run_test_names = opts.TEST
-    else:
-        # if no tests are explicitly specified, then run only those with a
-        # 'default' run_on tag
-        run_test_names = runner.get_test_names(run_on=["default"])
+    run_test_names = runner.find_requested_test_names(opts.TEST)
 
-        if not run_test_names:
-            print(
-                "No tests with 'default' run_on tag found in %s" % uri,
-                file=sys.stderr
-            )
-            sys.exit(0)
+    if not run_test_names:
+        print(
+            "No tests with 'default' run_on tag found in %s" % uri,
+            file=sys.stderr
+        )
+        sys.exit(0)
 
     exitcode = 0
 

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -215,7 +215,7 @@ class PackageTestRunner(object):
         requested_test_names = set()
         for requested_test in requested_tests:
             requested_test_names.update(set(fnmatch.filter(pkg_test_names, requested_test)))
-        return sorted(requested_test_names)
+        return requested_test_names
 
     @property
     def num_tests(self):

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -11,6 +11,7 @@ from rez.utils.colorize import heading, Printer
 from rez.utils.logging_ import print_info, print_warning, print_error
 from rez.version import Requirement, RequirementList
 from shlex import quote
+import fnmatch
 import time
 import sys
 import os
@@ -205,6 +206,16 @@ class PackageTestRunner(object):
             return []
 
         return self.get_package_test_names(package, run_on=run_on)
+
+    def find_requested_test_names(self, requested_tests):
+        # if no tests are explicitly specified, then run only those with a
+        # 'default' run_on tag
+        run_on = ["default"] if not requested_tests else None
+        pkg_test_names = self.get_test_names(run_on=run_on)
+        requested_test_names = set()
+        for requested_test in requested_tests:
+            requested_test_names.update(set(fnmatch.filter(pkg_test_names, requested_test)))
+        return sorted(requested_test_names)
 
     @property
     def num_tests(self):

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -115,7 +115,10 @@ class TestTest(TestBase, TempdirMixin):
         )
 
     def test_wildcard_02(self):
-        """package.py unit tests are correctly found with a wildcard + a package name then run in a testing environment"""
+        """
+        package.py unit tests are correctly found with a wildcard + a package name then run
+        in a testing environment
+        """
         self.inject_python_repo()
         context = ResolvedContext(["testing_obj", "python"])
         # This will get us more code coverage :)
@@ -152,7 +155,10 @@ class TestTest(TestBase, TempdirMixin):
         )
 
     def test_wildcard_03(self):
-        """package.py unit tests are correctly found with a wildcard equivalent to 'default' then run in a testing environment"""
+        """
+        package.py unit tests are correctly found with a wildcard equivalent to 'default' then run
+        in a testing environment
+        """
         self.inject_python_repo()
         context = ResolvedContext(["testing_obj", "python"])
         # This will get us more code coverage :)
@@ -191,12 +197,11 @@ class TestTest(TestBase, TempdirMixin):
             "failed",
             "command_as_string_fail did not fail",
         )
-    
 
     def test_wildcard_04(self):
         """
-        package.py unit tests are correctly found with a wildcard which get all test starting by 'c' and the second letter is 'h' or 'o'
-        then run in a testing environment
+        package.py unit tests are correctly found with a wildcard which get all test starting by 'c' and
+        the second letter is 'h' or 'o' then run in a testing environment
         """
         self.inject_python_repo()
         context = ResolvedContext(["testing_obj", "python"])

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -83,3 +83,180 @@ class TestTest(TestBase, TempdirMixin):
             (result for result in runner.test_results.test_results if result.get("test_name") == test_name),
             None
         )
+
+    def test_wildcard_01(self):
+        """package.py unit tests are correctly found with a wildcard then run in a testing environment"""
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+        )
+
+        test_names = runner.find_requested_test_names(["command_as_*"])
+        self.assertEqual(2, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 2)
+
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )
+
+    def test_wildcard_02(self):
+        """package.py unit tests are correctly found with a wildcard + a package name then run in a testing environment"""
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names(["command_as_*", "check_car_ideas"])
+        self.assertEqual(3, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 3)
+
+        self.assertEqual(
+            self._get_test_result(runner, "check_car_ideas")["status"],
+            "success",
+            "check_car_ideas did not succeed",
+        )
+
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )
+
+    def test_wildcard_03(self):
+        """package.py unit tests are correctly found with a wildcard equivalent to 'default' then run in a testing environment"""
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names(["*"])
+        self.assertEqual(4, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 4)
+
+        self.assertEqual(
+            self._get_test_result(runner, "check_car_ideas")["status"],
+            "success",
+            "check_car_ideas did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "move_meeting_to_noon")["status"],
+            "failed",
+            "move_meeting_to_noon did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )
+    
+
+    def test_wildcard_04(self):
+        """
+        package.py unit tests are correctly found with a wildcard which get all test starting by 'c' and the second letter is 'h' or 'o'
+        then run in a testing environment
+        """
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names(["c[ho]*"])
+        self.assertEqual(3, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 3)
+
+        self.assertEqual(
+            self._get_test_result(runner, "check_car_ideas")["status"],
+            "success",
+            "check_car_ideas did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )
+
+    def test_wildcard_05(self):
+        """
+        package.py unit tests are correctly found with a wildcard which get all test which is not starting by 'c'
+        then run in a testing environment
+        """
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names(["[!c]*"])
+        self.assertEqual(1, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 1)
+
+        self.assertEqual(
+            self._get_test_result(runner, "move_meeting_to_noon")["status"],
+            "failed",
+            "move_meeting_to_noon did not fail",
+        )

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -142,7 +142,6 @@ class TestTest(TestBase, TempdirMixin):
             "success",
             "check_car_ideas did not succeed",
         )
-
         self.assertEqual(
             self._get_test_result(runner, "command_as_string_success")["status"],
             "success",


### PR DESCRIPTION
Allow user to run multiple tests thanks wildcard

For example:
* `rez test testing_obj-1.0 command_as_*` will run `command_as_string_success` and command_as_string_fail`
* `rez test testing_obj-1.0 command_as_* check_car_ideas` will run `command_as_string_success`, `command_as_string_fail' and `check_car_idea`