### PR TITLE
Apply correct schema on build_requires and private_build_requires to avoid crashes in rez-search

### DIFF
--- a/src/rez/package_search.py
+++ b/src/rez/package_search.py
@@ -87,11 +87,7 @@ def get_reverse_dependency_tree(package_name, depth=None, paths=None,
             )
 
         for req in requires:
-            if isinstance(req, str):
-                # Ignore negated requirements
-                if not req[0] == '!':
-                    lookup[req].add(package_name_)
-            elif not req.conflict:
+            if not req.conflict:
                 lookup[req.name].add(package_name_)
 
         bar.next()

--- a/src/rez/package_search.py
+++ b/src/rez/package_search.py
@@ -87,7 +87,11 @@ def get_reverse_dependency_tree(package_name, depth=None, paths=None,
             )
 
         for req in requires:
-            if not req.conflict:
+            if isinstance(req, str):
+                # Ignore negated requirements
+                if not req[0] == '!':
+                    lookup[req].add(package_name_)
+            elif not req.conflict:
                 lookup[req.name].add(package_name_)
 
         bar.next()

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -72,7 +72,9 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
     """Abstract base class for `Package` and `Variant`.
     """
     late_bind_schemas = {
-        "requires": late_requires_schema
+        "requires": late_requires_schema,
+        "build_requires": late_requires_schema,
+        "private_build_requires": late_requires_schema,
     }
 
     def __init__(self, resource, context=None):


### PR DESCRIPTION
Fixes #2003
Fixes #1766

Signed-off-by: Craig Zerouni <czerouni@gmail.com>
I was running `rez depends` on a number of packages, and some of them would crash Rez with the message:
```
AttributeError: 'str' object has no attribute 'conflict'
```
This happens in `package_search.py` where you have this loop:
```
for req in requires:
    if not req.conflict:
        lookup[req.name].add(package_name_)
```
The problem is that some requirements in that list are not of type `PackageRequest`, but instead are simply type `str`. This happens if in the `package.py` file of the package being queried there is a `private_build_requires` configured as a late-binding function. Eg, a package with this this pbr will not crash Rez
```
private_build_requires = ["foo"]
```
but this one will
```
@late()
def private_build_requires():
    return ["foo"]
```
I initially assumed this was a bug in the way these are handled, except that in the file `resolved_context.py` I see this comment:
```
Args:
    package_requests (list[typing.Union[str, PackageRequest]]): request
```
which leads me to think that requests of type `str` are expected. In which case, the fix is simple, as per this PR.
