### PR TITLE
PowerShell: Fix assumption that `$LASTEXITCODE` is always defined

### DIFF
--- a/src/rez/bind/hello_world.py
+++ b/src/rez/bind/hello_world.py
@@ -47,11 +47,16 @@ def bind(path, version_range=None, opts=None, parser=None):
     def make_root(variant, root):
         binpath = make_dirs(root, "bin")
         binpathtmp = make_dirs(root, "bintmp")
-        filepath = os.path.join(binpathtmp, "hello_world")
 
         create_executable_script(
-            filepath,
+            os.path.join(binpathtmp, "hello_world"),
             hello_world_source,
+            py_script_mode=ExecutableScriptMode.single,
+        )
+        create_executable_script(
+            os.path.join(binpathtmp, "hello_world_gui"),
+            hello_world_source,
+            program="pythonw",
             py_script_mode=ExecutableScriptMode.single,
         )
 
@@ -61,11 +66,12 @@ def bind(path, version_range=None, opts=None, parser=None):
         # instead.
         maker = ScriptMaker(binpathtmp, make_dirs(binpath))
         maker.make("hello_world")
+        maker.make("hello_world_gui")
         shutil.rmtree(binpathtmp)
 
     with make_package("hello_world", path, make_root=make_root) as pkg:
         pkg.version = version
-        pkg.tools = ["hello_world"]
+        pkg.tools = ["hello_world", "hello_world_gui"]
         pkg.commands = commands
 
     return pkg.installed_variants

--- a/src/rez/data/tests/builds/packages/whack/package.py
+++ b/src/rez/data/tests/builds/packages/whack/package.py
@@ -4,4 +4,6 @@ authors = ["joe.bloggs"]
 uuid = "4e9f63cbc4794453b0031f0c5ff50759"
 description = "a deliberately broken package"
 
+private_build_requires = ["python"]
+
 build_command = "python {root}/build.py {install}"

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -141,6 +141,7 @@ class TestBuild(TestBase, TempdirMixin):
         """Test that a broken build fails correctly.
         """
         config.override("default_shell", shell)
+        self.inject_python_repo()
 
         working_dir = os.path.join(self.src_root, "whack")
         builder = self._create_builder(working_dir)

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -11,8 +11,9 @@ from rez.resolved_context import ResolvedContext
 from rez.rex import literal, expandable
 from rez.plugin_managers import plugin_manager
 from rez.utils.execution import ExecutableScriptMode, _get_python_script_files
-from rez.tests.util import TestBase, TempdirMixin, per_available_shell, \
-    install_dependent
+from rez.utils.platform_ import platform_
+from rez.tests.util import TestBase, TempdirMixin, get_available_shells, \
+    per_available_shell, install_dependent
 from rez.bind import hello_world
 from rez.config import config
 import unittest
@@ -251,6 +252,39 @@ class TestShells(TestBase, TempdirMixin):
                 with r.execute_shell(command=cmd, stdout=subprocess.PIPE) as p:
                     p.wait()
                 self.assertEqual(p.returncode, 66)
+
+    @unittest.skipIf(platform_.name != "windows", "GUI entrypoint test is only relevant on Windows")
+    @unittest.skipIf("pwsh" not in get_available_shells(), "PowerShell unavailable or disabled")
+    def test_pwsh_lastexitcode_gui(self):
+        """This validates some semi-unintuitive behavior on Windows, where GUI applications
+        will "return" immediately without any exit status when launched from a shell.
+        """
+        sh = create_shell("pwsh")
+        _, _, _, command = sh.startup_capabilities(command=True)
+
+        if command:
+            def actions_callback(ex):
+                """Action callback to enable PowerShell's "strict" mode."""
+                ex.command("Set-StrictMode -version Latest")
+
+            r = self._create_context(["hello_world"])
+            command = "hello_world -q -r 66"
+            commands = (command, command.split())
+            for cmd in commands:
+                with r.execute_shell(shell="pwsh", command=cmd, actions_callback=actions_callback,
+                                     stdout=subprocess.PIPE) as p:
+                    p.wait()
+                self.assertEqual(p.returncode, 66)
+
+            command = "hello_world_gui -q -r 49"
+            commands = (command, command.split())
+            for cmd in commands:
+                with r.execute_shell(shell="pwsh", command=cmd, actions_callback=actions_callback,
+                                     stdout=subprocess.PIPE) as p:
+                    p.wait()
+                # The GUI application should return control to the shell immediately, and that
+                # should bubble up through the rez shell as a 0 exit status.
+                self.assertEqual(p.returncode, 0)
 
     @per_available_shell()
     def test_norc(self, shell):

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -203,6 +203,21 @@ def program_dependent(program_name, *program_names):
     return decorator
 
 
+def get_available_shells():
+    """Helper to get all available shells in a testing context."""
+    shells = get_shell_types()
+
+    only_shell = os.getenv("__REZ_SELFTEST_SHELL")
+    if only_shell:
+        shells = [only_shell]
+
+    # filter to only those shells available
+    return [
+        x for x in shells
+        if get_shell_class(x).is_available()
+    ]
+
+
 def per_available_shell(exclude=None):
     """Function decorator that runs the function over all available shell types.
     """

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -153,10 +153,10 @@ class PowerShellBase(Shell):
         # only the bool $? var is set.
         #
         executor.command(
-            "if(! $? -or $LASTEXITCODE) {\n"
-            "  if ($LASTEXITCODE) {\n"
-            "    exit $LASTEXITCODE\n"
-            "  }\n"
+            "if ((Test-Path variable:LASTEXITCODE) -and $LASTEXITCODE) {\n"
+            "  exit $LASTEXITCODE\n"
+            "}\n"
+            "if (! $?) {\n"
             "  exit 1\n"
             "}"
         )


### PR DESCRIPTION
https://github.com/AcademySoftwareFoundation/rez/pull/1778 added support for surfacing the exit code from aliased commands to the rez shell. However, it assumes `$LASTEXITCODE` will always be defined after *any* command is run, which is not safe.

On Windows, GUI applications will detach from their parent process at startup unless explicitly written to (re)attach. In PowerShell, this manifests as the command execution returning immediately, and `$LASTEXITCODE` being left unmodified, which means it may not be defined all depending on what has previously been run in the shell.

When running PowerShell with `Set-StrictMode` enabled, attempting to access an undefined variable is treated as an error, rather than returning `0` or `$null`.

Thus, launching a GUI application using a `rez-env` call (e.g. `rez-env some_package -- some_app.exe`) in a "strict" PowerShell session leads to an error like the following:
```pwsh
InvalidOperation: S:\Temp\rez_context_qwzoucq1\rez-shell.ps1:5
Line |
   5 |  if(! $? -or $LASTEXITCODE) {
     |              ~~~~~~~~~~~~~
     | The variable '$LASTEXITCODE' cannot be retrieved because it has not been set.
```

This MR fixes this particular error by ensuring `$LASTEXITCODE` is actually defined before trying to read it.