### PR TITLE
Fix calling rez test with empty test name to run all tests

### DIFF
--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -213,6 +213,12 @@ class PackageTestRunner(object):
         run_on = ["default"] if not requested_tests else None
         pkg_test_names = self.get_test_names(run_on=run_on)
         requested_test_names = set()
+
+        if not requested_tests:
+            # if no tests are explicitly specified, then return all tests
+            # found in the package
+            return pkg_test_names
+
         for requested_test in requested_tests:
             requested_test_names.update(set(fnmatch.filter(pkg_test_names, requested_test)))
         return requested_test_names

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -264,3 +264,48 @@ class TestTest(TestBase, TempdirMixin):
             "failed",
             "move_meeting_to_noon did not fail",
         )
+
+    def test_wildcard_06(self):
+        """
+        package.py unit tests are correctly found with a wildcard which get all test which is not starting by 'c'
+        then run in a testing environment
+        """
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names([])
+        self.assertEqual(4, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 4)
+
+        self.assertEqual(
+            self._get_test_result(runner, "check_car_ideas")["status"],
+            "success",
+            "check_car_ideas did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "move_meeting_to_noon")["status"],
+            "failed",
+            "move_meeting_to_noon did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )
+

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -265,10 +265,9 @@ class TestTest(TestBase, TempdirMixin):
             "move_meeting_to_noon did not fail",
         )
 
-    def test_wildcard_06(self):
+    def test_empty_test_list(self):
         """
-        package.py unit tests are correctly found with a wildcard which get all test which is not starting by 'c'
-        then run in a testing environment
+        package.py unit tests are correctly found when no test name is provided (empty list)
         """
         self.inject_python_repo()
         context = ResolvedContext(["testing_obj", "python"])

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -308,4 +308,3 @@ class TestTest(TestBase, TempdirMixin):
             "failed",
             "command_as_string_fail did not fail",
         )
-


### PR DESCRIPTION
Fixes #1983

This patch will fix rez test call without any test name.
