### PR TITLE
Add updates for Python 3.12 support

### DIFF
--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -8,6 +8,8 @@ Run unit tests. Use pytest if available.
 
 import os
 import sys
+import importlib
+import importlib.util
 import inspect
 import argparse
 import shutil
@@ -56,7 +58,9 @@ def setup_parser(parser, completions=False):
     prefix = "test_"
     for importer, name, ispkg in iter_modules([tests_dir]):
         if not ispkg and name.startswith(prefix):
-            module = importer.find_module(name).load_module(name)
+            spec = importer.find_spec(name)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
             name_ = name[len(prefix):]
             all_module_tests.append(name_)
             tests.append((name_, module))

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -12,6 +12,7 @@ from rez.utils.data_utils import LazySingleton, cached_property, deep_update
 from rez.utils.logging_ import print_debug, print_warning
 from rez.exceptions import RezPluginError
 from zipimport import zipimporter
+import importlib.util
 import pkgutil
 import os.path
 import sys
@@ -157,10 +158,10 @@ class RezPluginType(object):
                     # https://github.com/AcademySoftwareFoundation/rez/pull/218
                     # load_module will force reload the module if it's
                     # already loaded, so check for that
+                    # TODO: Confirm if the force reload still happens after this change.
                     plugin_module = sys.modules.get(modname)
                     if plugin_module is None:
-                        loader = importer.find_module(modname)
-                        plugin_module = loader.load_module(modname)
+                        plugin_module = importlib.import_module(modname)
 
                     elif os.path.dirname(plugin_module.__file__) != path:
                         if config.debug("plugins"):


### PR DESCRIPTION
This PR updates Rez to support Python 3.12, but is currently WIP.

Known TODOs:

Need to update vendored `packaging` package as it relies on `six` module which currently seems to rely on the `imp` module which was removed in Python 3.12. Perhaps we can get #1731 merged to fix this?

Confirm if we can remove special if statement that was avoiding a forced reload in `plugin_managers.py`