### PR TITLE
Add base and root bindings to pre test command

### DIFF
--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -247,8 +247,9 @@ Pre Test Commands
 
 Sometimes it's useful to perform some extra configuration in the environment that a package's test
 will run in. You can define the :pkgdef:func:`pre_test_commands` function to do this. It will be invoked just
-before the test is run. As well as the standard :rex:attr:`this` object, a :rex:attr:`test` object is also
-provided to distinguish which test is about to run.
+before the test is run. As well as the standard :rex:attr:`this` object, the :rex:attr:`root` and
+:rex:attr:`base` variables of the package under test, and a :rex:attr:`test` object are also provided
+to distinguish which test is about to run.
 
 A Largish Example
 =================

--- a/src/rez/data/tests/builds/packages/testing_obj/1.0.0/package.py
+++ b/src/rez/data/tests/builds/packages/testing_obj/1.0.0/package.py
@@ -19,6 +19,10 @@ def commands() -> None:
     else:
         env.SKIP_LUNCH = "False"
 
+def pre_test_commands():
+    env.REZ_TEST_ROOT = root
+    env.REZ_TEST_BASE = base
+
 build_command = 'python {root}/build.py {install}'
 
 tests = {
@@ -38,5 +42,10 @@ tests = {
         # should we tested separately.
         "command": ["python", "-c", "import os; assert os.environ.get('SKIP_LUNCH') is not None"],
         "requires": ["python"]
+    },
+    "pre_test_commands_bindings": {
+        "command": ["python", "-c", "import os; assert os.environ.get('REZ_TEST_ROOT') is not None; assert os.environ.get('REZ_TEST_BASE') is not None"],
+        "requires": ["python"],
+        "run_on": "pre_test"
     }
 }

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -457,6 +457,8 @@ class PackageTestRunner(object):
 
                 with executor.reset_globals():
                     executor.bind("this", variant)
+                    executor.bind('root', variant.root)
+                    executor.bind('base', executor.normalize_path(package.base))
                     executor.bind("test", RO_AttrDictWrapper(test_ns))
                     executor.execute_code(pre_test_commands)
 

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -56,7 +56,7 @@ class TestTest(TestBase, TempdirMixin):
         for test_name in test_names:
             runner.run_test(test_name)
 
-        self.assertEqual(runner.test_results.num_tests, 4)
+        self.assertEqual(runner.test_results.num_tests, 5)
         self.assertEqual(
             self._get_test_result(runner, "check_car_ideas")["status"],
             "success",
@@ -76,6 +76,11 @@ class TestTest(TestBase, TempdirMixin):
             self._get_test_result(runner, "command_as_string_fail")["status"],
             "failed",
             "command_as_string_fail did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "pre_test_commands_bindings")["status"],
+            "success",
+            "pre_test_commands_bindings did not succeed",
         )
 
     def _get_test_result(self, runner, test_name):
@@ -169,12 +174,12 @@ class TestTest(TestBase, TempdirMixin):
         )
 
         test_names = runner.find_requested_test_names(["*"])
-        self.assertEqual(4, len(test_names))
+        self.assertEqual(5, len(test_names))
 
         for test_name in test_names:
             runner.run_test(test_name)
 
-        self.assertEqual(runner.test_results.num_tests, 4)
+        self.assertEqual(runner.test_results.num_tests, 5)
 
         self.assertEqual(
             self._get_test_result(runner, "check_car_ideas")["status"],
@@ -195,6 +200,11 @@ class TestTest(TestBase, TempdirMixin):
             self._get_test_result(runner, "command_as_string_fail")["status"],
             "failed",
             "command_as_string_fail did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "pre_test_commands_bindings")["status"],
+            "success",
+            "pre_test_commands_bindings did not succeed",
         )
 
     def test_wildcard_04(self):
@@ -252,17 +262,22 @@ class TestTest(TestBase, TempdirMixin):
         )
 
         test_names = runner.find_requested_test_names(["[!c]*"])
-        self.assertEqual(1, len(test_names))
+        self.assertEqual(2, len(test_names))
 
         for test_name in test_names:
             runner.run_test(test_name)
 
-        self.assertEqual(runner.test_results.num_tests, 1)
+        self.assertEqual(runner.test_results.num_tests, 2)
 
         self.assertEqual(
             self._get_test_result(runner, "move_meeting_to_noon")["status"],
             "failed",
             "move_meeting_to_noon did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "pre_test_commands_bindings")["status"],
+            "success",
+            "pre_test_commands_bindings did not succeed",
         )
 
     def test_empty_test_list(self):


### PR DESCRIPTION
Hey ! 

I found that on pre_test_command, "base" and "root" bindings were missing. 

They are still available with "{this.base}" or "{this.root}", however I think it's important to keep consistency between available callback inside package.py

Feel free to comment or ask me question :) 