### PR TITLE
Fix rez.system is_production_rez_install to handle forward slash paths under windows.

### DIFF
--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -207,6 +207,7 @@ class System(object):
         #
         import rez
         module_path = rez.__path__[0]
+        module_path = os.path.normpath(module_path)
 
         parts = module_path.split(os.path.sep)
         parts_lower = module_path.lower().split(os.path.sep)

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -207,6 +207,8 @@ class System(object):
         #
         import rez
         module_path = rez.__path__[0]
+        # Best effort attempt at converting slashes to the current
+        # platform native slash. (for example, forward to backward).
         module_path = os.path.normpath(module_path)
 
         parts = module_path.split(os.path.sep)


### PR DESCRIPTION
This allows to import rez module from paths with forward slashes. The following code printed "False" before the fix:

```
import sys
sys.path.append('C:/rez_test/Lib/site-packages')
from rez.system import system
print( 'is_production_rez_install', system.is_production_rez_install )
```