### PR TITLE
fix: testing sonarqube scan args again - with block

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -15,11 +15,12 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf  #v5.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        args: >
-          -Dsonar.organization="academysoftwarefoundation"
-          -Dsonar.projectKey="AcademySoftwareFoundation_rez"
-          -Dsonar.projectName="rez"
-          -Dsonar.sources="src/"
-          -Dsonar.tests="tests/"
-          -Dsonar.exclusions="sonar.exclusions=src/build_utils/**,src/rez/data/**,src/rez/tests/**,src/rez/vendor/**"
-          -Dsonar.python.version="3.7, 3.8, 3.9, 3.10, 3.11, 3.12"
+        with:
+          args: >
+            -Dsonar.organization="academysoftwarefoundation"
+            -Dsonar.projectKey="AcademySoftwareFoundation_rez"
+            -Dsonar.projectName="rez"
+            -Dsonar.sources="src/"
+            -Dsonar.tests="tests/"
+            -Dsonar.exclusions="sonar.exclusions=src/build_utils/**,src/rez/data/**,src/rez/tests/**,src/rez/vendor/**"
+            -Dsonar.python.version="3.7, 3.8, 3.9, 3.10, 3.11, 3.12"


### PR DESCRIPTION
adding the `with:` block