### PR TITLE
Fix shell auto-completion

### DIFF
--- a/src/rez/cli/_complete_util.py
+++ b/src/rez/cli/_complete_util.py
@@ -5,8 +5,9 @@
 import os
 import os.path
 from fnmatch import fnmatch
-from rez.vendor.argcomplete import CompletionFinder, default_validator, \
-    sys_encoding, split_line, debug, USING_PYTHON2
+import locale
+from rez.vendor.argcomplete import CompletionFinder, split_line, debug
+from rez.vendor.argcomplete.finders import default_validator
 
 
 class RezCompletionFinder(CompletionFinder):
@@ -17,11 +18,9 @@ class RezCompletionFinder(CompletionFinder):
         self.validator = default_validator
         self.wordbreaks = " \t\"'@><=;|&(:"  # TODO: might need to be configurable/OS specific
 
-        if USING_PYTHON2:
-            comp_line = comp_line.decode(sys_encoding)
-            comp_point = len(comp_line[:comp_point].decode(sys_encoding))
-        else:
-            comp_point = len(comp_line.encode(sys_encoding)[:comp_point].decode(sys_encoding))
+        sys_encoding = locale.getpreferredencoding()
+
+        comp_point = len(comp_line.encode(sys_encoding)[:comp_point].decode(sys_encoding))
 
         cword_prequote, cword_prefix, cword_suffix, comp_words, \
             first_colon_pos = split_line(comp_line, comp_point)

--- a/src/rez/cli/_complete_util.py
+++ b/src/rez/cli/_complete_util.py
@@ -13,9 +13,13 @@ from rez.vendor.argcomplete.finders import default_validator
 class RezCompletionFinder(CompletionFinder):
     def __init__(self, parser, comp_line, comp_point) -> None:
         self._parser = parser
+        self._formatter = None
         self.always_complete_options = False
         self.exclude = None
         self.validator = default_validator
+        self.print_suppressed = False
+        self._display_completions = {}
+        self.append_space = False
         self.wordbreaks = " \t\"'@><=;|&(:"  # TODO: might need to be configurable/OS specific
 
         sys_encoding = locale.getpreferredencoding()

--- a/src/rez/tests/test_cli.py
+++ b/src/rez/tests/test_cli.py
@@ -6,6 +6,9 @@
 test running of all commandline tools (just -h on each)
 """
 from rez.tests.util import TestBase
+import argparse
+import contextlib
+import io
 import os
 import os.path
 import subprocess
@@ -17,7 +20,30 @@ from unittest.mock import patch
 from rez.system import system
 from rez.cli._entry_points import get_specifications
 from rez.cli._main import setup_parser
+from rez.cli import complete as complete_module
+from rez.cli.complete import command as complete_command
 from rez.vendor.argcomplete import autocomplete
+
+
+@contextlib.contextmanager
+def _disable_fd_9():
+    """Make ``os.fdopen(9, ...)`` raise within the ``with`` block.
+
+    argcomplete unconditionally does ``os.fdopen(9, "w")`` for its debug
+    stream. Under pytest, fd 9 is part of pytest's capture / faulthandler
+    machinery; wrapping it either breaks subsequent tests or breaks pytest
+    shutdown. Forcing the open to fail makes argcomplete fall back to
+    ``sys.stderr``, which is safe.
+    """
+    real_fdopen = os.fdopen
+
+    def fake_fdopen(fd, *args, **kwargs):
+        if fd == 9:
+            raise OSError("fd 9 disabled in tests")
+        return real_fdopen(fd, *args, **kwargs)
+
+    with patch("os.fdopen", side_effect=fake_fdopen):
+        yield
 
 
 class TestImports(TestBase):
@@ -67,21 +93,9 @@ class TestComplete(TestBase):
         os.environ["COMP_LINE"] = command
         os.environ["COMP_POINT"] = str(point)
 
-        # argcomplete's __call__ unconditionally does os.fdopen(9, "w") for a
-        # debug stream. Under pytest, fd 9 is part of pytest's capture /
-        # faulthandler machinery; wrapping it here either breaks subsequent
-        # tests or breaks pytest shutdown. Force the fallback by raising on
-        # fd 9 so debug_stream stays as sys.stderr.
-        real_fdopen = os.fdopen
-
-        def fake_fdopen(fd, *args, **kwargs):
-            if fd == 9:
-                raise OSError("fd 9 disabled in tests")
-            return real_fdopen(fd, *args, **kwargs)
-
         parser = setup_parser()
         with TemporaryFile(mode="w+") as t:
-            with patch("os.fdopen", side_effect=fake_fdopen):
+            with _disable_fd_9():
                 with self.assertRaises(SystemExit) as cm:
                     autocomplete(parser, output_stream=t, exit_method=sys.exit)
             self.assertEqual(cm.exception.code, 0)
@@ -106,6 +120,117 @@ class TestComplete(TestBase):
         self.assertIn("--help", completions)
         self.assertIn("--input", completions)
         self.assertIn("--output", completions)
+
+    def _run_complete_command(self, command, point=None):
+        """Drive ``rez.cli.complete.command()`` (the ``_rez-complete`` tool).
+
+        Unlike ``autocomplete()``, this entry point reads COMP_LINE/COMP_POINT
+        from the environment, prints space-separated completions to stdout,
+        and returns normally (no SystemExit).
+        """
+        if point is None:
+            point = len(command)
+        os.environ["COMP_LINE"] = command
+        os.environ["COMP_POINT"] = str(point)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            complete_command(None, None, None)
+        return set(buf.getvalue().split())
+
+    def test_command_subcommand_listing(self) -> None:
+        """`_rez-complete` for `rez ` should list subcommands."""
+        completions = self._run_complete_command("rez ")
+
+        # Only test a few entries as to not make these tests
+        # annoying to maintain.
+        self.assertIn("env", completions)
+        self.assertIn("build", completions)
+        self.assertGreater(len(completions), 2)
+        # hidden subcommands should not be listed
+        self.assertNotIn("complete", completions)
+        self.assertNotIn("forward", completions)
+
+    def test_command_subcommand_prefix(self) -> None:
+        """`_rez-complete` for `rez bui` should narrow to `build`."""
+        self.assertEqual(
+            self._run_complete_command("rez bui"),
+            {"build"}
+        )
+        self.assertEqual(
+            self._run_complete_command("rez c"),
+            {"config", "context", "cp"}
+        )
+
+    def test_command_subcommand_options(self) -> None:
+        """`_rez-complete` for `rez env --` should exercise RezCompletionFinder.
+
+        This is the path that uses ``rez.cli._complete_util.RezCompletionFinder``
+        (where the locale-aware byte->char COMP_POINT translation lives).
+        """
+        with _disable_fd_9():
+            completions = self._run_complete_command("rez env --")
+
+        # --help is on every parser, --input/--output are env-specific
+        self.assertIn("--help", completions)
+        self.assertIn("--input", completions)
+        self.assertIn("--output", completions)
+
+    def test_command_setup_parser_is_noop(self) -> None:
+        """``complete.setup_parser`` is a no-op; calling it must not modify
+        the parser or raise."""
+        parser = argparse.ArgumentParser()
+        before = list(parser._actions)
+        complete_module.setup_parser(parser)
+        self.assertEqual(parser._actions, before)
+
+    def test_command_invalid_comp_point(self) -> None:
+        """A non-numeric COMP_POINT must fall back to ``len(comp_line)``."""
+        os.environ["COMP_LINE"] = "rez bui"
+        os.environ["COMP_POINT"] = "not-an-int"
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            complete_command(None, None, None)
+        self.assertEqual(set(buf.getvalue().split()), {"build"})
+
+    def test_command_hyphenated_invocation(self) -> None:
+        """``rez-env --`` (the hyphenated form) must take the ``else`` branch
+        that derives the subcommand by splitting on ``-``."""
+        with _disable_fd_9():
+            completions = self._run_complete_command("rez-env --")
+
+        # Same expectations as the `rez env --` case — proves the
+        # `cmd.split("-", 1)[-1]` branch hands off to the same parser.
+        self.assertIn("--help", completions)
+        self.assertIn("--input", completions)
+        self.assertIn("--output", completions)
+
+    def test_command_double_dash_munging(self) -> None:
+        """A `` -- `` sequence in the line must be rewritten to ``--N#`` so
+        that the subcommand parser's ``--N0`` / ``--N1`` actions match."""
+        # `rez env` declares an `--N0` action for args after `--`. We type
+        # ``rez env -- `` so the regex r"\s--\s" matches and the munging
+        # loop runs. The resulting completions come from the env subparser.
+        with _disable_fd_9():
+            completions = self._run_complete_command("rez env -- ")
+
+        # We don't assert specific completions (the args-after-`--` path
+        # invokes an executables/files completer that depends on $PATH and
+        # cwd); we just need the munging loop to have run without raising.
+        # As a sanity check, make sure we got *some* output back.
+        self.assertIsInstance(completions, set)
+
+    def test_command_double_dash_cursor_before_dashes(self) -> None:
+        """When COMP_POINT is before the ``--``, the munging loop must
+        leave comp_point unchanged (the false branch of `if comp_point >= j`).
+        """
+        # Place the cursor early in the line ("rez ", position 4) so that
+        # by the time the munging loop runs, comp_point is below the index
+        # of the inserted N# token.
+        with _disable_fd_9():
+            completions = self._run_complete_command("rez env -- ", point=4)
+        self.assertIsInstance(completions, set)
 
 
 if __name__ == '__main__':

--- a/src/rez/tests/test_cli.py
+++ b/src/rez/tests/test_cli.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import unittest
 from tempfile import TemporaryFile
+from unittest.mock import patch
 
 from rez.system import system
 from rez.cli._entry_points import get_specifications
@@ -66,10 +67,23 @@ class TestComplete(TestBase):
         os.environ["COMP_LINE"] = command
         os.environ["COMP_POINT"] = str(point)
 
+        # argcomplete's __call__ unconditionally does os.fdopen(9, "w") for a
+        # debug stream. Under pytest, fd 9 is part of pytest's capture /
+        # faulthandler machinery; wrapping it here either breaks subsequent
+        # tests or breaks pytest shutdown. Force the fallback by raising on
+        # fd 9 so debug_stream stays as sys.stderr.
+        real_fdopen = os.fdopen
+
+        def fake_fdopen(fd, *args, **kwargs):
+            if fd == 9:
+                raise OSError("fd 9 disabled in tests")
+            return real_fdopen(fd, *args, **kwargs)
+
         parser = setup_parser()
         with TemporaryFile(mode="w+") as t:
-            with self.assertRaises(SystemExit) as cm:
-                autocomplete(parser, output_stream=t, exit_method=sys.exit)
+            with patch("os.fdopen", side_effect=fake_fdopen):
+                with self.assertRaises(SystemExit) as cm:
+                    autocomplete(parser, output_stream=t, exit_method=sys.exit)
             self.assertEqual(cm.exception.code, 0)
             t.seek(0)
             return set(t.read().split(self.IFS))

--- a/src/rez/tests/test_cli.py
+++ b/src/rez/tests/test_cli.py
@@ -6,12 +6,17 @@
 test running of all commandline tools (just -h on each)
 """
 from rez.tests.util import TestBase
+import os
 import os.path
 import subprocess
+import sys
 import unittest
+from tempfile import TemporaryFile
 
 from rez.system import system
 from rez.cli._entry_points import get_specifications
+from rez.cli._main import setup_parser
+from rez.vendor.argcomplete import autocomplete
 
 
 class TestImports(TestBase):
@@ -28,6 +33,65 @@ class TestImports(TestBase):
 
             binfile = os.path.join(system.rez_bin_path, toolname)
             subprocess.check_output([binfile, "-h"])
+
+
+class TestComplete(TestBase):
+    """Test argcomplete-driven completion against the actual rez parser.
+
+    Uses the in-process pattern from argcomplete's own test suite
+    (https://github.com/kislyuk/argcomplete/blob/main/test/test.py): set
+    COMP_LINE/COMP_POINT/_ARGCOMPLETE in the env, call ``autocomplete()``
+    with an output_stream and exit_method, then split the captured output
+    by IFS.
+    """
+
+    IFS = "\013"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved_environ = os.environ.copy()
+        os.environ["_ARGCOMPLETE"] = "1"
+        os.environ["IFS"] = self.IFS
+        os.environ["_ARGCOMPLETE_SHELL"] = "bash"
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._saved_environ)
+        super().tearDown()
+
+    # Inspired by https://github.com/kislyuk/argcomplete/blob/8e5ad6a5a702e5529f61ae9a63f720beda68ffaf/test/test.py#L118-L143  # noqa
+    def _run_completer(self, command, point=None):
+        if point is None:
+            point = len(command)
+        os.environ["COMP_LINE"] = command
+        os.environ["COMP_POINT"] = str(point)
+
+        parser = setup_parser()
+        with TemporaryFile(mode="w+") as t:
+            with self.assertRaises(SystemExit) as cm:
+                autocomplete(parser, output_stream=t, exit_method=sys.exit)
+            self.assertEqual(cm.exception.code, 0)
+            t.seek(0)
+            return set(t.read().split(self.IFS))
+
+    def test_subcommand_completion(self) -> None:
+        """`rez <TAB>` should list subcommands."""
+        completions = self._run_completer("rez ")
+        self.assertIn("env", completions)
+        self.assertIn("build", completions)
+
+    def test_subcommand_prefix(self) -> None:
+        """`rez bui<TAB>` should narrow to `build`."""
+        completions = self._run_completer("rez bui")
+        self.assertEqual(completions, {"build "})
+
+    def test_subcommand_options(self) -> None:
+        """`rez env --<TAB>` should list options for the env subcommand."""
+        completions = self._run_completer("rez env --")
+        # --help is on every parser, --input/--output are env-specific
+        self.assertIn("--help", completions)
+        self.assertIn("--input", completions)
+        self.assertIn("--output", completions)
 
 
 if __name__ == '__main__':

--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -27,12 +27,12 @@ tested.
 <tr><td>
 argcomplete
 </td><td>
-3.1.2 (Sep 16, 2023)
+3.6.3 (Oct 19, 2025)
 </td><td>
 Apache 2.0
 </td><td>
 https://github.com/kislyuk/argcomplete<br>
-Updated (Sept 2025)
+Updated (May 2026)
 </td></tr>
 
 <!-- ######################################################### -->

--- a/src/rez/vendor/argcomplete/_check_console_script.py
+++ b/src/rez/vendor/argcomplete/_check_console_script.py
@@ -11,20 +11,14 @@ https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-cre
 
 Intended to be invoked by argcomplete's global completion function.
 """
+
 import os
 import sys
-
-try:
-    from importlib.metadata import entry_points as importlib_entry_points
-    from importlib.metadata import EntryPoint
-    use_entry_points_backport = False
-except ImportError:
-    from importlib_metadata import entry_points as importlib_entry_points  # type:ignore
-    from importlib_metadata import EntryPoint # type:ignore
-    use_entry_points_backport = True
+from importlib.metadata import EntryPoint
+from importlib.metadata import entry_points as importlib_entry_points
+from typing import Iterable
 
 from ._check_module import ArgcompleteMarkerNotFound, find
-from typing import Iterable
 
 
 def main():
@@ -35,16 +29,14 @@ def main():
     # assuming it is actually a console script.
     name = os.path.basename(script_path)
 
-    entry_points : Iterable[EntryPoint] = importlib_entry_points() # type:ignore
+    entry_points: Iterable[EntryPoint] = importlib_entry_points()  # type:ignore
 
-    # The importlib_metadata backport returns a tuple of entry point objects
-    # whereas the official library returns a SelectableGroups object
-    # Python 3.12+ behaves like the importlib_metadata backport
-    if not use_entry_points_backport and sys.version_info < (3, 12):
-        entry_points = entry_points["console_scripts"] # type:ignore
+    # Python 3.12+ returns a tuple of entry point objects
+    # whereas <=3.11 returns a SelectableGroups object
+    if sys.version_info < (3, 12):
+        entry_points = entry_points["console_scripts"]  # type:ignore
 
-    entry_points = [ep for ep in entry_points \
-            if ep.name == name and ep.group == "console_scripts" ] # type:ignore
+    entry_points = [ep for ep in entry_points if ep.name == name and ep.group == "console_scripts"]  # type:ignore
 
     if not entry_points:
         raise ArgcompleteMarkerNotFound("no entry point found matching script")

--- a/src/rez/vendor/argcomplete/_check_module.py
+++ b/src/rez/vendor/argcomplete/_check_module.py
@@ -6,33 +6,11 @@ The module name should be specified in a form usable with `python -m`.
 
 Intended to be invoked by argcomplete's global completion function.
 """
+
 import os
 import sys
 import tokenize
-
-try:
-    from importlib.util import find_spec  # type:ignore
-except ImportError:
-    import typing as t
-    from collections import namedtuple
-    from imp import find_module
-
-    ModuleSpec = namedtuple("ModuleSpec", ["origin", "has_location", "submodule_search_locations"])
-
-    def find_spec(  # type:ignore
-        name: str,
-        package: t.Optional[str] = None,
-    ) -> t.Optional[ModuleSpec]:
-        """Minimal implementation as required by `find`."""
-        try:
-            f, path, _ = find_module(name)
-        except ImportError:
-            return None
-        has_location = path is not None
-        if f is None:
-            return ModuleSpec(None, has_location, [path])
-        f.close()
-        return ModuleSpec(path, has_location, None)
+from importlib.util import find_spec
 
 
 class ArgcompleteMarkerNotFound(RuntimeError):
@@ -41,7 +19,12 @@ class ArgcompleteMarkerNotFound(RuntimeError):
 
 def find(name, return_package=False):
     names = name.split(".")
-    spec = find_spec(names[0])
+    # Look for the first importlib ModuleSpec that has `origin` set, indicating it's not a namespace package.
+    for package_name_boundary in range(len(names)):
+        spec = find_spec(".".join(names[: package_name_boundary + 1]))
+        if spec is not None and spec.origin is not None:
+            break
+
     if spec is None:
         raise ArgcompleteMarkerNotFound('no module named "{}"'.format(names[0]))
     if not spec.has_location:
@@ -52,7 +35,7 @@ def find(name, return_package=False):
         return spec.origin
     if len(spec.submodule_search_locations) != 1:
         raise ArgcompleteMarkerNotFound("expecting one search location")
-    path = os.path.join(spec.submodule_search_locations[0], *names[1:])
+    path = os.path.join(spec.submodule_search_locations[0], *names[package_name_boundary + 1 :])
     if os.path.isdir(path):
         filename = "__main__.py"
         if return_package:

--- a/src/rez/vendor/argcomplete/bash_completion.d/_python-argcomplete
+++ b/src/rez/vendor/argcomplete/bash_completion.d/_python-argcomplete
@@ -1,9 +1,15 @@
-#compdef -P *
+#compdef -default-
 
+# argcomplete global completion loader for zsh and bash
 # Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors.
 # Licensed under the Apache License. See https://github.com/kislyuk/argcomplete for more info.
 
 # Note: both the leading underscore in the name of this file and the first line (compdef) are required by zsh
+
+# In zsh, this file is autoloaded and used as the default completer (_default).
+# There are many other special contexts we don't want to override
+# (as would be the case with `#compdef -P *`).
+# https://zsh.sourceforge.io/Doc/Release/Completion-System.html
 
 # Copy of __expand_tilde_by_ref from bash-completion
 # ZSH implementation added
@@ -41,9 +47,9 @@ __python_argcomplete_run() {
 
 __python_argcomplete_run_inner() {
     if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1 </dev/null
     else
-        "$@" 8>&1 9>&2 1>&9 2>&1
+        "$@" 8>&1 9>&2 1>&9 2>&1 </dev/null
     fi
 }
 
@@ -71,6 +77,7 @@ __python_argcomplete_scan_head() {
     local file="$1"
     local target="$2"
 
+    local REPLY
     if [[ -n "${ZSH_VERSION-}" ]]; then
         read -r -k 1024 -u 0 < "$file";
     else
@@ -138,11 +145,8 @@ _python_argcomplete_global() {
         req_argv=( "" "${COMP_WORDS[@]:1}" )
         __python_argcomplete_expand_tilde_by_ref executable
     else
-        # TODO: check if we should call _default or use a different condition here
-        if [[ "$service" != "-default-" ]]; then
-            return
-        fi
         executable="${words[1]}"
+        __python_argcomplete_expand_tilde_by_ref executable
         req_argv=( "${words[@]:1}" )
     fi
 
@@ -189,7 +193,8 @@ _python_argcomplete_global() {
             if (__python_argcomplete_scan_head_noerr "$SCRIPT_NAME" easy_install \
                 && "${interpreter[@]}" "$(__python_argcomplete_which python-argcomplete-check-easy-install-script)" "$SCRIPT_NAME") >/dev/null 2>&1; then
                 ARGCOMPLETE=1
-            elif __python_argcomplete_run "${interpreter[@]}" -m argcomplete._check_console_script "$SCRIPT_NAME"; then
+            elif ([[ "${interpreter[@]}" == *python* ]] || [[ "${interpreter[@]}" == *pypy* ]])\
+                && __python_argcomplete_run "${interpreter[@]}" -m argcomplete._check_console_script "$SCRIPT_NAME"; then
                 ARGCOMPLETE=1
             fi
         fi
@@ -206,7 +211,15 @@ _python_argcomplete_global() {
                 _ARGCOMPLETE_SHELL="zsh" \
                 _ARGCOMPLETE_SUPPRESS_SPACE=1 \
                 __python_argcomplete_run "$executable" "${(@)req_argv[1, ${ARGCOMPLETE}-1]}"))
-            _describe "$executable" completions
+            local nosort=()
+            local nospace=()
+            if is-at-least 5.8; then
+                nosort=(-o nosort)
+            fi
+            if [[ "${completions-}" =~ ([^\\\\]): && "${BASH_REMATCH[2]}" =~ [=/:] ]]; then
+                nospace=(-S '')
+            fi
+            _describe "$executable" completions "${nosort[@]}" "${nospace[@]}"
         else
             COMPREPLY=($(IFS="$IFS" \
                 COMP_LINE="$COMP_LINE" \
@@ -232,5 +245,20 @@ _python_argcomplete_global() {
 if [[ -z "${ZSH_VERSION-}" ]]; then
     complete -o default -o bashdefault -D -F _python_argcomplete_global
 else
-    compdef _python_argcomplete_global -P '*'
+    # -Uz is recommended for the use of functions supplied with the zsh distribution.
+    # https://unix.stackexchange.com/a/214306
+    autoload -Uz is-at-least
+    # If this is being implicitly loaded because we placed it on fpath,
+    # the comment at the top of this file causes zsh to invoke this script directly,
+    # so we must explicitly call the global completion function.
+    # Note $service should only ever be -default- because the comment at the top
+    # registers this script as the default completer (#compdef -default-).
+    if [[ $service == -default- ]]; then
+        _python_argcomplete_global
+    fi
+    # If this has been executed directly (e.g. `eval "$(activate-global-python-argcomplete --dest=-)"`)
+    # we need to explicitly call compdef to register the completion function.
+    # If we have been implicitly loaded, we still call compdef as a slight optimisation
+    # (there is no need to execute any top-level code more than once).
+    compdef _python_argcomplete_global -default-
 fi

--- a/src/rez/vendor/argcomplete/completers.py
+++ b/src/rez/vendor/argcomplete/completers.py
@@ -22,7 +22,7 @@ class BaseCompleter:
 
     def __call__(
         self, *, prefix: str, action: argparse.Action, parser: argparse.ArgumentParser, parsed_args: argparse.Namespace
-    ):
+    ) -> None:
         raise NotImplementedError("This method should be implemented by a subclass.")
 
 
@@ -59,13 +59,26 @@ class FilesCompleter(BaseCompleter):
         completion = []
         if self.allowednames:
             if self.directories:
-                files = _call(["bash", "-c", "compgen -A directory -- '{p}'".format(p=prefix)])
+                # Using 'bind' in this and the following commands is a workaround to a bug in bash
+                # that was fixed in bash 5.3 but affects older versions. Environment variables are not treated
+                # correctly in older versions and calling bind makes them available. For details, see
+                # https://savannah.gnu.org/support/index.php?111125
+                files = _call(
+                    ["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+                )
                 completion += [f + "/" for f in files]
             for x in self.allowednames:
-                completion += _call(["bash", "-c", "compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)])
+                completion += _call(
+                    ["bash", "-c", "bind; compgen -A file -X '!*.{0}' -- '{p}'".format(x, p=prefix)],
+                    stderr=subprocess.DEVNULL,
+                )
         else:
-            completion += _call(["bash", "-c", "compgen -A file -- '{p}'".format(p=prefix)])
-            anticomp = _call(["bash", "-c", "compgen -A directory -- '{p}'".format(p=prefix)])
+            completion += _call(
+                ["bash", "-c", "bind; compgen -A file -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+            )
+            anticomp = _call(
+                ["bash", "-c", "bind; compgen -A directory -- '{p}'".format(p=prefix)], stderr=subprocess.DEVNULL
+            )
             completion = list(set(completion) - set(anticomp))
 
             if self.directories:

--- a/src/rez/vendor/argcomplete/finders.py
+++ b/src/rez/vendor/argcomplete/finders.py
@@ -7,10 +7,10 @@ import argparse
 import os
 import sys
 from collections.abc import Mapping
-from typing import Callable, Dict, List, Optional, Sequence, Union
+from typing import Callable, Dict, List, Optional, Sequence, TextIO, Union
 
 from . import io as _io
-from .completers import ChoicesCompleter, FilesCompleter, SuppressCompleter
+from .completers import BaseCompleter, ChoicesCompleter, FilesCompleter, SuppressCompleter
 from .io import debug, mute_stderr
 from .lexers import split_line
 from .packages._argparse import IntrospectiveArgumentParser, action_is_greedy, action_is_open, action_is_satisfied
@@ -48,6 +48,7 @@ class CompletionFinder(object):
         append_space=None,
     ):
         self._parser = argument_parser
+        self._formatter = None
         self.always_complete_options = always_complete_options
         self.exclude = exclude
         if validator is None:
@@ -66,13 +67,13 @@ class CompletionFinder(object):
         argument_parser: argparse.ArgumentParser,
         always_complete_options: Union[bool, str] = True,
         exit_method: Callable = os._exit,
-        output_stream=None,
+        output_stream: Optional[TextIO] = None,
         exclude: Optional[Sequence[str]] = None,
         validator: Optional[Callable] = None,
         print_suppressed: bool = False,
         append_space: Optional[bool] = None,
-        default_completer=FilesCompleter(),
-    ):
+        default_completer: BaseCompleter = FilesCompleter(),
+    ) -> None:
         """
         :param argument_parser: The argument parser to autocomplete on
         :param always_complete_options:
@@ -117,11 +118,7 @@ class CompletionFinder(object):
             # not an argument completion invocation
             return
 
-        try:
-            _io.debug_stream = os.fdopen(9, "w")
-        except Exception:
-            _io.debug_stream = sys.stderr
-        debug()
+        self._init_debug_stream()
 
         if output_stream is None:
             filename = os.environ.get("_ARGCOMPLETE_STDOUT_FILENAME")
@@ -135,6 +132,8 @@ class CompletionFinder(object):
             except Exception:
                 debug("Unable to open fd 8 for writing, quitting")
                 exit_method(1)
+
+        assert output_stream is not None
 
         ifs = os.environ.get("_ARGCOMPLETE_IFS", "\013")
         if len(ifs) != 1:
@@ -189,6 +188,19 @@ class CompletionFinder(object):
         output_stream.flush()
         _io.debug_stream.flush()
         exit_method(0)
+
+    def _init_debug_stream(self):
+        """Initialize debug output stream
+
+        By default, writes to file descriptor 9, or stderr if that fails.
+        This can be overridden by derived classes, for example to avoid
+        clashes with file descriptors being used elsewhere (such as in pytest).
+        """
+        try:
+            _io.debug_stream = os.fdopen(9, "w")
+        except Exception:
+            _io.debug_stream = sys.stderr
+        debug()
 
     def _get_completions(self, comp_words, cword_prefix, cword_prequote, last_wordbreak_pos):
         active_parsers = self._patch_argument_parser()
@@ -272,6 +284,15 @@ class CompletionFinder(object):
 
         return self.active_parsers
 
+    def _get_action_help(self, action):
+        if action.help is None:
+            return ""
+        if "%" not in action.help:
+            return action.help
+        if self._formatter is None:
+            self._formatter = self._parser.formatter_class(prog=self._parser.prog)
+        return self._formatter._expand_help(action)
+
     def _get_subparser_completions(self, parser, cword_prefix):
         aliases_by_parser: Dict[argparse.ArgumentParser, List[str]] = {}
         for key in parser.choices.keys():
@@ -281,7 +302,7 @@ class CompletionFinder(object):
         for action in parser._get_subactions():
             for alias in aliases_by_parser[parser.choices[action.dest]]:
                 if alias.startswith(cword_prefix):
-                    self._display_completions[alias] = action.help or ""
+                    self._display_completions[alias] = self._get_action_help(action)
 
         completions = [subcmd for subcmd in parser.choices.keys() if subcmd.startswith(cword_prefix)]
         return completions
@@ -302,7 +323,7 @@ class CompletionFinder(object):
             if action.option_strings:
                 for option_string in action.option_strings:
                     if option_string.startswith(cword_prefix):
-                        self._display_completions[option_string] = action.help or ""
+                        self._display_completions[option_string] = self._get_action_help(action)
 
         option_completions = []
         for action in parser._actions:
@@ -394,7 +415,7 @@ class CompletionFinder(object):
                             if self.validator(completion, cword_prefix):
                                 completions.append(completion)
                                 if isinstance(completer, ChoicesCompleter):
-                                    self._display_completions[completion] = active_action.help or ""
+                                    self._display_completions[completion] = self._get_action_help(active_action)
                                 else:
                                     self._display_completions[completion] = ""
                 else:
@@ -504,7 +525,7 @@ class CompletionFinder(object):
             # Bash mangles completions which contain characters in COMP_WORDBREAKS.
             # This workaround has the same effect as __ltrim_colon_completions in bash_completion
             # (extended to characters other than the colon).
-            if last_wordbreak_pos:
+            if last_wordbreak_pos is not None:
                 completions = [c[last_wordbreak_pos + 1 :] for c in completions]
             special_chars += "();<>|&!`$* \t\n\"'"
         elif cword_prequote == '"':
@@ -525,19 +546,29 @@ class CompletionFinder(object):
             special_chars = special_chars.replace('`', '')
         else:
             escape_char = "\\"
-        for char in special_chars:
-            completions = [c.replace(char, escape_char + char) for c in completions]
+            if os.environ.get("_ARGCOMPLETE_SHELL") == "zsh":
+                # zsh uses colon as a separator between a completion and its description.
+                special_chars += ":"
+
+        escaped_completions = []
+        for completion in completions:
+            escaped_completion = completion
+            for char in special_chars:
+                escaped_completion = escaped_completion.replace(char, escape_char + char)
+            escaped_completions.append(escaped_completion)
+            if completion in self._display_completions:
+                self._display_completions[escaped_completion] = self._display_completions[completion]
 
         if self.append_space:
             # Similar functionality in bash was previously turned off by supplying the "-o nospace" option to complete.
             # Now it is conditionally disabled using "compopt -o nospace" if the match ends in a continuation character.
             # This code is retained for environments where this isn't done natively.
             continuation_chars = "=/:"
-            if len(completions) == 1 and completions[0][-1] not in continuation_chars:
+            if len(escaped_completions) == 1 and escaped_completions[0][-1] not in continuation_chars:
                 if cword_prequote == "":
-                    completions[0] += " "
+                    escaped_completions[0] += " "
 
-        return completions
+        return escaped_completions
 
     def rl_complete(self, text, state):
         """
@@ -569,7 +600,7 @@ class CompletionFinder(object):
 
     def get_display_completions(self):
         """
-        This function returns a mapping of option names to their help strings for displaying to the user.
+        This function returns a mapping of completions to their help strings for displaying to the user.
         """
         return self._display_completions
 

--- a/src/rez/vendor/argcomplete/packages/_argparse.py
+++ b/src/rez/vendor/argcomplete/packages/_argparse.py
@@ -75,7 +75,7 @@ class IntrospectiveArgumentParser(ArgumentParser):
     except for the lines that contain the string "Added by argcomplete".
     '''
 
-    def _parse_known_args(self, arg_strings, namespace):
+    def _parse_known_args(self, arg_strings, namespace, intermixed=False, **kwargs):
         _num_consumed_args.clear()  # Added by argcomplete
         self._argcomplete_namespace = namespace
         self.active_actions: List[Action] = []  # Added by argcomplete
@@ -162,7 +162,12 @@ class IntrospectiveArgumentParser(ArgumentParser):
         def consume_optional(start_index):
             # get the optional identified at this index
             option_tuple = option_string_indices[start_index]
-            action, option_string, explicit_arg = option_tuple
+            if isinstance(option_tuple, list):  # Python 3.12.7+
+                option_tuple = option_tuple[0]
+            if len(option_tuple) == 3:
+                action, option_string, explicit_arg = option_tuple
+            else:  # Python 3.11.9+, 3.12.3+, 3.13+
+                action, option_string, _, explicit_arg = option_tuple
 
             # identify additional optionals in the same arg string
             # (e.g. -xyz is the same as -x -y -z if no args are required)

--- a/src/rez/vendor/argcomplete/packages/_shlex.py
+++ b/src/rez/vendor/argcomplete/packages/_shlex.py
@@ -36,7 +36,7 @@ class shlex:
         else:
             self.eof = ''
         self.commenters = '#'
-        self.wordchars = 'abcdfeghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_'
+        self.wordchars = 'abcdfeghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_'
         # Modified by argcomplete: 2/3 compatibility
         # if self.posix:
         #     self.wordchars += ('ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
@@ -177,6 +177,9 @@ class shlex:
                 elif self.whitespace_split:
                     self.token = nextchar
                     self.state = 'a'
+                    # Modified by argcomplete: Record last wordbreak position
+                    if nextchar in self.wordbreaks:
+                        self.last_wordbreak_pos = len(self.token) - 1
                 else:
                     self.token = nextchar
                     if self.token or (self.posix and quoted):

--- a/src/rez/vendor/argcomplete/scripts/activate_global_python_argcomplete.py
+++ b/src/rez/vendor/argcomplete/scripts/activate_global_python_argcomplete.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+
+# Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors.
+# Licensed under the Apache License. See https://github.com/kislyuk/argcomplete for more info.
+
+"""
+Activate the generic bash-completion script or zsh completion autoload function for the argcomplete module.
+"""
+
+import argparse
+import os
+import shutil
+import site
+import subprocess
+import sys
+
+import rez.vendor.argcomplete as argcomplete
+
+# PEP 366
+__package__ = "argcomplete.scripts"
+
+zsh_shellcode = """
+# Begin added by argcomplete
+fpath=( {zsh_fpath} "${{fpath[@]}}" )
+# End added by argcomplete
+"""
+
+bash_shellcode = """
+# Begin added by argcomplete
+source "{activator}"
+# End added by argcomplete
+"""
+
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument("-y", "--yes", help="automatically answer yes for all questions", action="store_true")
+parser.add_argument("--dest", help='Specify the shell completion modules directory to install into, or "-" for stdout')
+parser.add_argument("--user", help="Install into user directory", action="store_true")
+argcomplete.autocomplete(parser)
+args = None
+
+
+def get_local_dir():
+    try:
+        return subprocess.check_output(["brew", "--prefix"]).decode().strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "/usr/local"
+
+
+def get_zsh_system_dir():
+    return f"{get_local_dir()}/share/zsh/site-functions"
+
+
+def get_bash_system_dir():
+    if "BASH_COMPLETION_COMPAT_DIR" in os.environ:
+        return os.environ["BASH_COMPLETION_COMPAT_DIR"]
+    elif sys.platform == "darwin":
+        return f"{get_local_dir()}/etc/bash_completion.d"  # created by homebrew
+    else:
+        return "/etc/bash_completion.d"  # created by bash-completion
+
+
+def get_activator_dir():
+    return os.path.join(os.path.abspath(os.path.dirname(argcomplete.__file__)), "bash_completion.d")
+
+
+def get_activator_path():
+    return os.path.join(get_activator_dir(), "_python-argcomplete")
+
+
+def install_to_destination(dest):
+    activator = get_activator_path()
+    if dest == "-":
+        with open(activator) as fh:
+            sys.stdout.write(fh.read())
+        return
+    destdir = os.path.dirname(dest)
+    if not os.path.exists(destdir):
+        try:
+            os.makedirs(destdir, exist_ok=True)
+        except Exception as e:
+            parser.error(
+                f"path {destdir} does not exist and could not be created: {e}. Please run this command using sudo, or see --help for more options."
+            )
+    try:
+        print(f"Installing {activator} to {dest}...", file=sys.stderr)
+        shutil.copy(activator, dest)
+        print("Installed.", file=sys.stderr)
+    except Exception as e:
+        parser.error(
+            f"while installing to {dest}: {e}. Please run this command using sudo, or see --help for more options."
+        )
+
+
+def get_consent():
+    assert args is not None
+    if args.yes is True:
+        return True
+    while True:
+        res = input("OK to proceed? [y/n] ")
+        if res.lower() not in {"y", "n", "yes", "no"}:
+            print('Please answer "yes" or "no".', file=sys.stderr)
+        elif res.lower() in {"y", "yes"}:
+            return True
+        else:
+            return False
+
+
+def append_to_config_file(path, shellcode):
+    if os.path.exists(path):
+        with open(path, 'r') as fh:
+            if shellcode in fh.read():
+                print(f"The code already exists in the file {path}.", file=sys.stderr)
+                return
+        print(f"argcomplete needs to append to the file {path}. The following code will be appended:", file=sys.stderr)
+        for line in shellcode.splitlines():
+            print(">", line, file=sys.stderr)
+        if not get_consent():
+            print("Not added.", file=sys.stderr)
+            return
+    print(f"Adding shellcode to {path}...", file=sys.stderr)
+    with open(path, "a") as fh:
+        fh.write(shellcode)
+    print("Added.", file=sys.stderr)
+
+
+def link_zsh_user_rcfile(zsh_fpath=None):
+    zsh_rcfile = os.path.join(os.path.expanduser(os.environ.get("ZDOTDIR", "~")), ".zshenv")
+    append_to_config_file(zsh_rcfile, zsh_shellcode.format(zsh_fpath=zsh_fpath or get_activator_dir()))
+
+
+def link_bash_user_rcfile():
+    bash_completion_user_file = os.path.expanduser("~/.bash_completion")
+    append_to_config_file(bash_completion_user_file, bash_shellcode.format(activator=get_activator_path()))
+
+
+def link_user_rcfiles():
+    # TODO: warn if running as superuser
+    link_zsh_user_rcfile()
+    link_bash_user_rcfile()
+
+
+def add_zsh_system_dir_to_fpath_for_user():
+    if "zsh" not in os.environ.get("SHELL", ""):
+        return
+    try:
+        zsh_system_dir = get_zsh_system_dir()
+        fpath_output = subprocess.check_output([os.environ["SHELL"], "-c", 'printf "%s\n" "${fpath[@]}"'])
+        for fpath in fpath_output.decode().splitlines():
+            if fpath == zsh_system_dir:
+                return
+        link_zsh_user_rcfile(zsh_fpath=zsh_system_dir)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+
+def main():
+    global args
+    args = parser.parse_args()
+
+    destinations = []
+
+    if args.dest:
+        if args.dest != "-" and not os.path.exists(args.dest):
+            parser.error(f"directory {args.dest} was specified via --dest, but it does not exist")
+        destinations.append(args.dest)
+    elif site.ENABLE_USER_SITE and site.USER_SITE and site.USER_SITE in argcomplete.__file__:
+        print(
+            "Argcomplete was installed in the user site local directory. Defaulting to user installation.",
+            file=sys.stderr,
+        )
+        link_user_rcfiles()
+    elif sys.prefix != sys.base_prefix:
+        print("Argcomplete was installed in a virtual environment. Defaulting to user installation.", file=sys.stderr)
+        link_user_rcfiles()
+    elif args.user:
+        link_user_rcfiles()
+    else:
+        print("Defaulting to system-wide installation.", file=sys.stderr)
+        destinations.append(f"{get_zsh_system_dir()}/_python-argcomplete")
+        destinations.append(f"{get_bash_system_dir()}/python-argcomplete")
+
+    for destination in destinations:
+        install_to_destination(destination)
+
+    add_zsh_system_dir_to_fpath_for_user()
+
+    if args.dest is None:
+        print("Please restart your shell or source the installed file to activate it.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rez/vendor/argcomplete/scripts/python_argcomplete_check_easy_install_script.py
+++ b/src/rez/vendor/argcomplete/scripts/python_argcomplete_check_easy_install_script.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors.
+# Licensed under the Apache License. See https://github.com/kislyuk/argcomplete for more info.
+
+"""
+This script is part of the Python argcomplete package (https://github.com/kislyuk/argcomplete).
+It is used to check if an EASY-INSTALL-SCRIPT wrapper redirects to a script that contains the string
+"PYTHON_ARGCOMPLETE_OK". If you have enabled global completion in argcomplete, the completion hook will run it every
+time you press <TAB> in your shell.
+
+Usage:
+    python-argcomplete-check-easy-install-script <input executable file>
+"""
+
+import sys
+
+# PEP 366
+__package__ = "argcomplete.scripts"
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+
+    sys.tracebacklimit = 0
+
+    with open(sys.argv[1]) as fh:
+        line1, head = fh.read(1024).split("\n", 1)[:2]
+        if line1.startswith("#") and ("py" in line1 or "Py" in line1):
+            import re
+
+            lines = head.split("\n", 12)
+            for line in lines:
+                if line.startswith("# EASY-INSTALL-SCRIPT"):
+                    import pkg_resources  # type: ignore
+
+                    re_match = re.match("# EASY-INSTALL-SCRIPT: '(.+)','(.+)'", line)
+                    assert re_match is not None
+                    dist, script = re_match.groups()
+                    if "PYTHON_ARGCOMPLETE_OK" in pkg_resources.get_distribution(dist).get_metadata(
+                        "scripts/" + script
+                    ):
+                        return 0
+                elif line.startswith("# EASY-INSTALL-ENTRY-SCRIPT"):
+                    re_match = re.match("# EASY-INSTALL-ENTRY-SCRIPT: '(.+)','(.+)','(.+)'", line)
+                    assert re_match is not None
+                    dist, group, name = re_match.groups()
+                    import pkgutil
+
+                    import pkg_resources  # type: ignore
+
+                    entry_point_info = pkg_resources.get_distribution(dist).get_entry_info(group, name)
+                    assert entry_point_info is not None
+                    module_name = entry_point_info.module_name
+                    with open(pkgutil.get_loader(module_name).get_filename()) as mod_fh:  # type: ignore
+                        if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
+                            return 0
+                elif line.startswith("# EASY-INSTALL-DEV-SCRIPT"):
+                    for line2 in lines:
+                        if line2.startswith("__file__"):
+                            re_match = re.match("__file__ = '(.+)'", line2)
+                            assert re_match is not None
+                            filename = re_match.group(1)
+                            with open(filename) as mod_fh:
+                                if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
+                                    return 0
+                elif line.startswith("# PBR Generated"):
+                    re_match = re.search("from (.*) import", head)
+                    assert re_match is not None
+                    module = re_match.groups()[0]
+                    import pkgutil
+
+                    import pkg_resources  # type: ignore
+
+                    with open(pkgutil.get_loader(module).get_filename()) as mod_fh:  # type: ignore
+                        if "PYTHON_ARGCOMPLETE_OK" in mod_fh.read(1024):
+                            return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rez/vendor/argcomplete/scripts/register_python_argcomplete.py
+++ b/src/rez/vendor/argcomplete/scripts/register_python_argcomplete.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+
+# Copyright 2012-2023, Andrey Kislyuk and argcomplete contributors.
+# Licensed under the Apache License. See https://github.com/kislyuk/argcomplete for more info.
+
+"""
+Register a Python executable for use with the argcomplete module.
+
+To perform the registration, source the output of this script in your bash shell
+(quote the output to avoid interpolation).
+
+Example:
+
+    $ eval "$(register-python-argcomplete my-favorite-script.py)"
+
+For Tcsh
+
+    $ eval `register-python-argcomplete --shell tcsh my-favorite-script.py`
+
+For Fish
+
+    $ register-python-argcomplete --shell fish my-favourite-script.py > ~/.config/fish/my-favourite-script.py.fish
+"""
+
+import argparse
+import sys
+
+import rez.vendor.argcomplete as argcomplete
+
+# PEP 366
+__package__ = "argcomplete.scripts"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        "--no-defaults",
+        dest="use_defaults",
+        action="store_false",
+        default=True,
+        help="when no matches are generated, do not fallback to readline's default completion (affects bash only)",
+    )
+    parser.add_argument(
+        "--complete-arguments",
+        nargs=argparse.REMAINDER,
+        help="arguments to call complete with; use of this option discards default options (affects bash only)",
+    )
+    parser.add_argument(
+        "-s",
+        "--shell",
+        choices=("bash", "zsh", "tcsh", "fish", "powershell"),
+        default="bash",
+        help="output code for the specified shell",
+    )
+    parser.add_argument(
+        "-e", "--external-argcomplete-script", help="external argcomplete script for auto completion of the executable"
+    )
+
+    parser.add_argument("executable", nargs="+", help="executable to completed (when invoked by exactly this name)")
+
+    argcomplete.autocomplete(parser)
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    sys.stdout.write(
+        argcomplete.shellcode(
+            args.executable, args.use_defaults, args.shell, args.complete_arguments, args.external_argcomplete_script
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rez/vendor/argcomplete/shell_integration.py
+++ b/src/rez/vendor/argcomplete/shell_integration.py
@@ -5,7 +5,7 @@
 
 from shlex import quote
 
-bashcode = r"""
+bashcode = r"""#compdef %(executables)s
 # Run something, muting output or redirecting it to the debug stream
 # depending on the value of _ARC_DEBUG.
 # If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
@@ -24,14 +24,15 @@ __python_argcomplete_run() {
 
 __python_argcomplete_run_inner() {
     if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1 </dev/null
     else
-        "$@" 8>&1 9>&2 1>&9 2>&1
+        "$@" 8>&1 9>&2 1>&9 2>&1 </dev/null
     fi
 }
 
 _python_argcomplete%(function_suffix)s() {
     local IFS=$'\013'
+    local script="%(argcomplete_script)s"
     if [[ -n "${ZSH_VERSION-}" ]]; then
         local completions
         completions=($(IFS="$IFS" \
@@ -40,8 +41,16 @@ _python_argcomplete%(function_suffix)s() {
             _ARGCOMPLETE=1 \
             _ARGCOMPLETE_SHELL="zsh" \
             _ARGCOMPLETE_SUPPRESS_SPACE=1 \
-            __python_argcomplete_run "${words[1]}") )
-        _describe "${words[1]}" completions -o nosort
+            __python_argcomplete_run ${script:-${words[1]}}))
+        local nosort=()
+        local nospace=()
+        if is-at-least 5.8; then
+            nosort=(-o nosort)
+        fi
+        if [[ "${completions-}" =~ ([^\\\\]): && "${match[1]}" =~ [=/:] ]]; then
+            nospace=(-S '')
+        fi
+        _describe "${words[1]}" completions "${nosort[@]}" "${nospace[@]}"
     else
         local SUPPRESS_SPACE=0
         if compopt +o nospace 2> /dev/null; then
@@ -55,7 +64,7 @@ _python_argcomplete%(function_suffix)s() {
             _ARGCOMPLETE=1 \
             _ARGCOMPLETE_SHELL="bash" \
             _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-            __python_argcomplete_run "%(argcomplete_script)s"))
+            __python_argcomplete_run ${script:-$1}))
         if [[ $? != 0 ]]; then
             unset COMPREPLY
         elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
@@ -66,7 +75,16 @@ _python_argcomplete%(function_suffix)s() {
 if [[ -z "${ZSH_VERSION-}" ]]; then
     complete %(complete_opts)s -F _python_argcomplete%(function_suffix)s %(executables)s
 else
-    compdef _python_argcomplete%(function_suffix)s %(executables)s
+    # When called by the Zsh completion system, this will end with
+    # "loadautofunc" when initially autoloaded and "shfunc" later on, otherwise,
+    # the script was "eval"-ed so use "compdef" to register it with the
+    # completion system
+    autoload is-at-least
+    if [[ $zsh_eval_context == *func ]]; then
+        _python_argcomplete%(function_suffix)s "$@"
+    else
+        compdef _python_argcomplete%(function_suffix)s %(executables)s
+    fi
 fi
 """
 
@@ -76,14 +94,14 @@ complete "%(executable)s" 'p@*@`python-argcomplete-tcsh "%(argcomplete_script)s"
 
 fishcode = r"""
 function __fish_%(function_name)s_complete
-    set -x _ARGCOMPLETE 1
-    set -x _ARGCOMPLETE_DFS \t
-    set -x _ARGCOMPLETE_IFS \n
-    set -x _ARGCOMPLETE_SUPPRESS_SPACE 1
-    set -x _ARGCOMPLETE_SHELL fish
-    set -x COMP_LINE (commandline -p)
-    set -x COMP_POINT (string length (commandline -cp))
-    set -x COMP_TYPE
+    set -lx _ARGCOMPLETE 1
+    set -lx _ARGCOMPLETE_DFS \t
+    set -lx _ARGCOMPLETE_IFS \n
+    set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
+    set -lx _ARGCOMPLETE_SHELL fish
+    set -lx COMP_LINE (commandline -p)
+    set -lx COMP_POINT (string length (commandline -cp))
+    set -lx COMP_TYPE
     if set -q _ARC_DEBUG
         %(argcomplete_script)s 8>&1 9>&2 1>&9 2>&1
     else
@@ -142,9 +160,10 @@ def shellcode(executables, use_defaults=True, shell="bash", complete_arguments=N
         executables_list = " ".join(quoted_executables)
         script = argcomplete_script
         if script:
-            function_suffix = "_" + script
+            # If the script path contain a space, this would generate an invalid function name.
+            function_suffix = "_" + script.replace(" ", "_SPACE_")
         else:
-            script = "$1"
+            script = ""
             function_suffix = ""
         code = bashcode % dict(
             complete_opts=complete_options,


### PR DESCRIPTION
Auto completion in shells was broken by the last update of argcomplete we did in 2025. This PR fixes that and also adds a test to make sure we don't regress on this anymore in the future.

Autocomplete was also broken on Python 3.12, which requires a newer argcomplete version. So I also updated argcomplete.

Note that the tests have been AI generated. You can see my LLM session at https://ampcode.com/threads/T-019debb1-9b44-75c1-b786-0ff399afec9e. I also create a follow-up session to get even more coverage: https://ampcode.com/threads/T-019debfb-1e29-772e-8d45-6f613e7a25aa. Total cost is $15 US.