### PR TITLE
Improvement move pkg cache fs calls to repo plugin

### DIFF
--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -405,7 +405,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            shutil.copytree(variant_root, rootpath)
+            variant.repository.cache_variant(variant, rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -405,7 +405,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            variant.repository.cache_variant(variant, rootpath)
+            variant.resource._cache(rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -410,7 +410,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            variant.resource._cache(rootpath)
+            variant.copy_payload(rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -410,7 +410,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            shutil.copytree(variant_root, rootpath)
+            variant.repository.cache_variant(variant, rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -410,7 +410,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            variant.repository.cache_variant(variant, rootpath)
+            variant.resource._cache(rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 import threading
 import os.path
 import time
+import shutil
 
 
 def get_package_repository_types():
@@ -509,6 +510,12 @@ class PackageRepository(object):
             Hashable value.
         """
         return (self.name(), self.location)
+
+    def cache_variant(self, variant, location):
+        """
+        Copy a variant from repository to cache location
+        """
+        shutil.copytree(variant.root, location)
 
 
 class PackageRepositoryManager(object):

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -14,6 +14,7 @@ import threading
 import os.path
 import time
 from typing import Any, Hashable, Iterator, TYPE_CHECKING
+import shutil
 
 if TYPE_CHECKING:
     from rez.package_resources import (PackageFamilyResource, PackageResource, PackageResourceHelper,
@@ -526,6 +527,12 @@ class PackageRepository(object):
             Hashable value.
         """
         return (self.name(), self.location)
+
+    def cache_variant(self, variant, location):
+        """
+        Copy a variant from repository to cache location
+        """
+        shutil.copytree(variant.root, location)
 
 
 class PackageRepositoryManager(object):

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -533,7 +533,7 @@ class PackageRepository(object):
         Args:
             variant_resource (VariantResource): VariantResource to be copied.
             path (str): Filesystem path to copy variant payload to.
-        
+
         Returns:
             bool: Should return True on success.
         """

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -14,7 +14,6 @@ import threading
 import os.path
 import time
 from typing import Any, Hashable, Iterator, TYPE_CHECKING
-import shutil
 
 if TYPE_CHECKING:
     from rez.package_resources import (PackageFamilyResource, PackageResource, PackageResourceHelper,

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -511,11 +511,17 @@ class PackageRepository(object):
         """
         return (self.name(), self.location)
 
-    def cache_variant(self, variant, location):
+    def copy_variant_payload(self, variant_resource, path):
         """
-        Copy a variant from repository to cache location
+        Copy a variants payload from repository to a directory location
+        Args:
+            variant_resource (VariantResource): VariantResource to be copied.
+            path (str): Filesystem path to copy variant payload to.
+        
+        Returns:
+            bool: Should return True on success.
         """
-        shutil.copytree(variant.root, location)
+        raise NotImplementedError
 
 
 class PackageRepositoryManager(object):

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -528,11 +528,17 @@ class PackageRepository(object):
         """
         return (self.name(), self.location)
 
-    def cache_variant(self, variant, location):
+    def copy_variant_payload(self, variant_resource, path):
         """
-        Copy a variant from repository to cache location
+        Copy a variants payload from repository to a directory location
+        Args:
+            variant_resource (VariantResource): VariantResource to be copied.
+            path (str): Filesystem path to copy variant payload to.
+        
+        Returns:
+            bool: Should return True on success.
         """
-        shutil.copytree(variant.root, location)
+        raise NotImplementedError
 
 
 class PackageRepositoryManager(object):

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -529,7 +529,7 @@ class VariantResourceHelper(VariantResource, metaclass=_Metas):
             subpath = self._subpath(ignore_shortlinks=ignore_shortlinks)
             root = os.path.join(self.base, subpath)
             return root
-        
+
     def _cache(self, path: str):
         return self._repository.copy_variant_payload(self, path)
 

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -529,6 +529,9 @@ class VariantResourceHelper(VariantResource, metaclass=_Metas):
             subpath = self._subpath(ignore_shortlinks=ignore_shortlinks)
             root = os.path.join(self.base, subpath)
             return root
+        
+    def _cache(self, path: str):
+        return self._repository.copy_variant_payload(self, path)
 
     @cached_property
     def variant_requires(self) -> list[Requirement]:

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -530,9 +530,6 @@ class VariantResourceHelper(VariantResource, metaclass=_Metas):
             root = os.path.join(self.base, subpath)
             return root
 
-    def _cache(self, path: str):
-        return self._repository.copy_variant_payload(self, path)
-
     @cached_property
     def variant_requires(self) -> list[Requirement]:
         index = self.index

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -497,6 +497,9 @@ class VariantResourceHelper(VariantResource, metaclass=_Metas):
             subpath = self._subpath(ignore_shortlinks=ignore_shortlinks)
             root = os.path.join(self.base, subpath)
             return root
+        
+    def _cache(self, path: str):
+        return self._repository.copy_variant_payload(self, path)
 
     @cached_property
     def variant_requires(self):

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -483,6 +483,21 @@ class Variant(PackageBaseResourceWrapper):
         else:
             return Variant(resource)
 
+    def copy_payload(self, path: str):
+        """Copy the variants payload to filesystem path.
+
+        If the package already exists, this variant will be correctly merged
+        into the package. If the variant already exists in this package, the
+        existing variant is returned.
+
+        Args:
+            path (str): Path to copy variant payload data.
+
+        Returns:
+            `bool` - Returns true on success
+        """
+        return self.repository.copy_variant_payload(self.resource, path)
+
     @property
     def _non_shortlinked_subpath(self) -> str:
         return self.resource._subpath(ignore_shortlinks=True)

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -122,7 +122,7 @@ class TestFilesystemRepoUriCaseSensitivity(TestBase, TempdirMixin):
 class TestFilesystemRepoCopyVariant(TestBase, TempdirMixin):
     """copy_variant_payload will copy a variants payload to dest path,
 
-    Test that it will not copy files that are in its payload, fail where required
+    Test that it will copy data that is in its payload, fail where required
     """
 
     @classmethod

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -6,6 +6,7 @@
 Test package repository plugin.
 """
 import unittest
+import os
 
 from rezplugins.package_repository import filesystem
 from rez.packages import create_package
@@ -39,3 +40,55 @@ class TestFilesystemPackageRepository(TestBase, TempdirMixin):
         pkg_repository._create_variant(variant, overrides={})
         with self.assertRaises(filesystem.PackageRepositoryError):
             pkg_repository._create_variant(case_mismatch_variant, overrides={})
+
+    def test_copy_variant_payload(self):
+        '''Test copy_variant_payload copies a variant payload to path'''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        package = create_package("copy_test1", data={})
+        variant = next(package.iter_variants())
+
+        fs_variant = variant.install(repo_path)
+        with open(os.path.join(fs_variant.root, 'payload.txt'), 'w'):
+            pass
+
+        pkg_repository.copy_variant_payload(fs_variant.resource, copy_target)
+
+        assert os.path.isfile(os.path.join(copy_target, 'payload.txt'))
+
+    def test_copy_variant_payload_wrong_resource(self):
+        '''Test copy_variant_payload failure
+        when a different repo variant resource is passed
+        '''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        mem_package = create_package("copy_test2", data={})
+        mem_variant = next(mem_package.iter_variants())
+
+        with self.assertRaises(filesystem.PackageRepositoryError):
+            pkg_repository.copy_variant_payload(mem_variant.resource, copy_target)
+
+    def test_copy_variant_payload_missing_root(self):
+        '''Test copy_variant_payload failure when a variant has missing root'''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        package = create_package("copy_test3", data={'variants': [['python']]})
+        variant = next(package.iter_variants())
+
+        fs_variant = variant.install(repo_path)
+ 
+        with self.assertRaises(filesystem.PackageRepositoryError):
+            pkg_repository.copy_variant_payload(fs_variant.resource, copy_target)
+

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -181,7 +181,6 @@ class TestFilesystemRepoCopyVariant(TestBase, TempdirMixin):
         variant = next(package.iter_variants())
 
         fs_variant = variant.install(repo_path)
- 
+
         with self.assertRaises(filesystem.PackageRepositoryError):
             pkg_repository.copy_variant_payload(fs_variant.resource, copy_target)
-

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -6,6 +6,7 @@
 Test package repository plugin.
 """
 import unittest
+import os
 
 from rezplugins.package_repository import filesystem
 from rez.packages import create_package
@@ -116,3 +117,71 @@ class TestFilesystemRepoUriCaseSensitivity(TestBase, TempdirMixin):
             "get_variant_from_uri returned None for %r — "
             "version '1.0B' was normcased to '1.0b' before lookup" % variant_uri,
         )
+
+
+class TestFilesystemRepoCopyVariant(TestBase, TempdirMixin):
+    """copy_variant_payload will copy a variants payload to dest path,
+
+    Test that it will not copy files that are in its payload, fail where required
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+        cls.settings = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def test_copy_variant_payload(self):
+        '''Test copy_variant_payload copies a variant payload to path'''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        package = create_package("copy_test1", data={})
+        variant = next(package.iter_variants())
+
+        fs_variant = variant.install(repo_path)
+        with open(os.path.join(fs_variant.root, 'payload.txt'), 'w'):
+            pass
+
+        pkg_repository.copy_variant_payload(fs_variant.resource, copy_target)
+
+        assert os.path.isfile(os.path.join(copy_target, 'payload.txt'))
+
+    def test_copy_variant_payload_wrong_resource(self):
+        '''Test copy_variant_payload failure
+        when a different repo variant resource is passed
+        '''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        mem_package = create_package("copy_test2", data={})
+        mem_variant = next(mem_package.iter_variants())
+
+        with self.assertRaises(filesystem.PackageRepositoryError):
+            pkg_repository.copy_variant_payload(mem_variant.resource, copy_target)
+
+    def test_copy_variant_payload_missing_root(self):
+        '''Test copy_variant_payload failure when a variant has missing root'''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        package = create_package("copy_test3", data={'variants': [['python']]})
+        variant = next(package.iter_variants())
+
+        fs_variant = variant.install(repo_path)
+ 
+        with self.assertRaises(filesystem.PackageRepositoryError):
+            pkg_repository.copy_variant_payload(fs_variant.resource, copy_target)
+

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -23,6 +23,7 @@ import unittest
 from rez.version import Version
 from rez.version import VersionError
 from rez.utils.filesystem import canonical_path
+from rezplugins.package_repository import filesystem
 import shutil
 import os.path
 import os
@@ -630,6 +631,43 @@ class TestMemoryPackages(TestBase):
         variant = next(package.iter_variants())
         parent_package = variant.parent
         self.assertEqual(parent_package.description, desc)
+
+
+class TestPackageCopyVariant(TestBase, TempdirMixin):
+    """Test variant.copy_payload will copy a variants payload to dest path,
+
+    Similar testing is done for package_repository.copy_variant_payload
+
+    This test confirms interface on variant is correct
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+        cls.settings = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def test_copy_variant_payload(self):
+        '''Test copy_payload copies a variant payload to path'''
+        repo_path = os.path.join(self.root, 'repo')
+        copy_target = os.path.join(self.root, 'copy_target')
+        
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
+
+        package = create_package("copy_test1", data={})
+        variant = next(package.iter_variants())
+
+        fs_variant = variant.install(repo_path)
+        with open(os.path.join(fs_variant.root, 'payload.txt'), 'w'):
+            pass
+
+        fs_variant.copy_payload(copy_target)
+
+        assert os.path.isfile(os.path.join(copy_target, 'payload.txt'))
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -23,7 +23,6 @@ import unittest
 from rez.version import Version
 from rez.version import VersionError
 from rez.utils.filesystem import canonical_path
-from rezplugins.package_repository import filesystem
 import shutil
 import os.path
 import os

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -654,9 +654,6 @@ class TestPackageCopyVariant(TestBase, TempdirMixin):
         '''Test copy_payload copies a variant payload to path'''
         repo_path = os.path.join(self.root, 'repo')
         copy_target = os.path.join(self.root, 'copy_target')
-        
-        pool = filesystem.ResourcePool(cache_size=None)
-        pkg_repository = filesystem.FileSystemPackageRepository(repo_path, pool)
 
         package = create_package("copy_test1", data={})
         variant = next(package.iter_variants())

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1020,6 +1020,18 @@ class FileSystemPackageRepository(PackageRepository):
 
         return path
 
+    def copy_variant_payload(self, variant_resource, path):
+        if not variant_resource.repository_type == self.name():
+            msg = f'{self.__class__} cant copy variant resource it doesnt own'
+            raise PackageRepositoryError(msg)
+
+        root = variant_resource.root
+        if not root and not os.path.isdir(root):
+            raise PackageRepositoryError('Variant root is missing')
+
+        shutil.copytree(root, path)
+        return True
+
     # -- internal
 
     def _get_family_dirs__key(self):

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1032,6 +1032,18 @@ class FileSystemPackageRepository(PackageRepository):
 
         return path
 
+    def copy_variant_payload(self, variant_resource, path):
+        if not variant_resource.repository_type == self.name():
+            msg = f'{self.__class__} cant copy variant resource it doesnt own'
+            raise PackageRepositoryError(msg)
+
+        root = variant_resource.root
+        if not root and not os.path.isdir(root):
+            raise PackageRepositoryError('Variant root is missing')
+
+        shutil.copytree(root, path)
+        return True
+
     # -- internal
 
     def _get_family_dirs__key(self) -> str:

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -13,6 +13,7 @@ import os.path
 import os
 import stat
 import time
+import shutil
 
 from rez.package_repository import PackageRepository
 from rez.package_resources import PackageFamilyResource, VariantResourceHelper, \
@@ -1038,7 +1039,7 @@ class FileSystemPackageRepository(PackageRepository):
             raise PackageRepositoryError(msg)
 
         root = variant_resource.root
-        if not root and not os.path.isdir(root):
+        if not isinstance(root, str) or not os.path.isdir(root):
             raise PackageRepositoryError('Variant root is missing')
 
         shutil.copytree(root, path)

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1026,7 +1026,7 @@ class FileSystemPackageRepository(PackageRepository):
             raise PackageRepositoryError(msg)
 
         root = variant_resource.root
-        if not root and not os.path.isdir(root):
+        if not isinstance(root, str) or not os.path.isdir(root):
             raise PackageRepositoryError('Variant root is missing')
 
         shutil.copytree(root, path)


### PR DESCRIPTION
This PR is an attempt to decouple the package cache operation to the repository plugins

This can allow users to customize how the package cache touches the filesystem on a per repository bases either via the cache_variant() call, or on the variant resource

Does this help with the artifact repo direction, could some remote repos use the current cache system via moving these functions to the repository plugin?

I personally would like a way to customize pkg cache operation via a custom filesystem plugin to optimize cache speeds
 