### PR TITLE
fix(utils.execution): cmd file should exit with an error code

### DIFF
--- a/src/rez/utils/execution.py
+++ b/src/rez/utils/execution.py
@@ -155,7 +155,7 @@ def create_executable_script(filepath, body, program=None, py_script_mode=None):
                 # before yaml.load
                 f.write("@echo off\n")
                 f.write("%s.exe %%~dpnx0 %%*\n" % program)
-                f.write("goto :eof\n")  # skip YAML body
+                f.write("exit /B %errorlevel%\n")
                 f.write(":: YAML\n")    # comment for human
             else:
                 f.write("#!/usr/bin/env %s\n" % program)


### PR DESCRIPTION
This will allow file execution through another shell to catch the exit code.

example:
```file.cmd
color 00
```
```
cmd file.cmd
echo %errorlevel%
> 0  # instead of 1
```

closes: https://github.com/AcademySoftwareFoundation/rez/issues/1892