### PR TITLE
Allow building with cmake on Windows

### DIFF
--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -205,6 +205,12 @@ what environment variables are actually paths. You determine this with the
 variable ending in ``PATH`` will be treated as a filepath or list of filepaths, and any
 set/append/prepend operation on it will cause those values to be path-normalized automatically.
 
+However, some variables match ``*PATH`` but must not be path-normalized. For example,
+``CMAKE_MODULE_PATH`` requires forward slashes regardless of shell, and backslash conversion will
+break CMake. You can exclude variables from normalization using the :data:`non_pathed_env_vars`
+config setting, which takes priority over :data:`pathed_env_vars`. By default,
+``CMAKE_MODULE_PATH`` is already excluded. Both settings support ``fnmatch``-style wildcards.
+
 .. warning::
    Avoid using :data:`os.pathsep` or hardcoded lists of paths such as
    ``{root}/foo:{root}/bah``. Doing so can cause your package to be incompatible with some shells or

--- a/docs/source/package_commands.rst
+++ b/docs/source/package_commands.rst
@@ -209,7 +209,7 @@ However, some variables match ``*PATH`` but must not be path-normalized. For exa
 ``CMAKE_MODULE_PATH`` requires forward slashes regardless of shell, and backslash conversion will
 break CMake. You can exclude variables from normalization using the :data:`non_pathed_env_vars`
 config setting, which takes priority over :data:`pathed_env_vars`. By default,
-``CMAKE_MODULE_PATH`` is already excluded. Both settings support ``fnmatch``-style wildcards.
+``CMAKE_MODULE_PATH`` is already excluded. Both settings support :func:`fnmatch`-style wildcards.
 
 .. warning::
    Avoid using :data:`os.pathsep` or hardcoded lists of paths such as

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -389,6 +389,7 @@ config_schema = Schema({
     "release_hooks":                                StrList,
     "context_tracking_context_fields":              StrList,
     "pathed_env_vars":                              StrList,
+    "non_pathed_env_vars":                          StrList,
     "prompt_release_message":                       Bool,
     "critical_styles":                              OptionalStrList,
     "error_styles":                                 OptionalStrList,

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -379,6 +379,7 @@ config_schema = Schema({
     "release_hooks":                                StrList,
     "context_tracking_context_fields":              StrList,
     "pathed_env_vars":                              StrList,
+    "non_pathed_env_vars":                          StrList,
     "prompt_release_message":                       Bool,
     "critical_styles":                              OptionalStrList,
     "error_styles":                                 OptionalStrList,

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -569,6 +569,8 @@ class ActionInterpreter(object):
 
     @classmethod
     def _is_pathed_key(cls, key):
+        if any(fnmatch(key, x) for x in config.non_pathed_env_vars):
+            return False
         return any(fnmatch(key, x) for x in config.pathed_env_vars)
 
     def normalize_path(self, path):

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -558,6 +558,8 @@ class ActionInterpreter(object):
 
     @classmethod
     def _is_pathed_key(cls, key):
+        if any(fnmatch(key, x) for x in config.non_pathed_env_vars):
+            return False
         return any(fnmatch(key, x) for x in config.pathed_env_vars)
 
     def normalize_path(self, path):

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -569,6 +569,7 @@ class ActionInterpreter(object):
 
     @classmethod
     def _is_pathed_key(cls, key):
+        """Return True if ``key`` is a path-like env var subject to normalization."""
         if any(fnmatch(key, x) for x in config.non_pathed_env_vars):
             return False
         return any(fnmatch(key, x) for x in config.pathed_env_vars)

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -538,6 +538,14 @@ pathed_env_vars = [
     "*PATH"
 ]
 
+# This setting identifies environment variables that should NOT have path
+# normalization applied, even if they match a pattern in ``pathed_env_vars``.
+# This is useful for variables like ``CMAKE_MODULE_PATH`` which end in ``PATH``
+# but require forward slashes regardless of the shell. Wildcards are supported.
+non_pathed_env_vars = [
+    "CMAKE_MODULE_PATH"
+]
+
 # Defines what suites on ``$PATH`` stay visible when a new rez environment is resolved.
 # Possible values are:
 #

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -539,6 +539,14 @@ pathed_env_vars = [
     "*PATH"
 ]
 
+# This setting identifies environment variables that should NOT have path
+# normalization applied, even if they match a pattern in ``pathed_env_vars``.
+# This is useful for variables like ``CMAKE_MODULE_PATH`` which end in ``PATH``
+# but require forward slashes regardless of the shell. Wildcards are supported.
+non_pathed_env_vars = [
+    "CMAKE_MODULE_PATH"
+]
+
 # Defines what suites on ``$PATH`` stay visible when a new rez environment is resolved.
 # Possible values are:
 #

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -539,12 +539,13 @@ pathed_env_vars = [
     "*PATH"
 ]
 
-# This setting identifies environment variables that should NOT have path
-# normalization applied, even if they match a pattern in ``pathed_env_vars``.
+# This setting identifies environment variables that should not have path
+# normalization applied, even if they match a pattern in :data:`pathed_env_vars`.
 # This is useful for variables like ``CMAKE_MODULE_PATH`` which end in ``PATH``
 # but require forward slashes regardless of the shell. Wildcards are supported.
+# Takes priority over :data:`pathed_env_vars`.
 non_pathed_env_vars = [
-    "CMAKE_MODULE_PATH"
+    "CMAKE_*_PATH"
 ]
 
 # Defines what suites on ``$PATH`` stay visible when a new rez environment is resolved.

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -5,9 +5,9 @@
 """
 test the rex command generator API
 """
-from rez.rex import RexExecutor, Python, Setenv, Appendenv, Prependenv, Info, \
-    Comment, Alias, Command, Source, Error, Shebang, Unsetenv, expandable, \
-    literal
+from rez.rex import RexExecutor, Python, ActionInterpreter, Setenv, Appendenv, \
+    Prependenv, Info, Comment, Alias, Command, Source, Error, Shebang, Unsetenv, \
+    expandable, literal
 from rez.rex_bindings import VersionBinding, VariantBinding, VariantsBinding, \
     RequirementsBinding, EphemeralsBinding, intersects
 from rez.exceptions import RexError, RexUndefinedVariableError
@@ -546,6 +546,33 @@ class TestRex(TestBase):
         ephemerals = EphemeralsBinding([])
         self.assertRaises(RuntimeError,  # no default
                           intersects, ephemerals.get_range("foo.bar"), "0")
+
+    def test_is_pathed_key(self):
+        """Test that _is_pathed_key correctly identifies path-like env vars."""
+        self.assertTrue(ActionInterpreter._is_pathed_key("PATH"))
+        self.assertTrue(ActionInterpreter._is_pathed_key("PYTHONPATH"))
+        self.assertTrue(ActionInterpreter._is_pathed_key("LD_LIBRARY_PATH"))
+        self.assertTrue(ActionInterpreter._is_pathed_key("SOMEPATH"))
+
+        self.assertFalse(ActionInterpreter._is_pathed_key("FOO"))
+        self.assertFalse(ActionInterpreter._is_pathed_key("HOME"))
+
+    def test_non_pathed_env_vars(self):
+        """Test that non_pathed_env_vars excludes vars from path normalization."""
+        self.assertFalse(ActionInterpreter._is_pathed_key("CMAKE_MODULE_PATH"))
+
+        self.assertTrue(ActionInterpreter._is_pathed_key("PYTHONPATH"))
+        self.assertTrue(ActionInterpreter._is_pathed_key("PATH"))
+
+        config.override("non_pathed_env_vars", [])
+        self.assertTrue(ActionInterpreter._is_pathed_key("CMAKE_MODULE_PATH"))
+
+    def test_non_pathed_env_vars_wildcard_patterns(self):
+        """Test that wildcard patterns work in non_pathed_env_vars."""
+        config.override("non_pathed_env_vars", ["*CMAKE*"])
+        self.assertFalse(ActionInterpreter._is_pathed_key("CMAKE_MODULE_PATH"))
+        self.assertFalse(ActionInterpreter._is_pathed_key("CMAKE_PREFIX_PATH"))
+        self.assertTrue(ActionInterpreter._is_pathed_key("PYTHONPATH"))  # not excluded
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -730,5 +730,35 @@ class TestShells(TestBase, TempdirMixin):
         )
 
 
+    @unittest.skipIf(platform_.name != "windows", "cmd shell path normalization only relevant on Windows")
+    def test_cmd_non_pathed_env_var_not_normalized(self):
+        """Test that CMAKE_MODULE_PATH values are not backslash-converted in cmd shell output.
+
+        CMAKE_MODULE_PATH ends with PATH so it matches the default pathed_env_vars
+        pattern, but it is excluded by default via non_pathed_env_vars. CMake
+        requires forward slashes and breaks if backslashes are used.
+        """
+        sh = create_shell("cmd")
+        sh.setenv("CMAKE_MODULE_PATH", "C:/foo/bar")
+        output = sh.get_output()
+
+        self.assertIn("C:/foo/bar", output)
+        self.assertNotIn("C:\\foo\\bar", output)
+
+    @unittest.skipIf(platform_.name != "windows", "cmd shell path normalization only relevant on Windows")
+    def test_cmd_pathed_env_var_is_normalized(self):
+        """Test that a normal *PATH variable still gets backslash-converted in cmd shell output.
+
+        Ensures that non_pathed_env_vars exclusion does not accidentally suppress
+        normalization for legitimate path variables.
+        """
+        sh = create_shell("cmd")
+        sh.setenv("SOME_CUSTOM_PATH", "C:/foo/bar")
+        output = sh.get_output()
+
+        self.assertIn("C:\\foo\\bar", output)
+        self.assertNotIn("C:/foo/bar", output)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -654,5 +654,35 @@ class TestShells(TestBase, TempdirMixin):
                 assert cls.find_executable(cls.executable_name()) == exe_path
 
 
+    @unittest.skipIf(platform_.name != "windows", "cmd shell path normalization only relevant on Windows")
+    def test_cmd_non_pathed_env_var_not_normalized(self):
+        """Test that CMAKE_MODULE_PATH values are not backslash-converted in cmd shell output.
+
+        CMAKE_MODULE_PATH ends with PATH so it matches the default pathed_env_vars
+        pattern, but it is excluded by default via non_pathed_env_vars. CMake
+        requires forward slashes and breaks if backslashes are used.
+        """
+        sh = create_shell("cmd")
+        sh.setenv("CMAKE_MODULE_PATH", "C:/foo/bar")
+        output = sh.get_output()
+
+        self.assertIn("C:/foo/bar", output)
+        self.assertNotIn("C:\\foo\\bar", output)
+
+    @unittest.skipIf(platform_.name != "windows", "cmd shell path normalization only relevant on Windows")
+    def test_cmd_pathed_env_var_is_normalized(self):
+        """Test that a normal *PATH variable still gets backslash-converted in cmd shell output.
+
+        Ensures that non_pathed_env_vars exclusion does not accidentally suppress
+        normalization for legitimate path variables.
+        """
+        sh = create_shell("cmd")
+        sh.setenv("SOME_CUSTOM_PATH", "C:/foo/bar")
+        output = sh.get_output()
+
+        self.assertIn("C:\\foo\\bar", output)
+        self.assertNotIn("C:/foo/bar", output)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -729,7 +729,6 @@ class TestShells(TestBase, TempdirMixin):
             "Expected rez wrapper .zshenv in ZDOTDIR=%s" % zdotdir,
         )
 
-
     @unittest.skipIf(platform_.name != "windows", "cmd shell path normalization only relevant on Windows")
     def test_cmd_non_pathed_env_var_not_normalized(self):
         """Test that CMAKE_MODULE_PATH values are not backslash-converted in cmd shell output.

--- a/src/rezplugins/build_system/cmake_files/InstallPython.cmake
+++ b/src/rezplugins/build_system/cmake_files/InstallPython.cmake
@@ -107,7 +107,7 @@ macro (install_python)
 			add_custom_command(
 				OUTPUT ${local_fc}
 				COMMAND ${CMAKE_COMMAND} -E make_directory ${pycopy_path}
-				COMMAND ${py_bin} -c 'import py_compile \; py_compile.compile(\"${fabs}\", \"${local_fc}\", None, True)'
+				COMMAND ${py_bin} -c "import py_compile; py_compile.compile('${fabs}', '${local_fc}', None, True)"
 				DEPENDS ${fabs}
 			)
 

--- a/src/rezplugins/build_system/cmake_files/InstallPython.cmake
+++ b/src/rezplugins/build_system/cmake_files/InstallPython.cmake
@@ -109,6 +109,7 @@ macro (install_python)
 				COMMAND ${CMAKE_COMMAND} -E make_directory ${pycopy_path}
 				COMMAND ${py_bin} -c "import py_compile; py_compile.compile('${fabs}', '${local_fc}', None, True)"
 				DEPENDS ${fabs}
+				VERBATIM
 			)
 
 			if(install_pyc)

--- a/src/rezplugins/build_system/cmake_files/InstallPython.cmake
+++ b/src/rezplugins/build_system/cmake_files/InstallPython.cmake
@@ -107,7 +107,7 @@ macro (install_python)
 			add_custom_command(
 				OUTPUT ${local_fc}
 				COMMAND ${CMAKE_COMMAND} -E make_directory ${pycopy_path}
-				COMMAND ${py_bin} -c "import py_compile; py_compile.compile('${fabs}', '${local_fc}', None, True)"
+				COMMAND ${py_bin} -c "import sys; import py_compile; py_compile.compile(sys.argv[1], sys.argv[2], None, True)" ${fabs} ${local_fc}
 				DEPENDS ${fabs}
 				VERBATIM
 			)


### PR DESCRIPTION
Resolves #1321
Resolves #2123

# Premise

## Path normalization

On Windows, rez applies path normalization (converting forward slashes to back slashes) to any environment variable whose name matches the pattern in the `pathed_env_vars` config setting, which defaults to `*PATH`. This is correct behavior for variables like `PATH`, `PYTHONPATH`, and `LD_LIBRARY_PATH`, which need native Windows path separators. However, `CMAKE_MODULE_PATH` also matches `*PATH`, but Cmake requires forward slashes in this variable. 

## Unterminated string literal in `rez_install_python`

When building rez packages on Windows that use `rez_install_python` (with `nmake`), the build fails with a Python `SyntaxError: unterminated string literal`

```
File "<string>", line 1
    'import
    ^
SyntaxError: unterminated string literal (detected at line 1)
```

The root cause is in `InstallPython.cmake` - the `add_custom_command` that compiles `.py` files into `.pyc` uses single quotes around the Python `-c` argument.

```cmake
COMMAND ${py_bin} -c 'import py_compile \; py_compile.compile(...)'
```

On Unix, make dispatches commands via `/bin/sh` where single quotes are valid string delimiters. On Windows, `nmake` dispatches via `cmd.exe`, where single quotes are literal characters, so Python receives `'import` as the start of an unterminated string literal.

# Changes

- Add a new configuration setting, `non_pathed_env_vars`, which is an exclusion list that takes priority over `pathed_env_vars`. 
    - Any variable matching a pattern in this list is except from path normalization, even if it also matches `pathed_env_vars`
    - Supports the same `fnmatch` wildcards as `pathed_env_vars`
    - The default value ships with `CMAKE_MODULE_PATH` out of the box, since this is a known case where we don't want normalization
- Fix `install_python` macro
    - Switch from single quoted shell args to cmake double quoted string for the `-c` argument
    - Add `VERBATIM` keyword to `add_custom_command` so Cmake handles all platform-specific argument quoting correctly

# Tests

- I'm able to build the `hello_world` example package on both Windows and Linux after setting `build_system = "cmake"`
- Add new tests for `ActionInterpreter._is_pathed_key` and `shell.set_env`
- I was unable to write tests for the `rez_install_python` cmake macro, but I verified that it worked manually
