### PR TITLE
Package repository case insensitive error handling

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1213,6 +1213,11 @@ class FileSystemPackageRepository(PackageRepository):
         family = self.get_package_family(variant_name)
         if not family:
             family = self._create_family(variant_name)
+            if not family:
+                raise PackageRepositoryError(
+                    f'Package family: {variant_name} does not exist and could not be created '
+                    f'in repository: {self.location}. Perhaps family already exists with different character case?'
+                )
 
         if isinstance(family, FileSystemCombinedPackageFamilyResource):
             raise NotImplementedError(


### PR DESCRIPTION
Handle case where case mismatch happens on non case sensitive platforms so we have a diagnosable error sent to the user.

Closes #1931

# TODO

* Needs a unit test