### PR TITLE
Fix shell injection in rez-build process

### DIFF
--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -254,6 +254,11 @@ class BuildSystem(object):
         else:
             variant_subpath = variant._non_shortlinked_subpath
 
+        # Security warning!
+        # Be very careful with values in this dict. Escape (using literal)
+        # anything that could either contain arbitrary text/commands
+        # or things that could be accidentally interpreter by shells.
+        # We really want to avoid possible shell injections.
         vars_ = {
             'REZ_BUILD_ENV': 1,
             'REZ_BUILD_PATH': executor.normalize_path(build_path),

--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -9,6 +9,7 @@ import os.path
 from typing import Sequence, TypedDict, TYPE_CHECKING
 
 
+from rez.rex import literal
 from rez.build_process import BuildType
 from rez.exceptions import BuildSystemError
 from rez.packages import get_developer_package
@@ -258,22 +259,26 @@ class BuildSystem(object):
             'REZ_BUILD_PATH': executor.normalize_path(build_path),
             'REZ_BUILD_THREAD_COUNT': package.config.build_thread_count,
             'REZ_BUILD_VARIANT_INDEX': variant.index or 0,
-            'REZ_BUILD_VARIANT_REQUIRES': ' '.join(variant_requires),
+            'REZ_BUILD_VARIANT_REQUIRES': literal(' '.join(variant_requires)),
             'REZ_BUILD_VARIANT_SUBPATH': executor.normalize_path(variant_subpath),
-            'REZ_BUILD_PROJECT_VERSION': str(package.version),
-            'REZ_BUILD_PROJECT_NAME': package.name,
-            'REZ_BUILD_PROJECT_DESCRIPTION': (package.description or '').strip(),
-            'REZ_BUILD_PROJECT_FILE': package.filepath,
+            'REZ_BUILD_PROJECT_VERSION': literal(str(package.version)),
+            'REZ_BUILD_PROJECT_NAME': literal(package.name),
+            'REZ_BUILD_PROJECT_DESCRIPTION': literal((package.description or '').strip()),
+            'REZ_BUILD_PROJECT_FILE': literal(package.filepath),
             'REZ_BUILD_SOURCE_PATH': executor.normalize_path(
                 os.path.dirname(package.filepath)
             ),
-            'REZ_BUILD_REQUIRES': ' '.join(
-                str(x) for x in context.requested_packages(True)
+            'REZ_BUILD_REQUIRES': literal(
+                ' '.join(
+                    str(x) for x in context.requested_packages(True)
+                )
             ),
-            'REZ_BUILD_REQUIRES_UNVERSIONED': ' '.join(
-                x.name for x in context.requested_packages(True)
+            'REZ_BUILD_REQUIRES_UNVERSIONED': literal(
+                ' '.join(
+                    x.name for x in context.requested_packages(True)
+                )
             ),
-            'REZ_BUILD_TYPE': build_type.name,
+            'REZ_BUILD_TYPE': literal(build_type.name),
             'REZ_BUILD_INSTALL': 1 if install else 0,
         }
 

--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -257,7 +257,7 @@ class BuildSystem(object):
         # Security warning!
         # Be very careful with values in this dict. Escape (using literal)
         # anything that could either contain arbitrary text/commands
-        # or things that could be accidentally interpreter by shells.
+        # or things that could be accidentally interpreted by shells.
         # We really want to avoid possible shell injections.
         # In case of doubt, use literal.
         vars_ = {

--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -259,19 +259,22 @@ class BuildSystem(object):
         # anything that could either contain arbitrary text/commands
         # or things that could be accidentally interpreter by shells.
         # We really want to avoid possible shell injections.
+        # In case of doubt, use literal.
         vars_ = {
-            'REZ_BUILD_ENV': 1,
-            'REZ_BUILD_PATH': executor.normalize_path(build_path),
-            'REZ_BUILD_THREAD_COUNT': package.config.build_thread_count,
-            'REZ_BUILD_VARIANT_INDEX': variant.index or 0,
+            'REZ_BUILD_ENV': literal("1"),
+            'REZ_BUILD_PATH': literal(executor.normalize_path(build_path)),
+            'REZ_BUILD_THREAD_COUNT': literal(str(package.config.build_thread_count)),
+            'REZ_BUILD_VARIANT_INDEX': literal(str(variant.index or 0)),
             'REZ_BUILD_VARIANT_REQUIRES': literal(' '.join(variant_requires)),
-            'REZ_BUILD_VARIANT_SUBPATH': executor.normalize_path(variant_subpath),
+            'REZ_BUILD_VARIANT_SUBPATH': literal(executor.normalize_path(variant_subpath)),
             'REZ_BUILD_PROJECT_VERSION': literal(str(package.version)),
             'REZ_BUILD_PROJECT_NAME': literal(package.name),
             'REZ_BUILD_PROJECT_DESCRIPTION': literal((package.description or '').strip()),
             'REZ_BUILD_PROJECT_FILE': literal(package.filepath),
-            'REZ_BUILD_SOURCE_PATH': executor.normalize_path(
-                os.path.dirname(package.filepath)
+            'REZ_BUILD_SOURCE_PATH': literal(
+                executor.normalize_path(
+                    os.path.dirname(package.filepath)
+                )
             ),
             'REZ_BUILD_REQUIRES': literal(
                 ' '.join(
@@ -284,16 +287,16 @@ class BuildSystem(object):
                 )
             ),
             'REZ_BUILD_TYPE': literal(build_type.name),
-            'REZ_BUILD_INSTALL': 1 if install else 0,
+            'REZ_BUILD_INSTALL': literal("1" if install else "0"),
         }
 
         if install_path:
-            vars_['REZ_BUILD_INSTALL_PATH'] = executor.normalize_path(install_path)
+            vars_['REZ_BUILD_INSTALL_PATH'] = literal(executor.normalize_path(install_path))
 
         if config.rez_1_environment_variables and \
                 not config.disable_rez_1_compatibility and \
                 build_type == BuildType.central:
-            vars_['REZ_IN_REZ_RELEASE'] = 1
+            vars_['REZ_IN_REZ_RELEASE'] = literal("1")
 
         # set env vars
         for key, value in vars_.items():

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -10,7 +10,7 @@ from rez.build_process import create_build_process, BuildType
 from rez.build_system import create_build_system, BuildSystem
 from rez.resolved_context import ResolvedContext
 from rez.exceptions import BuildError, BuildContextResolveError, \
-    PackageFamilyNotFoundError
+    PackageFamilyNotFoundError, RezPluginError
 import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \
     per_available_shell, install_dependent, program_dependent
@@ -233,10 +233,14 @@ requires = []
         context = self._create_context()  # Empty context
 
         # Create a bash shell executor using RexExecutor
-        shell_type = "bash"
+        shell_type = "gitbash"
         if platform_.name == "windows":
             shell_type = "gitbash"
-        bash_shell = create_shell(shell_type)
+        try:
+            bash_shell = create_shell(shell_type)
+        except RezPluginError:
+            self.skipTest(f"Required shell {shell_type!r} is not available")
+
         executor = RexExecutor(interpreter=bash_shell, parent_environ={}, shebang=False)
 
         build_path = os.path.join(self.root, "build")

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -6,8 +6,8 @@
 test the build system
 """
 from rez.config import config
-from rez.build_process import create_build_process
-from rez.build_system import create_build_system
+from rez.build_process import create_build_process, BuildType
+from rez.build_system import create_build_system, BuildSystem
 from rez.resolved_context import ResolvedContext
 from rez.exceptions import BuildError, BuildContextResolveError, \
     PackageFamilyNotFoundError
@@ -15,6 +15,9 @@ import unittest
 from rez.tests.util import TestBase, TempdirMixin, find_file_in_path, \
     per_available_shell, install_dependent, program_dependent
 from rez.utils.platform_ import platform_
+from rez.shells import create_shell
+from rez.packages import get_developer_package
+from rez.rex import RexExecutor
 import shutil
 import os.path
 
@@ -199,6 +202,76 @@ class TestBuild(TestBase, TempdirMixin):
         proc = context.execute_command(['hai'], stdout=PIPE)
         stdout = proc.communicate()[0]
         self.assertEqual('Oh hai!', stdout.decode("utf-8").strip())
+
+    def test_set_standard_vars_escaping(self) -> None:
+        """Test that set_standard_vars properly escapes environment variables."""
+        # Create a test package directory with special characters in description
+        temp_pkg_dir = os.path.join(self.root, "test_special_package")
+        os.makedirs(temp_pkg_dir)
+
+        # Create a package.py file with special characters
+        package_py_content = """
+name = "test_special_chars"
+version = "1.0.0"
+description = 'A test package with "quotes" and $pecial characters & more!'
+authors = ["test@example.com"]
+requires = []
+"""
+
+        package_py_path = os.path.join(temp_pkg_dir, "package.py")
+        with open(package_py_path, 'w') as f:
+            f.write(package_py_content)
+
+        # Get the developer package
+        package = get_developer_package(temp_pkg_dir)
+
+        # Get the first variant from the package
+        variant = next(package.iter_variants())
+
+        # Create a minimal context for testing - we don't need to resolve packages
+        # since we're only testing environment variable escaping
+        context = self._create_context()  # Empty context
+
+        # Create a bash shell executor using RexExecutor
+        bash_shell = create_shell("bash")
+        executor = RexExecutor(interpreter=bash_shell, parent_environ={}, shebang=False)
+
+        build_path = os.path.join(self.root, "build")
+        install_path = os.path.join(self.root, "install")
+
+        BuildSystem.set_standard_vars(
+            executor=executor,
+            context=context,
+            variant=variant,
+            build_type=BuildType.local,
+            install=True,
+            build_path=build_path,
+            install_path=install_path
+        )
+
+        # Get the generated shell script
+        script_output = executor.get_output()
+
+        self.assertEqual(
+            script_output,
+            f"""export REZ_BUILD_ENV="1"
+export REZ_BUILD_PATH="{build_path}"
+export REZ_BUILD_THREAD_COUNT="{package.config.build_thread_count}"
+export REZ_BUILD_VARIANT_INDEX="0"
+export REZ_BUILD_VARIANT_REQUIRES=''
+export REZ_BUILD_VARIANT_SUBPATH=""
+export REZ_BUILD_PROJECT_VERSION='1.0.0'
+export REZ_BUILD_PROJECT_NAME='test_special_chars'
+export REZ_BUILD_PROJECT_DESCRIPTION='A test package with "quotes" and $pecial characters & more!'
+export REZ_BUILD_PROJECT_FILE='{package_py_path}'
+export REZ_BUILD_SOURCE_PATH='{temp_pkg_dir}'
+export REZ_BUILD_REQUIRES=''
+export REZ_BUILD_REQUIRES_UNVERSIONED=''
+export REZ_BUILD_TYPE='local'
+export REZ_BUILD_INSTALL="1"
+export REZ_BUILD_INSTALL_PATH='{install_path}'
+"""
+        )
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -258,7 +258,7 @@ requires = []
         self.assertEqual(
             script_output,
             f"""export REZ_BUILD_ENV="1"
-export REZ_BUILD_PATH="{build_path}"
+export REZ_BUILD_PATH="{executor.normalize_path(build_path)}"
 export REZ_BUILD_THREAD_COUNT="{package.config.build_thread_count}"
 export REZ_BUILD_VARIANT_INDEX="0"
 export REZ_BUILD_VARIANT_REQUIRES=''
@@ -266,13 +266,13 @@ export REZ_BUILD_VARIANT_SUBPATH=""
 export REZ_BUILD_PROJECT_VERSION='1.0.0'
 export REZ_BUILD_PROJECT_NAME='test_special_chars'
 export REZ_BUILD_PROJECT_DESCRIPTION='A test package with "quotes" and $pecial characters & more!'
-export REZ_BUILD_PROJECT_FILE='{package_py_path}'
-export REZ_BUILD_SOURCE_PATH="{temp_pkg_dir}"
+export REZ_BUILD_PROJECT_FILE='{executor.normalize_path(package_py_path)}'
+export REZ_BUILD_SOURCE_PATH="{executor.normalize_path(temp_pkg_dir)}"
 export REZ_BUILD_REQUIRES=''
 export REZ_BUILD_REQUIRES_UNVERSIONED=''
 export REZ_BUILD_TYPE='local'
 export REZ_BUILD_INSTALL="1"
-export REZ_BUILD_INSTALL_PATH="{install_path}"
+export REZ_BUILD_INSTALL_PATH="{executor.normalize_path(install_path)}"
 """
         )
 

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -233,7 +233,10 @@ requires = []
         context = self._create_context()  # Empty context
 
         # Create a bash shell executor using RexExecutor
-        bash_shell = create_shell("bash")
+        shell_type = "bash"
+        if platform_.name == "windows":
+            shell_type = "gitbash"
+        bash_shell = create_shell(shell_type)
         executor = RexExecutor(interpreter=bash_shell, parent_environ={}, shebang=False)
 
         build_path = os.path.join(self.root, "build")

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -213,7 +213,7 @@ class TestBuild(TestBase, TempdirMixin):
         package_py_content = """
 name = "test_special_chars"
 version = "1.0.0"
-description = 'A test package with "quotes" and $pecial characters & more!'
+description = 'A test \\'package with "quotes" and $pecial characters & more!'
 authors = ["test@example.com"]
 requires = []
 """
@@ -257,22 +257,22 @@ requires = []
 
         self.assertEqual(
             script_output,
-            f"""export REZ_BUILD_ENV="1"
-export REZ_BUILD_PATH="{executor.normalize_path(build_path)}"
-export REZ_BUILD_THREAD_COUNT="{package.config.build_thread_count}"
-export REZ_BUILD_VARIANT_INDEX="0"
+            f"""export REZ_BUILD_ENV='1'
+export REZ_BUILD_PATH='{executor.normalize_path(build_path)}'
+export REZ_BUILD_THREAD_COUNT='{package.config.build_thread_count}'
+export REZ_BUILD_VARIANT_INDEX='0'
 export REZ_BUILD_VARIANT_REQUIRES=''
-export REZ_BUILD_VARIANT_SUBPATH=""
+export REZ_BUILD_VARIANT_SUBPATH=''
 export REZ_BUILD_PROJECT_VERSION='1.0.0'
 export REZ_BUILD_PROJECT_NAME='test_special_chars'
-export REZ_BUILD_PROJECT_DESCRIPTION='A test package with "quotes" and $pecial characters & more!'
-export REZ_BUILD_PROJECT_FILE='{executor.normalize_path(package_py_path)}'
-export REZ_BUILD_SOURCE_PATH="{executor.normalize_path(temp_pkg_dir)}"
+export REZ_BUILD_PROJECT_DESCRIPTION='A test '"'"'package with "quotes" and $pecial characters & more!'
+export REZ_BUILD_PROJECT_FILE='{package_py_path}'
+export REZ_BUILD_SOURCE_PATH='{executor.normalize_path(temp_pkg_dir)}'
 export REZ_BUILD_REQUIRES=''
 export REZ_BUILD_REQUIRES_UNVERSIONED=''
 export REZ_BUILD_TYPE='local'
-export REZ_BUILD_INSTALL="1"
-export REZ_BUILD_INSTALL_PATH="{executor.normalize_path(install_path)}"
+export REZ_BUILD_INSTALL='1'
+export REZ_BUILD_INSTALL_PATH='{executor.normalize_path(install_path)}'
 """
         )
 

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -264,12 +264,12 @@ export REZ_BUILD_PROJECT_VERSION='1.0.0'
 export REZ_BUILD_PROJECT_NAME='test_special_chars'
 export REZ_BUILD_PROJECT_DESCRIPTION='A test package with "quotes" and $pecial characters & more!'
 export REZ_BUILD_PROJECT_FILE='{package_py_path}'
-export REZ_BUILD_SOURCE_PATH='{temp_pkg_dir}'
+export REZ_BUILD_SOURCE_PATH="{temp_pkg_dir}"
 export REZ_BUILD_REQUIRES=''
 export REZ_BUILD_REQUIRES_UNVERSIONED=''
 export REZ_BUILD_TYPE='local'
 export REZ_BUILD_INSTALL="1"
-export REZ_BUILD_INSTALL_PATH='{install_path}'
+export REZ_BUILD_INSTALL_PATH="{install_path}"
 """
         )
 

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -206,6 +206,12 @@ class CustomBuildSystem(BuildSystem):
                         varname = "__PARSE_ARG_%s" % key.upper()
 
                         # do some value conversions
+
+                        # Security warning!
+                        # Be very careful with values in this dict. Escape (using quote)
+                        # anything that could either contain arbitrary text/commands
+                        # or things that could be accidentally interpreter by shells.
+                        # We really want to avoid possible shell injections.
                         if isinstance(value, bool):
                             value = 1 if value else 0
                         elif isinstance(value, (list, tuple)):

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -208,17 +208,19 @@ class CustomBuildSystem(BuildSystem):
                         # do some value conversions
 
                         # Security warning!
-                        # Be very careful with values in this dict. Escape (using quote)
+                        # Be very careful with values in the env var value. Escape (using quote)
                         # anything that could either contain arbitrary text/commands
-                        # or things that could be accidentally interpreter by shells.
+                        # or things that could be accidentally interpreted by shells.
                         # We really want to avoid possible shell injections.
                         if isinstance(value, bool):
                             value = 1 if value else 0
                         elif isinstance(value, (list, tuple)):
                             value = list(map(str, value))
+                            # TODO: use rez.rex.literal?
                             value = list(map(quote, value))
                             value = ' '.join(value)
                         else:
+                            # TODO: use rez.rex.literal?
                             value = quote(str(value))
 
                         executor.env[varname] = value

--- a/src/rezplugins/build_system/custom.py
+++ b/src/rezplugins/build_system/custom.py
@@ -212,6 +212,8 @@ class CustomBuildSystem(BuildSystem):
                             value = list(map(str, value))
                             value = list(map(quote, value))
                             value = ' '.join(value)
+                        else:
+                            value = quote(str(value))
 
                         executor.env[varname] = value
 


### PR DESCRIPTION
Fixes #417
Fixes #797
Fixes #937
Fixes #964
Fixes #1107

Fix shell injection in rez-build process caused by non-sanitized strings in environment variables.

Note that it doesn't improve the security by a lot. By design building something will execute code other than rez's code. But it increases security by relying on the principle of least surprise (it is very surprising to see random stuff in a string assigned to a variable named "description" to execute any code. Thre is another another side effect to this PR, which is the reduction in attack surface. No SCA (source code analysis) tool would be able to detect the vulnerable packages today without custom rules. With this PR, this problem goes away.