### PR TITLE
Fix sphinx warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ Thanks to everybody who contributed and made all these features, bugfixes and im
 - Remove the note about Python 2.7 compatibility from the docs [\#1644](https://github.com/AcademySoftwareFoundation/rez/pull/1644) ([@vergeev](https://github.com/vergeev))
 - Add clear information on how to contact maintainers [\#1659](https://github.com/AcademySoftwareFoundation/rez/pull/1659) ([@JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
 - Installation instructions now include how to download rez [\#1660](https://github.com/AcademySoftwareFoundation/rez/pull/1660) ([@JeanChristopheMorinPerso](https://github.com/JeanChristopheMorinPerso))
-- Add development environment docs to [CONTRIBUTING.md](./CONTRIBUTING.md) [\#1633](https://github.com/AcademySoftwareFoundation/rez/pull/1633) ([@BryceGattis](https://github.com/BryceGattis))
+- Add development environment docs to `CONTRIBUTING.md` [\#1633](https://github.com/AcademySoftwareFoundation/rez/pull/1633) ([@BryceGattis](https://github.com/BryceGattis))
 - Improve clarity and expliciteness of `rez-env --command` flag help [\#1682](https://github.com/AcademySoftwareFoundation/rez/pull/1682) ([@BryceGattis](https://github.com/BryceGattis))
 - Add releasing packages documentation [\#1689](https://github.com/AcademySoftwareFoundation/rez/pull/1689) ([@BryceGattis](https://github.com/BryceGattis))
 - Improve clarify of early binding functions documentation [\#1677](https://github.com/AcademySoftwareFoundation/rez/pull/1677) ([@BryceGattis](https://github.com/BryceGattis))

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -455,8 +455,8 @@ def write_cli_documents(app: sphinx.application.Sphinx) -> None:
             help_str = re.sub(r"[^`]{2}(\*)[^`]{2}", r"\1", help_str)
 
             # Replace everything that looks like an argument with an option directive.
-            help_str = re.sub(r"(?<!\w)-[a-zA-Z](?=\s|\/|\)|\.?$)|(?<!\w)--[a-zA-Z-0-9]+(?=\s|\/|\)|\.?$)", r":option:`\g<0>`", help_str)
-            help_str = re.sub(r"[^`]{2}(--)", "\\--", help_str)
+            help_str = re.sub(r"(?<!\w)-[a-zA-Z](?![\w=])(?=\s|\/|\)|\.?)|(?<!\w)--[a-zA-Z-0-9]+(?![\w=])(?=\s|\/|\)|\.?)", r":option:`\g<0>`", help_str)
+            help_str = re.sub(r"[^` ]{2}(--)", "\\--", help_str)
 
             # Options have the option_strings set, positional arguments don't
             name = action.option_strings

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -114,9 +114,7 @@ class FixedPyTypeAlias(DomainAwareMixin, PyTypeAlias):
 
 class BareNamePythonDomain(sphinx.domains.python.PythonDomain):
     """
-    A Python-like domain that:
-    1. Uses fixed directives that register objects in the correct domain
-    2. Falls back to bare-name resolution when qualified name resolution fails
+    A Python-like domain that
     """
 
     # Override directives to use the fixed versions

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -8,13 +8,11 @@ import rez.rezconfig
 import docutils.nodes
 import sphinx.util.nodes
 import sphinx.application
-import sphinx.environment
 import sphinx.util.logging
 import sphinx.util.docutils
 import sphinx.domains
 import sphinx.domains.python
 import docutils.statemachine
-from sphinx.domains.python._object import PyObject
 from sphinx.domains.python import (
     PyFunction,
     PyVariable,

--- a/docs/source/basic_concepts.rst
+++ b/docs/source/basic_concepts.rst
@@ -121,7 +121,7 @@ of each attribute):
       env.PYTHONPATH.append("{root}/python")
       env.PATH.append("{root}/bin")
 
-The :attr:`requires` section defines the requirements of the package. The :func:`commands` section describes
+The :pkgdef:attr:`requires` section defines the requirements of the package. The :pkgdef:func:`commands` section describes
 what happens when this package is added to an environment. Here, the ``bin`` directory in the package
 installation is appended to ``PATH``, and similarly the ``python`` subdirectory is appended to
 ``PYTHONPATH``.
@@ -207,7 +207,7 @@ environment variable.
 Package Commands
 ================
 
-The :func:`commands` section of the package definition determines how the environment is configured in
+The :pkgdef:func:`commands` section of the package definition determines how the environment is configured in
 order to use it. It is a python function, but note that if any imports are used, they must appear
 within the body of this function.
 
@@ -220,7 +220,7 @@ Consider this commands example:
       env.PATH.append("{root}/bin")
 
 This is a typical example, where a package adds its source path to ``PYTHONPATH``, and its tools to
-``PATH``. See :doc:`here <package_commands>` for details on what can be done within the :func:`commands` section,
+``PATH``. See :doc:`here <package_commands>` for details on what can be done within the :pkgdef:func:`commands` section,
 as well as details on what order package commands are executed in.
 
 .. _package-requests-concept:

--- a/docs/source/building_packages.rst
+++ b/docs/source/building_packages.rst
@@ -31,12 +31,12 @@ The Build Environment
 The build environment is a rez resolved environment. Its requirement list is
 constructed like so:
 
-* First, the package's :attr:`requires` list is used;
-* Then, the package's :attr:`build_requires` is
-  appended. This is transitive, meaning that the :attr:`build_requires` of all other packages in the
+* First, the package's :pkgdef:attr:`requires` list is used;
+* Then, the package's :pkgdef:attr:`build_requires` is
+  appended. This is transitive, meaning that the :pkgdef:attr:`build_requires` of all other packages in the
   environment are also used;
-* Then, the package's :attr:`private_build_requires`
-  is appended (unlike :attr:`build_requires`, it is not transitive).
+* Then, the package's :pkgdef:attr:`private_build_requires`
+  is appended (unlike :pkgdef:attr:`build_requires`, it is not transitive).
 * Finally, if the package has variants, the current variant's requirements are
   appended.
 
@@ -53,12 +53,12 @@ example: a C++ project may need to builds its docs using doxygen, but once the d
 generated, doxygen is no longer needed.
 
 This is achieved by listing build-time dependencies under a
-:attr:`build_requires` or :attr:`private_build_requires`
-section in the ``package.py``. The requirements in :attr:`private_build_requires` are only used
-from the package being built. Requirements from :attr:`build_requires` however are transitive, build
+:pkgdef:attr:`build_requires` or :pkgdef:attr:`private_build_requires`
+section in the ``package.py``. The requirements in :pkgdef:attr:`private_build_requires` are only used
+from the package being built. Requirements from :pkgdef:attr:`build_requires` however are transitive, build
 requirements from all packages in the build environment are included.
 
-Some example :attr:`private_build_requires` use cases include:
+Some example :pkgdef:attr:`private_build_requires` use cases include:
 
 * Documentation generators such as ``doxygen`` or ``sphinx``;
 * Build utilities. For example, you may have a package called ``pyqt_cmake_utils``, which
@@ -66,7 +66,7 @@ Some example :attr:`private_build_requires` use cases include:
 * Statically linked libraries (since the library is linked at build time, the package
   is not needed at runtime).
 
-An example use case of :attr:`build_requires` is a header-only (hpp) C++ library. If your own
+An example use case of :pkgdef:attr:`build_requires` is a header-only (hpp) C++ library. If your own
 C++ package includes this library in its own headers, other packages will also need this
 library at build time (since they may include your headers, which in turn include the
 hpp headers).
@@ -84,9 +84,9 @@ Having said that, `CMake <https://cmake.org/>`_ has been supported by rez for so
 decent amount of utility code to manage CMake builds.
 
 When a rez environment is configured, each required package's
-:func:`~commands` section configures the environment for the building
+:pkgdef:func:`~commands` section configures the environment for the building
 package to use. When a build is occurring, a special variable
-:attr:`building` is set to ``True``. Your required packages should use this
+:rex:attr:`building` is set to ``True``. Your required packages should use this
 variable to communicate build information to the package being built.
 
 For example, our ``boost`` package's commands might look like so:
@@ -99,8 +99,8 @@ For example, our ``boost`` package's commands might look like so:
          env.CMAKE_MODULE_PATH.append("{root}/cmake")
 
 .. warning::
-   Note that :func:`commands` is never executed for the package actually being built.
-   If you want to run commands in that case, you can use :func:`pre_build_commands` instead.
+   Note that :pkgdef:func:`commands` is never executed for the package actually being built.
+   If you want to run commands in that case, you can use :pkgdef:func:`pre_build_commands` instead.
 
 A (very simple) ``FindBoost.cmake`` file might look like this:
 
@@ -161,7 +161,7 @@ Custom Build Commands
 
 As well as detecting the build system from build files, a package can explicitly
 specify its own build command, using the
-:attr:`build_command` package attribute. If present,
+:pkgdef:attr:`build_command` package attribute. If present,
 this takes precedence over other detected build systems.
 
 For example, consider the following ``package.py`` snippet:

--- a/docs/source/caching.rst
+++ b/docs/source/caching.rst
@@ -107,12 +107,12 @@ Package caching is not enabled by default. To enable it, you need to configure
 store the cache in.
 
 You also have granular control over whether an individual package will or will
-not be cached. To make a package cachable, you can set :attr:`cachable`
+not be cached. To make a package cachable, you can set :pkgdef:attr:`cachable`
 to False in its package definition file. Reasons you may *not* want to do this include
 packages that are large, or that aren't relocatable because other compiled packages are
 linked to them in a way that doesn't support library relocation.
 
-There are also config settings that affect cachability in the event that :attr:`cachable`
+There are also config settings that affect cachability in the event that :pkgdef:attr:`cachable`
 is not defined in a package's definition. For example, see
 :data:`default_cachable`, :data:`default_cachable_per_package`
 and :data:`default_cachable_per_repository`.

--- a/docs/source/caching.rst
+++ b/docs/source/caching.rst
@@ -108,7 +108,7 @@ store the cache in.
 
 You also have granular control over whether an individual package will or will
 not be cached. To make a package cachable, you can set :pkgdef:attr:`cachable`
-to False in its package definition file. Reasons you may *not* want to do this include
+to True in its package definition file. Reasons you may *not* want to do this include
 packages that are large, or that aren't relocatable because other compiled packages are
 linked to them in a way that doesn't support library relocation.
 

--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -76,10 +76,10 @@ Later, you can read the context back again, to reconstruct the same environment:
 Contexts do not store a copy of the environment that is configured (that is, the
 environment variables exported, for example). A context just stores the resolved
 list of packages that need to be applied in order to configure the environment.
-When you load a context via :option:`rez-env --input`, each of the packages' :attr:`commands`
+When you load a context via :option:`rez-env --input`, each of the packages' :pkgdef:attr:`commands`
 sections are interpreted once more.
 
-You can think of package :attr:`commands` like fragments of a wrapper script which
+You can think of package :pkgdef:attr:`commands` like fragments of a wrapper script which
 configures an environment. By creating a context, you are creating a list of
 script fragments which, when run in serial, produce the target environment. So,
 if your package added a path to ``$PATH`` which included a reference to ``$USER``

--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -76,10 +76,10 @@ Later, you can read the context back again, to reconstruct the same environment:
 Contexts do not store a copy of the environment that is configured (that is, the
 environment variables exported, for example). A context just stores the resolved
 list of packages that need to be applied in order to configure the environment.
-When you load a context via :option:`rez-env --input`, each of the packages' :pkgdef:attr:`commands`
+When you load a context via :option:`rez-env --input`, each of the packages' :pkgdef:func:`commands`
 sections are interpreted once more.
 
-You can think of package :pkgdef:attr:`commands` like fragments of a wrapper script which
+You can think of package :pkgdef:func:`commands` like fragments of a wrapper script which
 configures an environment. By creating a context, you are creating a list of
 script fragments which, when run in serial, produce the target environment. So,
 if your package added a path to ``$PATH`` which included a reference to ``$USER``

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -71,7 +71,7 @@ These are variables that rez generates within a resolved environment (a "context
 .. envvar:: REZ_CONTEXT_FILE
 
    Filepath of the current context's shell code that is the result of all the
-   resolved packages :func:`commands`'s sections.
+   resolved packages :pkgdef:func:`commands`'s sections.
 
 Package environment variables
 -----------------------------
@@ -160,8 +160,8 @@ to context environment variables listed :ref:`here <context-environment-variable
 
 .. envvar:: REZ_BUILD_REQUIRES
 
-   Space-separated list of requirements for the build - comes from the current package's :attr:`requires`,
-   :attr:`build_requires` and :attr:`private_build_requires` attributes, including the current variant's requirements.
+   Space-separated list of requirements for the build - comes from the current package's :pkgdef:attr:`requires`,
+   :pkgdef:attr:`build_requires` and :pkgdef:attr:`private_build_requires` attributes, including the current variant's requirements.
 
 .. envvar:: REZ_BUILD_REQUIRES_UNVERSIONED
 

--- a/docs/source/ephemerals.rst
+++ b/docs/source/ephemerals.rst
@@ -64,7 +64,7 @@ Environment Variables
 =====================
 
 Ephemerals do not affect the runtime in the way that packages can (via their
-:func:`commands` section), however some environment variables are set:
+:pkgdef:func:`commands` section), however some environment variables are set:
 
 * :envvar:`REZ_USED_EPH_RESOLVE`
 * :envvar:`REZ_EPH_(PKG)_REQUEST`
@@ -84,9 +84,9 @@ Introspection
 =============
 
 In order for a package to inspect the ephemerals that are present in a runtime,
-there is an :attr:`ephemerals` object provided, similar
-to the :attr:`resolve` object. You would typically use the
-:func:`intersects` function to inspect it, like so:
+there is an :rex:attr:`ephemerals` object provided, similar
+to the :rex:attr:`resolve` object. You would typically use the
+:rex:func:`intersects` function to inspect it, like so:
 
 .. code-block:: python
 
@@ -98,13 +98,13 @@ to the :attr:`resolve` object. You would typically use the
 In this example, the given package would set the ``TRACKING_ENABLED`` environment
 variable if an ephemeral such as ``.enable_tracking-1`` (or ``.enable_tracking-1.2+``
 etc) is present in the resolve. Note that the leading ``.`` is implied and not
-included when querying the :attr:`ephemerals` object.
+included when querying the :rex:attr:`ephemerals` object.
 
 .. warning::
-   Since :attr:`ephemerals` is a dict-like object, so it has
+   Since :rex:attr:`ephemerals` is a dict-like object, so it has
    a ``get`` function which will return a full request string if key exists. Hence,
    the default value should also be a full request string, not just a version range
-   string like ``0`` in :func:`ephemerals.get_range`. Or :func:`intersects` may not work as expect.
+   string like ``0`` in :rex:func:`ephemerals.get_range`. Or :rex:func:`intersects` may not work as expect.
 
 Ephemeral Use Cases
 ===================

--- a/docs/source/managing_packages.rst
+++ b/docs/source/managing_packages.rst
@@ -97,7 +97,7 @@ Copying packages is enabled by default, however you're also able to specify whic
 packages are and are not *relocatable*, for much the same reasons as given
 :ref:`here <enabling-package-caching>`.
 
-You can mark a package as non-relocatable by setting :attr:`relocatable`
+You can mark a package as non-relocatable by setting :pkgdef:attr:`relocatable`
 to ``False`` in its package definition file. There are also config settings that affect relocatability
 in the event that relocatable is not defined in a package's definition. For example,
 see :data:`default_relocatable`, :data:`default_relocatable_per_package`
@@ -143,7 +143,7 @@ Via API:
    None
 
 Be aware that a non-relocatable package is also not movable (see
-:attr:`here <relocatable>`. Like package
+:pkgdef:attr:`here <relocatable>`. Like package
 copying, there is a ``force`` option to move it regardless.
 
 A typical reason you might want to move a package is to archive packages that are

--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -2,7 +2,7 @@
 Package commands
 ================
 
-Package definition files (``package.py``) usually define a :func:`.commands` section. This is a python
+Package definition files (``package.py``) usually define a :pkgdef:func:`.commands` section. This is a python
 function that determines how the environment is configured in order to include the package.
 
 Consider the simple example:
@@ -16,13 +16,13 @@ Consider the simple example:
 This is a typical case, where a package adds its source path to ``PYTHONPATH``, and its tools to
 ``PATH``. The ``{root}`` string expands to the installation directory of the package.
 
-When a rez environment is configured, every package in the resolve list has its :func:`.commands` section
+When a rez environment is configured, every package in the resolve list has its :pkgdef:func:`.commands` section
 interpreted and converted into shell code (the language, bash or other, depends on the platform
 and is extensible). The resulting shell code is sourced, and this configures the environment.
 Within a configured environment, the variable :envvar:`REZ_CONTEXT_FILE` points at this shell code, and the
 command :option:`rez-context --interpret` prints it.
 
-The python API that you use in the :func:`.commands` section is called ``rex`` (**R**\ez **EX**\ecution language). It
+The python API that you use in the :pkgdef:func:`.commands` section is called ``rex`` (**R**\ez **EX**\ecution language). It
 is an API for performing shell operations in a shell-agnostic way. Some common operations you would
 perform with this API include setting environment variables, and appending/prepending path-like
 environment variables.
@@ -32,7 +32,7 @@ environment variables.
    are left unaltered. There will typically be many system variables that are left unchanged.
 
 .. warning:: 
-   If you need to import any python modules to use in a :func:`.commands`
+   If you need to import any python modules to use in a :pkgdef:func:`.commands`
    section, the import statements **must** be done inside that function.
 
 .. _package-commands-order-of-execution:
@@ -59,7 +59,7 @@ For example, consider the request:
    ]$ rez-env maya_anim_tool-1.3+ PyYAML-3.10 maya-2015
 
 Assuming that ``PyYAML`` depends on ``python``, and ``maya_anim_tool`` depends on ``maya``, then the
-resulting :func:`.commands` execution order would be:
+resulting :pkgdef:func:`.commands` execution order would be:
 
 * maya;
 * maya_anim_tool;
@@ -107,15 +107,15 @@ String Expansion
 Object Expansion
 ----------------
 
-Any of the objects available to you in a :func:`commands` section can be referred to in formatted strings
-that are passed to rex functions such as :func:`setenv` and so on. For example, consider the code:
+Any of the objects available to you in a :pkgdef:func:`commands` section can be referred to in formatted strings
+that are passed to rex functions such as :rex:func:`setenv` and so on. For example, consider the code:
 
 .. code-block:: python
 
    appendenv("PATH", "{root}/bin")
 
-Here, ``{root}`` will expand out to the value of :attr:`root`, which is the installation path of the
-package (:attr:`this.root` could also have been used).
+Here, ``{root}`` will expand out to the value of :rex:attr:`root`, which is the installation path of the
+package (:rex:attr:`this.root` could also have been used).
 
 You don't *have* to use this feature. It is provided as a convenience. For example, the following
 code is equivalent to the previous example, and is just as valid (but more verbose):
@@ -125,7 +125,7 @@ code is equivalent to the previous example, and is just as valid (but more verbo
    import os.path
    appendenv("PATH", os.path.join(root, "bin"))
 
-Object string expansion is also supported when setting an environment variable via the :attr:`env` object:
+Object string expansion is also supported when setting an environment variable via the :rex:attr:`env` object:
 
 .. code-block:: python
 
@@ -140,16 +140,16 @@ and ``${FOO}`` are supported, regardless of the syntax supported by the target s
 Literal Strings
 ---------------
 
-You can use the :func:`literal` function to inhibit object and environment variable string
+You can use the :rex:func:`literal` function to inhibit object and environment variable string
 expansion. For example, the following code will set the environment variable to the literal string:
 
 .. code-block:: python
 
    env.TEST = literal("this {root} will not expand")
 
-There is also an :func:`expandable` function, which matches the default behavior. You wouldn't typically
+There is also an :rex:func:`expandable` function, which matches the default behavior. You wouldn't typically
 use this function. However, you can define a string containing literal and expandable parts by
-chaining together :func:`literal` and :func:`expandable`:
+chaining together :rex:func:`literal` and :rex:func:`expandable`:
 
 .. code-block:: python
 
@@ -161,18 +161,18 @@ Explicit String Expansion
 -------------------------
 
 Object string expansion usually occurs **only** when a string is passed to a rex function, or to
-the :attr:`env` object. For example the simple statement ``var = "{root}/bin"`` would not expand ``{root}``
-into ``var``. However, you can use the :func:`expandvars` function to enable this behavior
+the :rex:attr:`env` object. For example the simple statement ``var = "{root}/bin"`` would not expand ``{root}``
+into ``var``. However, you can use the :rex:func:`expandvars` function to enable this behavior
 explicitly:
 
 .. code-block:: python
 
    var = expandvars("{root}/bin")
 
-The :func:`expandvars` and :func:`expandable` functions are slightly different. :func:`expandable` will generate a
-shell variable assignment that will expand out while :func:`expandvars` will expand the value immediately.
+The :rex:func:`expandvars` and :rex:func:`expandable` functions are slightly different. :rex:func:`expandable` will generate a
+shell variable assignment that will expand out while :rex:func:`expandvars` will expand the value immediately.
 
-This table illustrates the difference between :func:`literal`, :func:`expandable` and :func:`expandvars`:
+This table illustrates the difference between :rex:func:`literal`, :rex:func:`expandable` and :rex:func:`expandvars`:
 
 =================================== =======================
 Package command                     Equivalent bash command
@@ -216,15 +216,15 @@ Pre And Post Commands
 =====================
 
 Occasionally, it's useful for a package to run commands either before or after all other packages,
-regardless of the command execution order rules. This can be achieved by defining a :func:`pre_commands`
-or :func:`post_commands` function. A package can have any, all or none of :func:`pre_commands`, :func:`commands` and
-:func:`post_commands` defined, although it is very common for a package to define just :func:`commands`.
+regardless of the command execution order rules. This can be achieved by defining a :pkgdef:func:`pre_commands`
+or :pkgdef:func:`post_commands` function. A package can have any, all or none of :pkgdef:func:`pre_commands`, :pkgdef:func:`commands` and
+:pkgdef:func:`post_commands` defined, although it is very common for a package to define just :pkgdef:func:`commands`.
 
 The order of command execution is:
 
-* All package :func:`pre_commands` are executed, in standard execution order;
-* Then, all package :func:`commands` are executed, in standard execution order;
-* Then, all package :func:`post_commands` are executed, in standard execution order.
+* All package :pkgdef:func:`pre_commands` are executed, in standard execution order;
+* Then, all package :pkgdef:func:`commands` are executed, in standard execution order;
+* Then, all package :pkgdef:func:`post_commands` are executed, in standard execution order.
 
 .. _pre-build-commands:
 
@@ -236,9 +236,9 @@ not present in its own build environment! However, sometimes there is a need to 
 specifically for the package being built. For example, you may wish to set some environment
 variables to pass information along to the build system.
 
-The :func:`pre_build_commands` function does just this. It is called prior to the build. Note that info
+The :pkgdef:func:`pre_build_commands` function does just this. It is called prior to the build. Note that info
 about the current build (such as the installation path) is available in a
-:attr:`build` object (other commands functions do not have this object visible).
+:rex:attr:`build` object (other commands functions do not have this object visible).
 
 .. _pre-test-commands:
 
@@ -246,14 +246,14 @@ Pre Test Commands
 =================
 
 Sometimes it's useful to perform some extra configuration in the environment that a package's test
-will run in. You can define the :func:`pre_test_commands` function to do this. It will be invoked just
-before the test is run. As well as the standard :attr:`this` object, a :attr:`test` object is also
+will run in. You can define the :pkgdef:func:`pre_test_commands` function to do this. It will be invoked just
+before the test is run. As well as the standard :rex:attr:`this` object, a :rex:attr:`test` object is also
 provided to distinguish which test is about to run.
 
 A Largish Example
 =================
 
-Here is an example of a package definition with a fairly lengthy :func:`commands` section:
+Here is an example of a package definition with a fairly lengthy :pkgdef:func:`commands` section:
 
 .. code-block:: python
 
@@ -297,14 +297,14 @@ Here is an example of a package definition with a fairly lengthy :func:`commands
 Objects
 =======
 
-Various objects and functions are available to use in the :func:`commands` function (as well as
-:func:`pre_commands` and :func:`post_commands`).
+Various objects and functions are available to use in the :pkgdef:func:`commands` function (as well as
+:pkgdef:func:`pre_commands` and :pkgdef:func:`post_commands`).
 
 Following is a list of the objects and functions available.
 
 .. .. currentmodule:: pkgdefrex
 
-.. py:function:: alias()
+.. rex:function:: alias()
 
    Create a command alias.
 
@@ -315,16 +315,16 @@ Following is a list of the objects and functions available.
    .. note::
       In ``bash``, aliases are implemented as bash functions.
 
-.. py:attribute:: base
+.. rex:attribute:: base
    :type: str
 
-   See :attr:`this.base`.
+   See :rex:attr:`this.base`.
 
-.. py:attribute:: build
+.. rex:attribute:: build
 
    This is a dict like object. Each key can also be accessed as attributes.
 
-   This object is only available in the :func:`pre_build_commands`
+   This object is only available in the :pkgdef:func:`pre_build_commands`
    function. It has the following fields:
 
    .. code-block:: python
@@ -335,38 +335,38 @@ Following is a list of the objects and functions available.
       if build['build_type'] == 'local':
          pass
 
-.. py:attribute:: build.build_type
+.. rex:attribute:: build.build_type
    :type: typing.Literal['local', 'central']
 
    One of ``local``, ``central``. The type is ``central`` if a package release is occurring, and ``local``
    otherwise.
 
-.. py:attribute:: build.install
+.. rex:attribute:: build.install
    :type: bool
 
    True if an installation is taking place, False otherwise.
 
-.. py:attribute:: build.build_path
+.. rex:attribute:: build.build_path
    :type: str
 
    Path to the build directory (not the installation path). This will typically reside somewhere
    within the ``./build`` subdirectory of the package being built.
 
-.. py:attribute:: build.install_path
+.. rex:attribute:: build.install_path
    :type: str
 
    Installation directory. Note that this will be set, even if an installation is **not** taking place.
 
    .. warning::
-      Do not check this variable to detect if an installation is occurring. Use :attr:`build.install` instead.
+      Do not check this variable to detect if an installation is occurring. Use :rex:attr:`build.install` instead.
 
-.. py:attribute:: building
+.. rex:attribute:: building
    :type: bool
 
    This boolean variable is ``True`` if a build is occurring (typically done via the :ref:`rez-build` tool),
    and ``False`` otherwise.
    
-   However, the :func:`commands` block is only executed when the package is brought
+   However, the :pkgdef:func:`commands` block is only executed when the package is brought
    into a resolved environment, so this is not used when the package itself is building. Typically a
    package will use this variable to set environment variables that are only useful during when other
    packages are being built. C++ header include paths are a good example.
@@ -376,7 +376,7 @@ Following is a list of the objects and functions available.
       if building:
          env.FOO_INCLUDE_PATH = "{root}/include"
 
-.. py:function:: command(arg: str)
+.. rex:function:: command(arg: str)
 
    Run an arbitrary shell command.
 
@@ -405,7 +405,7 @@ Following is a list of the objects and functions available.
          if os.path.exists(path):
                shutil.rmtree(path)
 
-.. py:function:: comment(arg: str)
+.. rex:function:: comment(arg: str)
 
    Creates a comment line in the converted shell script code. This is only visible if the user views
    the current shell's code using the command :option:`rez-context --interpret` or looks at the file
@@ -419,7 +419,7 @@ Following is a list of the objects and functions available.
          alias("nuke", "foo_nuke_replacer")
 
 
-.. py:function:: defined(envvar: str) -> bool
+.. rex:function:: defined(envvar: str) -> bool
 
    Use this boolean function to determine whether or not an environment variable is set.
 
@@ -428,7 +428,7 @@ Following is a list of the objects and functions available.
       if defined("REZ_MAYA_VERSION"):
          env.FOO_MAYA = 1
 
-.. py:attribute:: env
+.. rex:attribute:: env
    :type: dict
 
    The ``env`` object represents the environment dict of the configured environment. Environment variables
@@ -436,7 +436,7 @@ Following is a list of the objects and functions available.
    
    .. note::
       Note that this is different from the standard python :data:`os.environ` dict, which represents the current environment,
-      not the one being configured. If a prior package's :func:`commands` sets a variable via the ``env`` object,
+      not the one being configured. If a prior package's :pkgdef:func:`commands` sets a variable via the ``env`` object,
       it will be visible only via ``env``, not :data:`os.environ`. The :data:`os.environ` dict hasn't been updated because the target
       configured environment does not yet exist!
 
@@ -445,7 +445,7 @@ Following is a list of the objects and functions available.
       env.FOO_DEBUG = 1
       env["BAH_LICENSE"] = "/lic/bah.lic"
 
-.. py:function:: env.append(value: str)
+.. rex:function:: env.append(value: str)
 
    Appends a value to an environment variable. By default this will use the :data:`os.pathsep` delimiter
    between list items, but this can be overridden using the config setting :data:`env_var_separators`. See
@@ -455,15 +455,15 @@ Following is a list of the objects and functions available.
 
       env.PATH.append("{root}/bin")
 
-.. py:function:: env.prepend(value: str)
+.. rex:function:: env.prepend(value: str)
 
-   Like :func:`env.append`, but prepends the environment variable instead.
+   Like :rex:func:`env.append`, but prepends the environment variable instead.
 
    .. code-block:: python
 
       env.PYTHONPATH.prepend("{root}/python")
 
-.. py:attribute:: ephemerals
+.. rex:attribute:: ephemerals
 
    A dict like object representing the list of ephemerals in the resolved environment. Each item is a
    string (the full request, eg ``.foo.cli-1``), keyed by the ephemeral package name. Note
@@ -477,9 +477,9 @@ Following is a list of the objects and functions available.
       if "foo.cli" in ephemerals:
          info("Foo cli option is being specified!")
 
-.. py:function:: ephemerals.get_range(name: str, range_: str) -> ~rez.version.VersionRange
+.. rex:function:: ephemerals.get_range(name: str, range_: str) -> ~rez.version.VersionRange
 
-   Use ``get_range`` to test with the :func:`intersects` function.
+   Use ``get_range`` to test with the :rex:func:`intersects` function.
    Here, we enable ``foo``'s commandline tools by default, unless explicitly disabled via
    a request for ``.foo.cli-0``:
 
@@ -489,28 +489,28 @@ Following is a list of the objects and functions available.
          info("Enabling foo cli tools")
          env.PATH.append("{root}/bin")
 
-.. py:function:: error(message: str)
+.. rex:function:: error(message: str)
 
    Prints to standard error.
 
    .. note::
       This function just prints the error, it does not prevent the target
-      environment from being constructed (use the :func:`stop`) command for that).
+      environment from being constructed (use the :rex:func:`stop`) command for that).
 
    .. code-block:: python
 
       if "PyQt" in resolve:
          error("The floob package has problems running in combo with PyQt")
 
-.. py:function:: expandable(arg: str) -> ~rez.rex.EscapedString
+.. rex:function:: expandable(arg: str) -> ~rez.rex.EscapedString
 
    See :ref:`explicit-string-expansion`.
 
-.. py:function:: expandvars(arg: str)
+.. rex:function:: expandvars(arg: str)
 
    See :ref:`explicit-string-expansion`.
 
-.. py:function:: getenv(envvar: str)
+.. rex:function:: getenv(envvar: str)
 
    Gets the value of an environment variable.
 
@@ -519,11 +519,11 @@ Following is a list of the objects and functions available.
       if getenv("REZ_MAYA_VERSION") == "2016.sp1":
          pass
 
-   :raises RexUndefinedVariableError: if the environment variable is not set.
+   :raises rex:exc:`RexUndefinedVariableError`: if the environment variable is not set.
 
-.. py:attribute:: implicits
+.. rex:attribute:: implicits
 
-   A dict like object that is similar to the :attr:`request` object, but it contains only the package request as
+   A dict like object that is similar to the :rex:attr:`request` object, but it contains only the package request as
    defined by the :data:`implicit_packages` configuration setting.
 
    .. code-block:: python
@@ -531,7 +531,7 @@ Following is a list of the objects and functions available.
       if "platform" in implicits:
          pass
 
-.. py:function:: info(message: str)
+.. rex:function:: info(message: str)
 
    Prints to standard out.
 
@@ -539,7 +539,7 @@ Following is a list of the objects and functions available.
 
       info("floob version is %s" % resolve.floob.version)
 
-.. py:function:: intersects(range1: str | ~rez.version.VersionRange | ~rez.rex_bindings.VariantBinding | ~rez.rex_bindings.VersionBinding, range2: str) -> bool
+.. rex:function:: intersects(range1: str | ~rez.version.VersionRange | ~rez.rex_bindings.VariantBinding | ~rez.rex_bindings.VersionBinding, range2: str) -> bool
 
    A boolean function that returns True if the version or version range of the given
    object, intersects with the given version range. Valid objects to query include:
@@ -562,7 +562,7 @@ Following is a list of the objects and functions available.
 
       If ``foo.cli`` is not present, this will unexpectedly compare the unversioned
       package named ``0`` against the version range ``1``, which will succeed! Use
-      :func:`ephemerals.get_range` and ``request.get_range`` functions instead:
+      :rex:func:`ephemerals.get_range` and ``request.get_range`` functions instead:
 
       .. code-block:: python
 
@@ -576,7 +576,7 @@ Following is a list of the objects and functions available.
       if intersects(resolve.maya, "2019+"):
          info("Maya 2019 or greater is present")
 
-.. py:function:: literal(arg: str) -> ~rez.rex.EscapedString
+.. rex:function:: literal(arg: str) -> ~rez.rex.EscapedString
 
    Inhibits expansion of object and environment variable references.
 
@@ -584,17 +584,17 @@ Following is a list of the objects and functions available.
 
       env.FOO = literal("this {root} will not expand")
 
-   You can also chain together ``literal`` and :func:`expandable` functions like so:
+   You can also chain together ``literal`` and :rex:func:`expandable` functions like so:
 
    .. code-block:: python
 
       env.FOO = literal("the value of {root} is").expandable("{root}")
 
-.. py:function:: optionvars(name: str, default: typing.Any | None = None) -> typing.Any
+.. rex:function:: optionvars(name: str, default: typing.Any | None = None) -> typing.Any
 
    A :meth:`dict.get` like function for package accessing arbitrary data from :data:`optionvars` in rez config.
 
-.. py:attribute:: request
+.. rex:attribute:: request
    :type: ~rez.rex_bindings.RequirementsBinding
 
    A dict like object representing the list of package requests. Each item is a request string keyed by the
@@ -614,7 +614,7 @@ Following is a list of the objects and functions available.
          "corelib": "!corelib-1.4.4"
       }
 
-   Use ``get_range`` to test with the :func:`intersects` function:
+   Use ``get_range`` to test with the :rex:func:`intersects` function:
 
       if intersects(request.get_range("maya", "0"), "2019"):
          info("maya 2019.* was asked for!")
@@ -631,11 +631,11 @@ Following is a list of the objects and functions available.
       request is combined ahead of time. In other words, if requests ``foo-4+`` and ``foo-<6`` were both
       present, the single request ``foo-4+<6`` would be present in the ``request`` object.
 
-.. py:function:: resetenv(envvar: str, value: str, friends=None) -> None
+.. rex:function:: resetenv(envvar: str, value: str, friends=None) -> None
 
    TODO: Document
 
-.. py:attribute:: resolve
+.. rex:attribute:: resolve
 
    A dict like object representing the list of packages in the resolved environment. Each item is a
    :ref:`Package <package-attributes>` object, keyed by the package name.
@@ -648,32 +648,32 @@ Following is a list of the objects and functions available.
          info("Maya version is %s", resolve.maya.version)
          # ..or resolve["maya"].version
 
-.. py:attribute:: root
+.. rex:attribute:: root
    :type: str
 
-   See :attr:`this.root`.
+   See :rex:attr:`this.root`.
 
-.. py:function:: setenv(envvar: str, value: str)
+.. rex:function:: setenv(envvar: str, value: str)
 
    This function sets an environment variable to the given value. It is equivalent to setting a
-   variable via the :attr:`env` object (eg, ``env.FOO = 'BAH'``).
+   variable via the :rex:attr:`env` object (eg, ``env.FOO = 'BAH'``).
 
    .. code-block:: python
 
       setenv("FOO_PLUGIN_PATH", "{root}/plugins")
 
-.. py:function:: source(path: str) -> None
+.. rex:function:: source(path: str) -> None
 
-   Source a shell script. Note that, similarly to :func:`commands`, this function cannot return a value, and
+   Source a shell script. Note that, similarly to :pkgdef:func:`commands`, this function cannot return a value, and
    any side effects that the script sourcing has is not visible to any packages. For example, if the
    ``init.sh`` script below contained ``export FOO=BAH``, a subsequent test for this variable on the
-   :attr:`env` object would yield nothing.
+   :rex:attr:`env` object would yield nothing.
 
    .. code-block:: python
 
       source("{root}/scripts/init.sh")
 
-.. py:attribute:: stop(message: str) -> typing.NoReturn
+.. rex:attribute:: stop(message: str) -> typing.NoReturn
 
    Raises an exception and stops a resolve from completing. You should use this when an unrecoverable
    error is detected and it is not possible to configure a valid environment.
@@ -682,7 +682,7 @@ Following is a list of the objects and functions available.
 
       stop("The value should be %s", expected_value)
 
-.. py:attribute:: system
+.. rex:attribute:: system
    :type: ~rez.system.System
 
    This object provided system information, such as current platform, arch and os.
@@ -692,12 +692,12 @@ Following is a list of the objects and functions available.
       if system.platform == "windows":
          ...
 
-.. py:attribute:: test
+.. rex:attribute:: test
 
-   Dict like object to access test related attributes. Only available in the :func:`pre_test_commands` function.
+   Dict like object to access test related attributes. Only available in the :pkgdef:func:`pre_test_commands` function.
    Keys can be accessed as object attributes.
 
-.. py:attribute:: test.name
+.. rex:attribute:: test.name
    :type: str
 
    Name of the test about to run.
@@ -707,7 +707,7 @@ Following is a list of the objects and functions available.
       if test.name == "unit":
          info("My unit test is about to run yay")
 
-.. py:attribute:: testing
+.. rex:attribute:: testing
    :type: bool
 
    This boolean variable is ``True`` if a test is occurring (typically done via the :ref:`rez-test` tool),
@@ -720,45 +720,45 @@ Following is a list of the objects and functions available.
       if testing:
           env.FOO_TEST_DATA_PATH = "{root}/tests/data"
 
-.. py:attribute:: this
+.. rex:attribute:: this
 
    The ``this`` object represents the current package. The following attributes are most commonly used
-   in a :func:`commands`) section (though you have access to all package attributes. See :ref:`here <package-attributes>`):
+   in a :pkgdef:func:`commands`) section (though you have access to all package attributes. See :ref:`here <package-attributes>`):
 
-   .. py:attribute:: this.base
+   .. rex:attribute:: this.base
       :type: str
 
-      Similar to :attr:`this.root`, but does not include the variant subpath, if there is one. Different
-      variants of the same package share the same :attr:`base` directory. See :doc:`here <variants>` for more
+      Similar to :rex:attr:`this.root`, but does not include the variant subpath, if there is one. Different
+      variants of the same package share the same :rex:attr:`base` directory. See :doc:`here <variants>` for more
       information on package structure in relation to variants.
 
-   .. py:attribute:: this.is_package
+   .. rex:attribute:: this.is_package
       :type: bool
 
       .. todo:: Document
 
       TODO: Document
 
-   .. py:attribute:: this.is_variant
+   .. rex:attribute:: this.is_variant
       :type: bool
 
       .. todo:: Document 
 
       TODO: Document
 
-   .. py:attribute:: this.name
+   .. rex:attribute:: this.name
       :type: str
 
       The name of the package, eg ``houdini``.
 
-   .. py:attribute:: this.root
+   .. rex:attribute:: this.root
       :type: str
 
       The installation directory of the package. If the package contains variants, this path will include
       the variant subpath. This is the directory that contains the installed package payload. See
       :doc:`here <variants>` for more information on package structure in relation to variants.
 
-   .. py:attribute:: this.version
+   .. rex:attribute:: this.version
       :type: ~rez.rex_bindings.VersionBinding
 
       The package version. It can be used as a string, however you can also access specific tokens in the
@@ -771,17 +771,17 @@ Following is a list of the objects and functions available.
       The available token references are ``this.version.major``, ``this.version.minor`` and
       ``this.version.patch``, but you can also use a standard list index to reference any version token.
 
-.. py:function:: undefined(envvar: str) -> bool
+.. rex:function:: undefined(envvar: str) -> bool
 
    Use this boolean function to determine whether or not an environment variable is set. This is the
-   opposite of :func:`defined`.
+   opposite of :rex:func:`defined`.
 
    .. code-block:: python
 
       if undefined("REZ_MAYA_VERSION"):
          info("maya is not present")
 
-.. py:function:: unsetenv(envvar: str) -> None
+.. rex:function:: unsetenv(envvar: str) -> None
 
    Unsets an environment variable. This function does nothing if the environment variable was not set.
 
@@ -789,7 +789,7 @@ Following is a list of the objects and functions available.
 
       unsetenv("FOO_LIC_SERVER")
 
-.. py:attribute:: version
+.. rex:attribute:: version
    :type: ~rez.rex_bindings.VersionBinding
 
-   See :attr:`this.version`.
+   See :rex:attr:`this.version`.

--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -673,7 +673,7 @@ Following is a list of the objects and functions available.
 
       source("{root}/scripts/init.sh")
 
-.. rex:attribute:: stop(message: str) -> typing.NoReturn
+.. rex:function:: stop(message: str) -> typing.NoReturn
 
    Raises an exception and stops a resolve from completing. You should use this when an unrecoverable
    error is detected and it is not possible to configure a valid environment.

--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -519,7 +519,7 @@ Following is a list of the objects and functions available.
       if getenv("REZ_MAYA_VERSION") == "2016.sp1":
          pass
 
-   :raises rex:exc:`RexUndefinedVariableError`: if the environment variable is not set.
+   :raises: :py:exc:`~rez.exceptions.RexUndefinedVariableError` if the environment variable is not set.
 
 .. rex:attribute:: implicits
 

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -58,7 +58,7 @@ Python variables that do **not** become package attributes include:
 
 * Python modules;
 * Functions, not including :ref:`early <package-definition-early-binding-functions>` and :ref:`late <package-definition-late-binding-functions>`
-  binding functions (see next), and not including the :attr:`commands` and related functions;
+  binding functions (see next), and not including the :pkgdef:func:`commands` and related functions;
 * Any variable with a leading double underscore;
 * Any variable that is a :ref:`build-package-attributes`.
 
@@ -70,7 +70,7 @@ the attribute value. There are two types of attribute functions: *early binding*
 and *late binding* functions - and these are decorated using ``@early`` and ``@late`` respectively.
 
 .. warning::
-   The :func:`commands` functions are an exception to the rule. They are
+   The :pkgdef:func:`commands` functions are an exception to the rule. They are
    late bound, but are not the same as a standard function attribute, and are **never** decorated
    with the early or late decorators.
 
@@ -87,10 +87,10 @@ evaluated before the resolve has occurred, and as such, before the
 there are some important distinctions that set early-bound functions apart from
 other function attributes:
 
-- The :attr:`this` object only exposes package attributes. Nothing else is accessible when inside an early-bound function.
+- The :rex:attr:`this` object only exposes package attributes. Nothing else is accessible when inside an early-bound function.
 - No rez-set :doc:`environment variables <environment>` can be accessed inside an early bound function.
 
-Any package attribute can be implemented as an early binding function. Here is an example of an :attr:`authors`
+Any package attribute can be implemented as an early binding function. Here is an example of an :pkgdef:attr:`authors`
 attribute that is automatically set to the contributors of the package's git project:
 
 .. code-block:: python
@@ -108,7 +108,7 @@ attribute that is automatically set to the contributors of the package's git pro
    current working directory is the root directory containing your ``package.py``.
 
 An early bound function can also have access to other package attributes. To do this, use the
-implicit :attr:`this` object:
+implicit :rex:attr:`this` object:
 
 .. code-block:: python
 
@@ -143,12 +143,12 @@ Following is the list of objects that are available during early evaluation.
 
 .. todo:: Document these properly with py:attribute?
 
-* **building**: See :attr:`building`;
+* **building**: See :rex:attr:`building`;
 * **build_variant_index**: The index of the variant currently being built. This is only relevant if
-  :attr:`building` is True.
+  :rex:attr:`building` is True.
 * **build_variant_requires**: The subset of package requirements specific to the variant
   currently being built. This is a list of ``PackageRequest`` objects. This is only relevant if
-  :attr:`building` is True.
+  :rex:attr:`building` is True.
 * **this**: The current package, as described previously.
 
 Be aware that early-bound functions are actually evaluated multiple times during a build: once
@@ -157,8 +157,8 @@ functions to change their return value based on variables like ``build_variant_i
 *pre-build* evaluated value is the one set into the installed package, and in this case, ``building``
 is False.
 
-An example of where you'd need to be aware of this is if you wanted the :attr:`requires` field to include
-a certain package at runtime only (ie, not present during the package build). In this case, :attr:`requires`
+An example of where you'd need to be aware of this is if you wanted the :pkgdef:attr:`requires` field to include
+a certain package at runtime only (ie, not present during the package build). In this case, :pkgdef:attr:`requires`
 might look like so:
 
 .. code-block:: python
@@ -191,7 +191,7 @@ Not any attribute can be implemented as a late binding function. The allowed att
 * help
 * any arbitrary attribute
 
-Here is an example of a late binding :attr:`tools` attribute:
+Here is an example of a late binding :pkgdef:attr:`tools` attribute:
 
 .. code-block:: python
 
@@ -244,7 +244,7 @@ reimplement the above example like so:
 
 Note how in the ``_tools`` function we're referring to a relative path. Remember that early binding
 functions are evaluated at build time. The package hasn't actually been built or installed yet,
-so attributes such as :attr:`this.root` don't exist.
+so attributes such as :rex:attr:`this.root` don't exist.
 
 .. _in_context:
 
@@ -259,7 +259,7 @@ the :ref:`rez-env` tool does) and iterate over its resolved packages, these belo
 
 The in-context or not-in-context distinction is important, because often the package attribute
 will need information from the context to give desired behavior. For example, consider the
-late binding :attr:`tools` attribute below:
+late binding :pkgdef:attr:`tools` attribute below:
 
 .. code-block:: python
 
@@ -272,7 +272,7 @@ late binding :attr:`tools` attribute below:
 
       return result
 
-Here the :attr:`request` object is being checked to see if the ``maya`` package was requested in the
+Here the :rex:attr:`request` object is being checked to see if the ``maya`` package was requested in the
 current env; if it was, a maya-specific tool ``maya-edit`` is added to the tool list.
 
 .. warning::
@@ -288,30 +288,30 @@ Following is the list of objects that are available during late evaluation, if :
 is ``True``:
 
 * **context**: the :class:`~rez.resolved_context.ResolvedContext` instance this package belongs to;
-* **system**: see :attr:`system`;
-* **building**: see :attr:`building`;
-* **testing**: see :attr:`testing`;
-* **request**: see :attr:`request`;
-* **implicits**: see :attr:`implicits`.
+* **system**: see :rex:attr:`system`;
+* **building**: see :rex:attr:`building`;
+* **testing**: see :rex:attr:`testing`;
+* **request**: see :rex:attr:`request`;
+* **implicits**: see :rex:attr:`implicits`.
 
 The following objects are available in **all** cases:
 
-* :attr:`this`: the current package/variant (see note below);
+* :rex:attr:`this`: the current package/variant (see note below);
 * **in_context**: the :ref:`in_context <in_context>` function itself.
 
 .. warning::
-   The :attr:`this` object may be either a package or a variant,
+   The :rex:attr:`this` object may be either a package or a variant,
    depending on the situation. For example, if :ref:`in_context <in_context>` is ``True``,
-   then :attr:`this` is a variant, because variants are the objects present in a resolved context. On the other
+   then :rex:attr:`this` is a variant, because variants are the objects present in a resolved context. On the other
    hand, if a package is accessed via API (for example, by using the :ref:`rez-search` tool),
-   then :attr:`this` may be a package. The difference matters, because variants have some
+   then :rex:attr:`this` may be a package. The difference matters, because variants have some
    attributes that packages don't, notably, ``root`` and ``index``. Use the properties
-   :attr:`this.is_package` and :attr:`this.is_variant` to distinguish the case if needed.
+   :rex:attr:`this.is_package` and :rex:attr:`this.is_variant` to distinguish the case if needed.
 
 Example - Late Bound build_requires
 ***********************************
 
-Here is an example of a ``package.py`` with a late-bound :attr:`build_requires` field:
+Here is an example of a ``package.py`` with a late-bound :pkgdef:attr:`build_requires` field:
 
 .. code-block:: python
 
@@ -335,15 +335,15 @@ Here is an example of a ``package.py`` with a late-bound :attr:`build_requires` 
 
 .. todo:: Figure out why I can't link to this.is_package
 
-Note the check for :attr:`this.is_package`. This is necessary, otherwise the evaluation would
-fail in some circumstances. Specifically, if someone ran the following command, the :attr:`this`
+Note the check for :rex:attr:`this.is_package`. This is necessary, otherwise the evaluation would
+fail in some circumstances. Specifically, if someone ran the following command, the :rex:attr:`this`
 field would actually be a :class:`.Package` instance, which doesn't have an ``index`` method:
 
 .. code-block:: text
 
    ]$ rez-search maya_thing --type package --format '{build_requires}'
 
-In this case, :attr:`build_requires` is somewhat nonsensical (there is no common build requirement
+In this case, :pkgdef:attr:`build_requires` is somewhat nonsensical (there is no common build requirement
 for both variants here), but something needs to be returned nonetheless.
 
 .. _package-definition-sharing-code:
@@ -361,7 +361,7 @@ Sharing Code During A Build
 
 Functions in a ``package.py`` file which are evaluated at build time include:
 
-* The :attr:`preprocess` function;
+* The :pkgdef:func:`preprocess` function;
 * Any package attribute implemented as a function using the :ref:`@early <package-definition-early-binding-functions>` decorator.
 
 You expose common code to these functions by using the
@@ -384,7 +384,7 @@ stays self-contained, and will not break or change behavior if the original modu
 files are changed. The downside though, is that these modules are not imported, and they themselves
 cannot import other modules managed in the same way.
 
-Here is an example of a package's :attr:`commands` using a shared module:
+Here is an example of a package's :pkgdef:func:`commands` using a shared module:
 
 .. code-block:: python
 
@@ -402,8 +402,8 @@ Often a package may be compatible with a broader range of its dependencies at bu
 at runtime. For example, a C++ package may build against any version of ``boost-1``, but may
 then need to link to the specific minor version that it was built against, say ``boost-1.55``.
 
-You can describe this in your package's :attr:`requires` attribute (or any of the related attributes,
-such as :attr:`build_requires`) by using wildcards as shown here:
+You can describe this in your package's :pkgdef:attr:`requires` attribute (or any of the related attributes,
+such as :pkgdef:attr:`build_requires`) by using wildcards as shown here:
 
 .. code-block:: python
 
@@ -417,8 +417,8 @@ requires list will be expanded to the latest found within the given range (``boo
 There is also a special wilcard available, ``**``. This expands to the full package version. For
 example, the requirement ``boost-1.**`` might expand to ``boost-1.55.1``.
 
-You can also achieve requirements expansion by implementing :attr:`requires` as an early binding
-function (and you may want to use some variation of this to generate :attr:`variants` for example), and
+You can also achieve requirements expansion by implementing :pkgdef:attr:`requires` as an early binding
+function (and you may want to use some variation of this to generate :pkgdef:attr:`variants` for example), and
 using the rez :func:`~rez.package_py_utils.expand_requires` function:
 
 .. code-block:: python
@@ -435,7 +435,7 @@ using the rez :func:`~rez.package_py_utils.expand_requires` function:
 Package Preprocessing
 =====================
 
-You can define a :func:`preprocess` function either globally or in a ``package.py``. This can be used to
+You can define a :pkgdef:func:`preprocess` function either globally or in a ``package.py``. This can be used to
 validate a package, or even change some of its attributes, before it is built. To set a global
 preprocessing function, see the :data:`package_preprocess_function` config setting.
 
@@ -456,7 +456,7 @@ Consider the following preprocessing function, defined in a ``package.py``:
 
 This preprocessor checks the package name against a regex and sets the package authors list to its
 git committers, if not already supplied in the ``package.py``. To update package attributes, you have
-to update the given ``data`` dict, **not** the package instance (:attr:`this`).
+to update the given ``data`` dict, **not** the package instance (:rex:attr:`this`).
 
 To halt a build because a package is not valid, you must raise an :exc:`~rez.exceptions.InvalidPackageError` as shown
 above.
@@ -585,17 +585,17 @@ Note the following:
 
 .. todo:: Document which attributes supports automatic wildcard expansion?
 
-* :attr:`variants` is implemented as an early bound attribute, and uses :ref:`requirements-expansion` to
-  dynamically define the variant requirements. Even though only the :attr:`requires` and related attributes
+* :pkgdef:attr:`variants` is implemented as an early bound attribute, and uses :ref:`requirements-expansion` to
+  dynamically define the variant requirements. Even though only the :pkgdef:attr:`requires` and related attributes
   natively expand wildcards, you can still use the :func:`~rez.package_py_utils.expand_requires` function
   yourself, as illustrated here.
 * A ``_version`` function has been defined, and its return value stored into the ``__version`` variable.
-  This is done because two other early binding attributes. :attr:`version` and :attr:`tools` use this value,
+  This is done because two other early binding attributes. :pkgdef:attr:`version` and :pkgdef:attr:`tools` use this value,
   and we avoid calling the function twice. Both ``_version`` and ``__version`` are later stripped from
   the package, because one is a normal function, and the other has double leading underscores.
 * An arbitrary attribute ``_bin_path`` has been defined, and implemented as an early bound attribute.
-  The :attr:`commands` function then uses this value. In this example, it was far better to take this
-  approach than the alternative of running the python subprocess in the :attr:`commands` function. Doing that
+  The :pkgdef:func:`commands` function then uses this value. In this example, it was far better to take this
+  approach than the alternative of running the python subprocess in the :pkgdef:func:`commands` function. Doing that
   would have been very costly, since commands are executed every time a new environment is created
   (and launching a subprocess is slow). Instead, here we take this cost at build time, and cache the
   result into the package attribute.
@@ -618,7 +618,7 @@ the data type, and includes a code snippet.
 
 .. .. currentmodule:: pkgdef
 
-.. py:attribute:: authors
+.. pkgdef:attribute:: authors
    :type: list[str]
 
    Package authors. Should be in order, starting with the major contributor.
@@ -627,10 +627,10 @@ the data type, and includes a code snippet.
 
       authors = ["jchrist", "sclaus"]
 
-.. py:attribute:: build_requires
+.. pkgdef:attribute:: build_requires
    :type: list[str]
 
-   This is the same as :attr:`requires`, except that these dependencies are only included during a build
+   This is the same as :pkgdef:attr:`requires`, except that these dependencies are only included during a build
    (typically invoked using the :ref:`rez-build` tool).
 
    .. code-block:: python
@@ -640,7 +640,7 @@ the data type, and includes a code snippet.
          "doxygen"
       ]
 
-.. py:attribute:: cachable
+.. pkgdef:attribute:: cachable
    :type: bool
 
    Determines whether a package can be cached when :ref:`package-caching` is enabled.
@@ -650,7 +650,7 @@ the data type, and includes a code snippet.
 
       cachable = True
 
-.. py:function:: commands() -> None
+.. pkgdef:function:: commands() -> None
 
    This is a block of python code which tells rez how to update an environment so that this package
    can be used. It is executed when the package is brought into a rez environment, either by explicit
@@ -672,7 +672,7 @@ the data type, and includes a code snippet.
          env.PYTHONPATH.append("{root}/python")
          env.PATH.append("{root}/bin")
 
-.. py:attribute:: config
+.. pkgdef:attribute:: config
    :type: dict[str, typing.Any]
 
    Packages are able to override rez configuration settings. This is useful in some cases. For example,
@@ -687,7 +687,7 @@ the data type, and includes a code snippet.
       with scope("config"):
          release_packages_path = "/software/packages/apps"
 
-.. py:attribute:: description
+.. pkgdef:attribute:: description
    :type: str
 
    This is a general description of the package. It should not mention details about a particular
@@ -697,17 +697,17 @@ the data type, and includes a code snippet.
 
       description = "Library for communicating with the dead."
 
-.. py:attribute:: has_plugins
+.. pkgdef:attribute:: has_plugins
    :type: bool
 
    Indicates that the package is an application that may have plugins. These plugins are often made
-   available as rez packages also. Used in conjuction with the :ref:`rez-plugins` command. Also, see :attr:`plugin_for`.
+   available as rez packages also. Used in conjuction with the :ref:`rez-plugins` command. Also, see :pkgdef:attr:`plugin_for`.
 
    .. code-block:: python
 
       has_plugins = True
 
-.. py:attribute:: hashed_variants
+.. pkgdef:attribute:: hashed_variants
    :type: bool
 
    Instructs the package to install variants into a subdirectory based on a hash of the variant's
@@ -719,7 +719,7 @@ the data type, and includes a code snippet.
 
       hashed_variants = True
 
-.. py:attribute:: help
+.. pkgdef:attribute:: help
    :type: str | list[list[str]]
 
    URL for package webpage, or, if a string containing spaces, a command to run. You can show the help
@@ -737,7 +737,7 @@ the data type, and includes a code snippet.
          ['API docs', 'https://example.com/docs/api']
       ]
 
-.. py:attribute:: name
+.. pkgdef:attribute:: name
    :type: str
 
    **Mandatory**
@@ -748,19 +748,19 @@ the data type, and includes a code snippet.
 
       name = "maya_utils"
 
-.. py:attribute:: plugin_for
+.. pkgdef:attribute:: plugin_for
    :type: str
 
    Provided if this package is a plugin of another package. For example, this might be a maya plugin.
-   This is useful when using the :ref:`rez-plugins` command. Also, see :attr:`has_plugins`.
+   This is useful when using the :ref:`rez-plugins` command. Also, see :pkgdef:attr:`has_plugins`.
 
    .. code-block:: python
 
       plugin_for = "maya"
 
-.. py:function:: post_commands() -> None
+.. pkgdef:function:: post_commands() -> None
 
-   Similar to :func:`pre_commands`, but runs in a final phase rather than the first. See that attribute for
+   Similar to :pkgdef:func:`pre_commands`, but runs in a final phase rather than the first. See that attribute for
    further details.
 
    .. code-block:: python
@@ -768,9 +768,9 @@ the data type, and includes a code snippet.
       def post_commands():
          env.FOO_PLUGIN_PATH.append("@")
 
-.. py:function:: pre_commands() -> None
+.. pkgdef:function:: pre_commands() -> None
 
-   This is the same as :func:`commands`, except that all packages' ``pre_commands`` are executed in a first
+   This is the same as :pkgdef:func:`commands`, except that all packages' ``pre_commands`` are executed in a first
    pass; then, all ``commands`` are run in a second; and lastly, ``post_commands`` are all run in a third
    phase. It is sometimes useful to ensure that some of a package's commands are run before, or after
    all others, and using pre/post_commands is a way of doing that.
@@ -781,10 +781,10 @@ the data type, and includes a code snippet.
          import os.path
          env.FOO_PLUGIN_PATH = os.path.join(this.root, "plugins")
 
-.. py:function:: pre_test_commands()
+.. pkgdef:function:: pre_test_commands()
 
-   This is similar to :func:`commands`, except that it is run prior to each test defined in
-   :attr:`tests`. See :ref:`pre-test-commands` for more details.
+   This is similar to :pkgdef:func:`commands`, except that it is run prior to each test defined in
+   :pkgdef:attr:`tests`. See :ref:`pre-test-commands` for more details.
 
    .. code-block:: python
 
@@ -792,7 +792,7 @@ the data type, and includes a code snippet.
          if test.name == "unit":
                env.IS_UNIT_TEST = 1
 
-.. py:attribute:: relocatable
+.. pkgdef:attribute:: relocatable
    :type: bool
 
    Determines whether a package can be copied to another package repository (using the :ref:`rez-cp` tool for
@@ -803,7 +803,7 @@ the data type, and includes a code snippet.
 
       relocatable = True
 
-.. py:attribute:: requires
+.. pkgdef:attribute:: requires
    :type: list[str]
 
    This is a list of other packages that this package depends on. A rez package should list all the
@@ -826,7 +826,7 @@ the data type, and includes a code snippet.
          "maya_utils-3.4+<4"
       ]
 
-.. py:attribute:: tests
+.. pkgdef:attribute:: tests
    :type: dict[str, str | dict]
 
    This is a dict of tests that can be run on the package using the :ref:`rez-test` tool.
@@ -881,7 +881,7 @@ the data type, and includes a code snippet.
       Prior to running the tests, you will need to run :ref:`rez-build`. :ref:`rez-test` can only
       run tests on already built packages.
 
-.. py:attribute:: tools
+.. pkgdef:attribute:: tools
    :type: list[str]
 
    This is a list of tools that the package provides. This entry is important later on when we talk
@@ -895,7 +895,7 @@ the data type, and includes a code snippet.
          "hython"
       ]
 
-.. py:attribute:: uuid
+.. pkgdef:attribute:: uuid
    :type: str
 
    This string should uniquely identify this *package family*. In other words, all the versions of a
@@ -917,7 +917,7 @@ the data type, and includes a code snippet.
 
       uuid = "489ad32867494baab7e5be3e462473c6"
 
-.. py:attribute:: variants
+.. pkgdef:attribute:: variants
    :type: list[list[str]]
 
    A package can contain *variants* - think of them as different flavors of the same package version,
@@ -931,7 +931,7 @@ the data type, and includes a code snippet.
          ["maya-2016.7"]
       ]
 
-.. py:attribute:: version
+.. pkgdef:attribute:: version
    :type: str
 
    This is the version of the package. See :ref:`versions-concept` for further details on valid
@@ -949,7 +949,7 @@ Build Time Package Attributes
 The following package attributes only appear in packages to be built; they are stripped from the
 package once installed because they are only used at build time.
 
-.. py:attribute:: build_command
+.. pkgdef:attribute:: build_command
    :type: str | list[str] | False
 
    Package build command. If present, this is used as the build command when :ref:`rez-build` is run,
@@ -981,7 +981,7 @@ package once installed because they are only used at build time.
 
       build_command = "bash {root}/build.sh {install}"
 
-.. py:attribute:: build_system
+.. pkgdef:attribute:: build_system
    :type: str
 
    .. todo:: reference the real --build-system cli flag
@@ -994,9 +994,9 @@ package once installed because they are only used at build time.
       build_system = "cmake"
 
 
-.. py:function:: pre_build_commands() -> None
+.. pkgdef:function:: pre_build_commands() -> None
 
-   This is similar to :func:`commands`, except that it is run *prior to the current package being built*.
+   This is similar to :pkgdef:func:`commands`, except that it is run *prior to the current package being built*.
    See :ref:`pre-build-commands` for more details.
 
    .. code-block:: python
@@ -1004,15 +1004,15 @@ package once installed because they are only used at build time.
       def pre_build_commands():
          env.FOO_BUILT_BY_REZ = 1
 
-.. py:function:: preprocess(this, data: dict[str, typing.Any])
+.. pkgdef:function:: preprocess(this, data: dict[str, typing.Any])
 
    See :ref:`package-preprocessing`.
 
-.. py:attribute:: private_build_requires
+.. pkgdef:attribute:: private_build_requires
    :type: list[str]
 
-   This is the same as :attr:`build_requires`, except that these dependencies are only included if this
-   package is being built. Contrast this with :attr:`build_requires`, whose dependencies are included if a
+   This is the same as :pkgdef:attr:`build_requires`, except that these dependencies are only included if this
+   package is being built. Contrast this with :pkgdef:attr:`build_requires`, whose dependencies are included if a
    build is occurring regardless of whether this package specifically is being built, or whether
    this package is a dependency of the package being built.
 
@@ -1023,7 +1023,7 @@ package once installed because they are only used at build time.
          "doxygen"
       ]
 
-.. py:attribute:: requires_rez_version
+.. pkgdef:attribute:: requires_rez_version
    :type: str
 
    This defines the minimum version of rez needed to build this package. New package features have
@@ -1042,7 +1042,7 @@ The following package attributes are created for you by Rez when your package is
 :ref:`rez-release` tool. If you look at the released ``package.py`` file you will notice that some or all
 of these attributes have been added.
 
-.. py:attribute:: changelog
+.. pkgdef:attribute:: changelog
    :type: str
 
    Change log containing all commits since the last released package. If the previous release was from
@@ -1061,13 +1061,13 @@ of these attributes have been added.
                first commit
          """
 
-.. py:attribute:: previous_revision
+.. pkgdef:attribute:: previous_revision
    :type: typing.Any
 
-   Revision information of the previously released package, if any (see :attr:`revision` for code example -
+   Revision information of the previously released package, if any (see :pkgdef:attr:`revision` for code example -
    the code for this attribute is the same).
 
-.. py:attribute:: previous_version
+.. pkgdef:attribute:: previous_version
    :type: str
 
    The version of the package previously released, if any.
@@ -1076,7 +1076,7 @@ of these attributes have been added.
 
       previous_version = "1.0.1"
 
-.. py:attribute:: release_message
+.. pkgdef:attribute:: release_message
    :type: str
 
    .. todo:: Reference --message option directly
@@ -1091,7 +1091,7 @@ of these attributes have been added.
 
       release_message = "Fixed the flickering thingo"
 
-.. py:attribute:: revision
+.. pkgdef:attribute:: revision
    :type: typing.Any
 
    Information about the source control revision containing the source code that was released. The
@@ -1107,7 +1107,7 @@ of these attributes have been added.
             'push_url': 'git@github.com:foo/dummy.git',
             'tracking_branch': 'origin/master'}
 
-.. py:attribute:: timestamp
+.. pkgdef:attribute:: timestamp
    :type: int
 
    Epoch time at which the package was released.
@@ -1116,7 +1116,7 @@ of these attributes have been added.
 
       timestamp = 1463350552
 
-.. py:attribute:: vcs
+.. pkgdef:attribute:: vcs
    :type: str
 
    Name of the version control system this package was released from.

--- a/docs/source/package_orderers.rst
+++ b/docs/source/package_orderers.rst
@@ -22,7 +22,7 @@ These are the available built-in orderers.
 sorted
 ------
 
-This is the default orderer that sorts based on the package's :attr:`version` attribute.
+This is the default orderer that sorts based on the package's :pkgdef:attr:`version` attribute.
 
 You can optionally explicitly request this orderer like this:
 

--- a/docs/source/pip.rst
+++ b/docs/source/pip.rst
@@ -17,43 +17,7 @@ To do so, it provides a :ref:`rez-pip` command.
 Usage
 =====
 
-.. code-block:: text
-
-   usage: rez pip [-h] [--python-version VERSION] [--pip-version VERSION] [-i]
-                  [-s] [-r] [-v]
-                  PACKAGE
-
-   Install a pip-compatible python package, and its dependencies, as rez
-   packages.
-
-   positional arguments:
-   PACKAGE               package to install or archive/url to install from
-
-   optional arguments:
-   -h, --help            show this help message and exit
-   --python-version VERSION
-                           python version (rez package) to use, default is
-                           latest. Note that the pip package(s) will be installed
-                           with a dependency on python-MAJOR.MINOR.
-   --pip-version VERSION
-                           pip version (rez package) to use, default is latest.
-                           This option is deprecated and will be removed in the
-                           future.
-   -i, --install         install the package
-   -s, --search          search for the package on PyPi
-   -r, --release         install as released package; if not set, package is
-                           installed locally only
-   -p PATH, --prefix PATH
-                           install to a custom package repository path.
-   -v, --verbose         verbose mode, repeat for more verbosity
-
-
-The :ref:`rez-pip` command allows you to do two main things.
-
-1. Install or release a pip package as a rez package.
-2. Search for a package on PyPI
-
-.. _which-pip-will-be-used:
+See :ref:`rez-pip`
 
 Which pip will be used?
 =======================
@@ -64,12 +28,7 @@ The logic is as follow:
 1. Search for pip in the rezified ``python`` package specified with :option:`--python-version <rez-pip --python-version>`, or
    the latest version if not specified;
 2. If found, use it;
-3. If not found, search for pip in the rezified ``pip`` package specified with :option:`--pip-version <rez-pip --pip-version>`,
-   or latest version if not specified.
-
-   .. note::
-      Note that this is deprecated and will be removed in the future
-
+3. If not found, search for pip in the rezified ``pip`` package (this is for backwards compatibility);
 4. If rezified ``pip`` is found, use it;
 5. If not found, fall back to pip installed in rez own virtualenv.
 
@@ -88,8 +47,8 @@ IronPython, etc), the architecture python was built with, and other variables. S
 really need to know first is which python you want to use and from there you should know
 which pip is used. Knowing the pip version comes in second place.
 
-At some point, we supported the :option:`--pip-version <rez-pip --pip-version>` argument, but considering what was just said
-above, we decided to deprecate it (but not yet removed) just for backward compatibility reasons.
+At some point, we supported a ``--pip-version`` argument, but considering what was just said
+above, we decided to remove it.
 Pip is too much (read tightly) coupled to the python version/interpreter it is installed with
 for us to support having pip as a rez package. We just can't guarantee that pip can be
 install once in a central way and work with multiple different python version, and potentially
@@ -137,7 +96,6 @@ See :ref:`which-pip-will-be-used` for more details.
 If the pip package is not pure (so contains ``.so`` for example), you will need to
 call :ref:`rez-pip` for each python version you want to install the pip package for.
 
-.. warning::
-   :option:`--pip-version <rez-pip --pip-version>` is deprecated and will be removed in the future.
+.. tip::
    See :ref:`how-should-i-install-pip` on how we recommend
-   to install pip from now on.
+   to install pip.

--- a/docs/source/pip.rst
+++ b/docs/source/pip.rst
@@ -19,6 +19,8 @@ Usage
 
 See :ref:`rez-pip`
 
+.. _which-pip-will-be-used:
+
 Which pip will be used?
 =======================
 

--- a/docs/source/suites.rst
+++ b/docs/source/suites.rst
@@ -84,8 +84,8 @@ Suite Tools
 ===========
 
 The tools in a context which are exposed by the suite is determined by the
-:attr:`tools` package attribute. For example, the
-``maya`` package might have a :attr:`tools` definition like so:
+:pkgdef:attr:`tools` package attribute. For example, the
+``maya`` package might have a :pkgdef:attr:`tools` definition like so:
 
 .. code-block:: python
 

--- a/docs/source/variants.rst
+++ b/docs/source/variants.rst
@@ -37,7 +37,7 @@ the version of maya present. Only one variant of a package is ever used in a
 given configured environment.
 
 Each variant entry is a list of dependencies, no different to the packages listed
-in the :attr:`requires` field. These dependencies are appended to the ``requires`` list
+in the :pkgdef:attr:`requires` field. These dependencies are appended to the ``requires`` list
 for each variant. Thus the first variant requires ``openexr-2.2`` and ``maya-2016.sp1``,
 and the second variant requires ``openexr-2.2`` and ``maya-2017``.
 
@@ -76,7 +76,7 @@ There are two problems with the variant subpath as illustrated above:
   can cause escaping problems that affect build systems; and, depending on the
   platform, may not be a valid filesystem path.
 
-You can avoid these issues by using :attr:`hashed_variants`. This sets the variant
+You can avoid these issues by using :pkgdef:attr:`hashed_variants`. This sets the variant
 sub-path to a hash of its requirements, rather than the requirements themselves.
 The resulting sub-directory is somewhat unwieldy (example:
 ``83e0c415db1b602f9d59cee028da6ac785e9bacc``). However, another feature,

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -100,9 +100,9 @@ class BuildProcess(object):
         """Create a BuildProcess.
 
         Args:
-            working_dir (DEPRECATED): Will be removed in rez 3.0.0.
+            working_dir: Will be removed in rez 3.0.0 (DEPRECATED).
             build_system (`BuildSystem`): Build system used to build the package.
-            package (DEPRECATED): Will be removed in rez 3.0.0.
+            package: Will be removed in rez 3.0.0 (DEPRECATED).
             vcs (`ReleaseVCS`): Version control system to use for the release
                 process.
             ensure_latest: If True, do not allow the release process to occur

--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -32,7 +32,7 @@ def setup_parser(parser, completions: bool = False) -> None:
         "-c", "--command", type=str,
         help="execute command within rez environment and exit, instead of "
         "starting an interactive shell. Alternatively, list command after a "
-        "'--'. The command and arguments passed to '-c' must be passed in as "
+        "'--'. The command and arguments passed to -c must be passed in as "
         "a single shell argument, whereas the command and arguments after "
         "'--' may be passed in as several shell arguments.")
     parser.add_argument(

--- a/src/rez/cli/search.py
+++ b/src/rez/cli/search.py
@@ -32,7 +32,7 @@ def setup_parser(parser, completions: bool = False) -> None:
         help="set package search path (ignores --no-local if set)")
     parser.add_argument(
         "-f", "--format", type=str,
-        help="format package output, eg --format='{qualified_name} | "
+        help="format package output, eg '{qualified_name} | "
         "{description}'. Valid fields include: %s" % format_choices)
     parser.add_argument(
         "--no-newlines", action="store_true",

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -37,7 +37,7 @@ def setup_parser(parser, completions: bool = False):
     parser.add_argument(
         "-s", "--only-shell", metavar="SHELL",
         help="limit shell-dependent tests to the specified shell. Note: This "
-             "flag shadowed pytest '–capture=no' shorthand '-s', so the long "
+             "flag shadowed pytest '--capture=no' shorthand -s, so the long "
              "name must be used for disabling stdout/err capturing in pytest."
     )
     parser.add_argument(

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -244,7 +244,7 @@ class PackageCache(object):
                 is no guarantee the resulting variant payload will be functional).
             wait_for_copying (bool): Whether the caching step should block when one of the
                 pending variants is marked as already copying.
-            logger (None | Logger): If a logger is provided, log information to it.
+            logger (None | logging.Logger): If a logger is provided, log information to it.
 
         Returns:
             tuple: 2-tuple:
@@ -493,7 +493,7 @@ class PackageCache(object):
         are then added to the cache in a separate process.
 
         .. deprecated:: 3.2.0
-           Use :method:`add_variants` instead.
+           Use :meth:`add_variants` instead.
         """
         return self.add_variants(variants, package_cache_async=True)
 

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -67,7 +67,7 @@ def copy_package(package: Package,
     will only be present when `overwrite` is False.
 
     .. note::
-       Whether or not a package can be copied is determined by its :attr:`relocatable`
+       Whether or not a package can be copied is determined by its :pkgdef:attr:`relocatable`
        attribute (see the :data:`default_relocatable` config setting for more details).
        An attempt to copy a non-relocatable package will fail. You can override
        this behaviour with the ``force`` argument.

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -44,7 +44,7 @@ class PackageTestRunner(object):
     list is added to the test env.
 
     Command strings automatically expand references such as ``{root}``, much
-    as happens in a :pkgdef:attr:`commands` function.
+    as happens in a :pkgdef:func:`commands` function.
 
     Commands can also be a list - in this case, the test process is launched
     directly, rather than interpreted via a shell.

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -22,7 +22,7 @@ import os
 class PackageTestRunner(object):
     """Object for running a package's tests.
 
-    This runs the tests listed in the package's "tests" attribute.
+    This runs the tests listed in the package's :pkgdef:attr:`tests` attribute.
 
     An example tests entry in a package.py might look like this:
 
@@ -44,7 +44,7 @@ class PackageTestRunner(object):
     list is added to the test env.
 
     Command strings automatically expand references such as ``{root}``, much
-    as happens in a :data:`commands` function.
+    as happens in a :pkgdef:attr:`commands` function.
 
     Commands can also be a list - in this case, the test process is launched
     directly, rather than interpreted via a shell.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -87,12 +87,12 @@ context_tmpdir = None
 # This means that any of the functions in the following list can import modules
 # from these paths:
 #
-# * The :func:`preprocess` function;
+# * The :pkgdef:func:`preprocess` function;
 # * Any function decorated with :ref:`@early <package-definition-early-binding-functions>`. These get evaluated at build time.
 #
 # You can use this to provide common code to your package definition files during
 # a build. To provide common code for packages to use at resolve time instead (for
-# example, in a :func:`commands` function) see the following
+# example, in a :pkgdef:func:`commands` function) see the following
 # :data:`package_definition_python_path` setting.
 package_definition_build_python_paths = []
 
@@ -111,7 +111,7 @@ package_definition_build_python_paths = []
 #
 #    package_definition_python_path = "/src/rezutils"
 #
-# Consider also the following package :func:`commands` function:
+# Consider also the following package :pkgdef:func:`commands` function:
 #
 # .. code-block:: python
 #
@@ -189,7 +189,7 @@ memcached_resolve_min_compress_len = 1
 ###############################################################################
 
 # Whether a package is relocatable or not, if it does not explicitly state with
-# the :attr:`relocatable` attribute in its package definition file.
+# the :pkgdef:attr:`relocatable` attribute in its package definition file.
 default_relocatable = True
 
 # Set relocatable on a per-package basis. This is here for migration purposes.
@@ -231,7 +231,7 @@ default_relocatable_per_repository = None
 ###############################################################################
 
 # Whether a package is cachable or not, if it does not explicitly state with
-# the :attr:`cachable` attribute in its package definition file. If None, defaults
+# the :pkgdef:attr:`cachable` attribute in its package definition file. If None, defaults
 # to packages' relocatability (ie cachable == relocatable).
 default_cachable = False
 
@@ -496,7 +496,7 @@ all_parent_variables = False
 # When two or more packages in a resolve attempt to set the same environment
 # variable, Rez's default behaviour is to flag this as a conflict and abort the
 # resolve. You can overcome this in a package's commands section by using the
-# Rex command :func:`resetenv` instead of :func:`setenv`. However, you can also turn off this
+# Rex command :rex:func:`resetenv` instead of :rex:func:`setenv`. However, you can also turn off this
 # behaviour globally for some varibles by adding them to :data:`resetting_variables`,
 # and for all variables, by setting :data:`all_resetting_variables` to true.
 resetting_variables = []
@@ -620,7 +620,7 @@ standard_system_paths = []
 package_preprocess_function = None
 
 # Defines in which order the :data:`package_preprocess_function`
-# and the :attr:`preprocess` function inside a ``package.py`` are executed.
+# and the :pkgdef:attr:`preprocess` function inside a ``package.py`` are executed.
 #
 # Note that "global preprocess" means the preprocess defined by
 # :data:`package_preprocess_function`.
@@ -968,8 +968,8 @@ pip_install_remaps = [
 ]
 
 # A dict type config for storing arbitrary data that can be
-# accessed by the :func:`optionvars` function in packages
-# :func:`commands`.
+# accessed by the :rex:func:`optionvars` function in packages
+# :pkgdef:func:`commands`.
 #
 # This is like user preferences for packages, which may not easy to define in
 # package's definition file directly due to the differences between machines/users/pipeline-roles.

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -620,7 +620,7 @@ standard_system_paths = []
 package_preprocess_function = None
 
 # Defines in which order the :data:`package_preprocess_function`
-# and the :pkgdef:attr:`preprocess` function inside a ``package.py`` are executed.
+# and the :pkgdef:func:`preprocess` function inside a ``package.py`` are executed.
 #
 # Note that "global preprocess" means the preprocess defined by
 # :data:`package_preprocess_function`.

--- a/src/rez/version/_requirement.py
+++ b/src/rez/version/_requirement.py
@@ -142,7 +142,7 @@ class Requirement(_Common):
         """
         Args:
             s (str): Requirement string
-            invalid_bound_error (bool): If True, raise :exc:`VersionError` if an
+            invalid_bound_error (bool): If True, raise :exc:`.VersionError` if an
                 impossible range is given, such as ``3+<2``.
         """
         self.name_ = None
@@ -248,8 +248,8 @@ class Requirement(_Common):
         return str(self)
 
     def conflicts_with(self, other: Requirement | VersionedObject) -> bool:
-        """Returns True if this requirement conflicts with another :class:`Requirement`
-        or :class:`VersionedObject`.
+        """Returns True if this requirement conflicts with another :class:`.Requirement`
+        or :class:`.VersionedObject`.
 
         Returns:
             bool:


### PR DESCRIPTION
Fix Sphinx warnings caused by duplicate symbols by introducing two new Sphinx domains: `rex` and `pkgdef`.

This makes it possible to reference package attributes in the docs using `:pkgdef:attr` for example, and stuff in commands using `:rex:attr`.

This removes any duplicates in symbols. These new domains won't affect users reading our docs in any way, but it will have an impact on any user that are cross-linking our docs using intersphinx (https://docs.readthedocs.com/platform/latest/guides/intersphinx.html). These users will have to update references to `:data:version`, etc to use our domains instead.

I also fixed some more warnings that were not related to the duplicate symbols, and modified the CLI docs auto-generation code to improve the readability of the docs a little bit (please look at https://rez--2062.org.readthedocs.build/en/2062/commands_index.html?readthedocs-diff=true to visualize the diff).

AI disclosure:

The custom domains code was written using Amp. Here are the threads:
* https://ampcode.com/threads/T-019b854a-b579-770f-bbd2-6f3c7283d9e1
* https://ampcode.com/threads/T-019b855b-4386-74db-a9c1-163b3a62f297
* https://ampcode.com/threads/T-019b8568-e761-736f-b079-246e9724cf42
* https://ampcode.com/threads/T-019b857b-ab87-73df-acf4-1faae6673a88