### PR TITLE
Add a new setting called debug_shell_startup

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -479,6 +479,7 @@ config_schema = Schema({
     "debug_memcache":                               Bool,
     "debug_resolve_memcache":                       Bool,
     "debug_context_tracking":                       Bool,
+    "debug_shell_startup":                          Bool,
     "debug_all":                                    Bool,
     "debug_none":                                   Bool,
     "quiet":                                        Bool,

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -17,7 +17,7 @@ from rez.utils.formatting import columnise, PackageRequest, ENV_VAR_REGEX, \
 from rez.utils.data_utils import deep_del
 from rez.utils.filesystem import TempDirs, is_subdirectory, canonical_path
 from rez.utils.memcached import pool_memcached_connections
-from rez.utils.logging_ import print_error, print_warning
+from rez.utils.logging_ import print_debug, print_error, print_warning
 from rez.utils.which import which
 from rez.rex import RexExecutor, Python, OutputStyle, literal
 from rez.rex_bindings import VersionBinding, VariantBinding, \
@@ -1454,6 +1454,10 @@ class ResolvedContext(object):
 
         # write out the native context file
         context_code = executor.get_output()
+
+        if config.debug("shell_startup"):
+            print_debug("Writing context to %s" % context_file)
+
         with open(context_file, 'w', encoding="utf-8") as f:
             f.write(context_code)
 

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -744,6 +744,9 @@ debug_memcache = False
 # Print debugging info when an AMPQ server is used in context tracking
 debug_context_tracking = False
 
+# Print debugging info related to shell startup
+debug_shell_startup = False
+
 # Turn on all debugging messages
 debug_all = False
 

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -8,7 +8,7 @@ Pluggable API for creating subshells using different programs, such as bash.
 from rez.rex import RexExecutor, ActionInterpreter, OutputStyle
 from rez.util import shlex_join, is_non_string_iterable
 from rez.utils.which import which
-from rez.utils.logging_ import print_warning
+from rez.utils.logging_ import print_debug, print_warning
 from rez.utils.execution import Popen
 from rez.system import system
 from rez.exceptions import RezSystemError
@@ -404,6 +404,10 @@ class UnixShell(Shell):
         def _write_shell(ex, filename):
             code = ex.get_output()
             target_file = os.path.join(tmpdir, filename)
+
+            if config.debug("shell_startup"):
+                print_debug("Writing shell script to %s" % target_file)
+
             with open(target_file, 'w') as f:
                 f.write(code)
             return target_file
@@ -467,6 +471,9 @@ class UnixShell(Shell):
                                       print_msg=bind_rez)
                         _write_shell(ex, os.path.basename(file_))
 
+                    if config.debug("shell_startup"):
+                        print_debug("Setting $HOME for new shell to %s" % tmpdir)
+
                     executor.setenv("HOME", tmpdir)
 
                     # keep history
@@ -489,6 +496,10 @@ class UnixShell(Shell):
 
         code = executor.get_output()
         target_file = os.path.join(tmpdir, "rez-shell.%s" % self.file_extension())
+
+        if config.debug("shell_startup"):
+            print_debug("Writing rez-shell to %s" % target_file)
+
         with open(target_file, 'w') as f:
             f.write(code)
 
@@ -502,6 +513,9 @@ class UnixShell(Shell):
             else:
                 cmd = pre_command
         cmd.extend([self.executable, target_file])
+
+        if config.debug("shell_startup"):
+            print_debug("Launching shell with command: %s" % self.join(cmd))
 
         try:
             p = Popen(cmd, env=env, **Popen_args)

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -12,6 +12,7 @@ from rez.system import system
 from rez.utils.platform_ import platform_
 from rez.utils.execution import Popen
 from rez.util import shlex_join
+from rez.utils.logging_ import print_debug
 from .windows import get_syspaths_from_registry, to_windows_path
 
 
@@ -173,6 +174,9 @@ class PowerShellBase(Shell):
         target_file = os.path.join(tmpdir,
                                    "rez-shell.%s" % self.file_extension())
 
+        if config.debug("shell_startup"):
+            print_debug("Writing shell script to %s" % target_file)
+
         with open(target_file, 'w') as f:
             f.write(code)
 
@@ -199,6 +203,9 @@ class PowerShellBase(Shell):
 
         if shell_command is None:
             cmd.insert(1, "-NoExit")
+
+        if config.debug("shell_startup"):
+            print_debug("Launching shell with command: %s" % self.join(cmd))
 
         p = Popen(cmd, env=env, **Popen_args)
         return p

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -11,6 +11,7 @@ from rez.shells import Shell
 from rez.system import system
 from rez.utils.execution import Popen
 from rez.utils.platform_ import platform_
+from rez.utils.logging_ import print_debug
 from ._utils.windows import to_windows_path, get_syspaths_from_registry
 from functools import partial
 import os
@@ -172,6 +173,9 @@ class CMD(Shell):
         target_file = os.path.join(tmpdir, "rez-shell.%s"
                                    % self.file_extension())
 
+        if config.debug("shell_startup"):
+            print_debug("Writing shell script to %s" % target_file)
+
         with open(target_file, 'w') as f:
             f.write(code)
 
@@ -192,6 +196,9 @@ class CMD(Shell):
             cmd_flags = ['/Q', '/K']
         else:
             cmd_flags = ['/Q', '/C']
+
+        if config.debug("shell_startup"):
+            print_debug("Launching shell with command: %s" % self.join(cmd))
 
         cmd += [self.executable]
         cmd += cmd_flags

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -197,12 +197,13 @@ class CMD(Shell):
         else:
             cmd_flags = ['/Q', '/C']
 
-        if config.debug("shell_startup"):
-            print_debug("Launching shell with command: %s" % self.join(cmd))
-
         cmd += [self.executable]
         cmd += cmd_flags
         cmd += ['call {}'.format(target_file)]
+
+        if config.debug("shell_startup"):
+            print_debug("Launching shell with command: %s" % self.join(cmd))
+
         is_detached = (cmd[0] == 'START')
 
         p = Popen(cmd, env=env, shell=is_detached, **Popen_args)


### PR DESCRIPTION
Add a new setting called `debug_shell_startup`. When enabled, it logs information about the shell startup sequence.

This is kind of related to https://github.com/AcademySoftwareFoundation/rez/issues/2058. While helping on that issue, I noticed that it was hard the shell startup code was annoying to debug and more importantly, that part of rez doesn't have a lot of visibility. We don't visit that part very often. I thought that having some logs could help us and others better understand the general setup.

Here is how it looks on my machine:
```
$ REZ_DEBUG_SHELL_STARTUP=1 rez-env python
12:52:41 DEBUG    Writing context to /tmp/rez_context_cnmb7aaw/context.sh
12:52:41 DEBUG    Writing shell script to /tmp/rez_context_cnmb7aaw/.profile
12:52:41 DEBUG    Writing shell script to /tmp/rez_context_cnmb7aaw/.bash_profile
12:52:41 DEBUG    Writing shell script to /tmp/rez_context_cnmb7aaw/.bashrc
12:52:41 DEBUG    Setting $HOME for new shell to /tmp/rez_context_cnmb7aaw
12:52:41 DEBUG    Writing rez-shell to /tmp/rez_context_cnmb7aaw/rez-shell.sh
12:52:41 DEBUG    Launching shell with command: /usr/bin/bash /tmp/rez_context_cnmb7aaw/rez-shell.sh

You are now in a rez-configured environment.
...
...
```