### PR TITLE
Chore/add warning about rez bind to docs fixes #1729

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,7 +7,7 @@ Essential packages
 
 .. warning::
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
-   Especially on windows, using :option:`--quickstart` is likely to fail.
+   Especially on windows, using :option:`--quickstart <rez-bind --quickstart>` is likely to fail.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -5,6 +5,10 @@ Getting started
 Essential packages
 ==================
 
+.. warning::
+   `rez-bind` is going to be deprecated. The current implementation is not actively maintained.
+   Especially on windows, using `--quickstart` is likely to fail.
+
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.
 Use the :option:`--quickstart <rez-bind --quickstart>` argument to bind a set of standard packages:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,8 +6,8 @@ Essential packages
 ==================
 
 .. warning::
-   `rez-bind` is going to be deprecated. The current implementation is not actively maintained.
-   Especially on windows, using `--quickstart` is likely to fail.
+   :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
+   Especially on windows, using :option:`--quickstart` is likely to fail.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -9,6 +9,8 @@ Essential packages
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
    Especially on windows, using :option:`--quickstart <rez-bind --quickstart>` is likely to fail.
 
+   Even if rez-bind will be deprecated and we generally discourage its use, you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
+
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.
 Use the :option:`--quickstart <rez-bind --quickstart>` argument to bind a set of standard packages:


### PR DESCRIPTION
Fixes #1729 and adds a warning to the docs. The second location mentioned in the ticket is created via automatic argument parsing and needs to be added to the actual CLI command not the docs.