### PR TITLE
fix(rex): case-insensitive parent_environ lookups on Windows (closes #2089)

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -23,7 +23,7 @@ from rez.util import shlex_join, is_non_string_iterable
 from rez.utils import reraise
 from rez.utils.execution import Popen
 from rez.utils.sourcecode import SourceCode, SourceCodeError
-from rez.utils.data_utils import AttrDictWrapper
+from rez.utils.data_utils import AttrDictWrapper, CaseInsensitiveEnvironDict
 from rez.utils.formatting import expandvars
 from rez.utils.platform_ import platform_
 
@@ -200,7 +200,19 @@ class ActionManager(object):
         '''
         self.interpreter = interpreter
         self.verbose = verbose
-        self.parent_environ = os.environ if parent_environ is None else parent_environ
+        if parent_environ is None:
+            # os.environ is already case-insensitive on Windows (Python's
+            # os._Environ normalizes keys internally), so leave it alone.
+            self.parent_environ = os.environ
+        elif platform_.name == "windows" and not isinstance(
+            parent_environ, CaseInsensitiveEnvironDict
+        ):
+            # User-provided dicts (e.g. dict(os.environ)) are case-sensitive.
+            # Wrap so env.SomeVariable lookups respect Windows native env
+            # semantics. See AcademySoftwareFoundation/rez#2089.
+            self.parent_environ = CaseInsensitiveEnvironDict(parent_environ)
+        else:
+            self.parent_environ = parent_environ
         self.parent_variables = True if parent_variables is True \
             else set(parent_variables or [])
         self.environ = {}

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -547,6 +547,45 @@ class TestRex(TestBase):
         self.assertRaises(RuntimeError,  # no default
                           intersects, ephemerals.get_range("foo.bar"), "0")
 
+    def test_parent_environ_case_insensitive_on_windows(self) -> None:
+        """Regression test for #2089.
+
+        On Windows, env-var lookup is case-insensitive natively, and Python's
+        os.environ preserves that. But a plain dict copy of os.environ (or any
+        user-built dict) is case-sensitive, so passing one as parent_environ
+        used to break rex lookups whenever the casing in the dict differed
+        from the casing referenced in the package commands. The fix wraps
+        any user-provided parent_environ in a case-insensitive view on
+        Windows so env.SomeVariable resolves regardless of how the dict was
+        populated.
+
+        Skipped on non-Windows platforms (the wrapper is a no-op there).
+        """
+        from rez.utils.platform_ import platform_
+        if platform_.name != "windows":
+            self.skipTest("Windows-only behavior")
+
+        # Direct lookup: dict has only one casing, but every variant resolves.
+        env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(env)
+        self.assertEqual(ex.manager.parent_environ["SomeVariable"], "covfefe")
+        self.assertEqual(ex.manager.parent_environ["SOMEVARIABLE"], "covfefe")
+        self.assertEqual(ex.manager.parent_environ["somevariable"], "covfefe")
+        self.assertIn("SOMEVARIABLE", ex.manager.parent_environ)
+        self.assertIn("somevariable", ex.manager.parent_environ)
+        self.assertNotIn("OtherVariable", ex.manager.parent_environ)
+
+        # End-to-end: rex code looking up a different casing than was stored
+        # in the parent_environ dict must succeed. Pre-fix this raised
+        # RexUndefinedVariableError.
+        def _rex() -> None:
+            v = getenv("SOMEVARIABLE")  # noqa: F821 - rex builtin
+            setenv("RESULT", v)  # noqa: F821 - rex builtin
+
+        ex2 = self._create_executor({"SomeVariable": "covfefe"})
+        ex2.execute_function(_rex)
+        self.assertEqual(ex2.manager.environ.get("RESULT"), "covfefe")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/utils/data_utils.py
+++ b/src/rez/utils/data_utils.py
@@ -13,7 +13,7 @@ import functools
 
 from rez.vendor.schema.schema import Schema, Optional
 from threading import Lock
-from typing import Any, Callable, Generic, MutableMapping, TypeVar, TYPE_CHECKING
+from typing import Any, Callable, Generic, Mapping, MutableMapping, TypeVar, TYPE_CHECKING
 
 T = TypeVar("T")
 
@@ -392,6 +392,57 @@ class RO_AttrDictWrapper(AttrDictWrapper):
         self[attr]  # may raise 'no attribute' error
         raise AttributeError("'%s' object attribute '%s' is read-only"
                              % (self.__class__.__name__, attr))
+
+
+class CaseInsensitiveEnvironDict(MutableMapping[str, str]):
+    """Case-insensitive read/write view over a string-keyed mapping.
+
+    Matches Windows native semantics: keys are stored as provided, but lookup
+    and ``in`` checks compare case-insensitively. If multiple keys collide
+    case-insensitively (e.g. both ``Path`` and ``PATH``), the last one written
+    wins on lookup, mirroring how ``os.environ`` resolves duplicates on
+    Windows.
+
+    Use this to wrap a user-provided ``parent_environ`` on Windows so that
+    rex environment lookups (``env.SomeVariable``) succeed regardless of the
+    casing the user happened to use when populating the dict.
+    """
+    def __init__(self, data: Mapping[str, str] | None = None) -> None:
+        self._data: dict[str, str] = {}
+        # `_index` maps an upper-cased key to the most recently inserted
+        # original-case key. Lookups go through `_index` first.
+        self._index: dict[str, str] = {}
+        if data:
+            for key, value in data.items():
+                self[key] = value
+
+    def __getitem__(self, key: str) -> str:
+        return self._data[self._index[key.upper()]]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        upper = key.upper()
+        existing = self._index.get(upper)
+        if existing is not None and existing != key:
+            del self._data[existing]
+        self._index[upper] = key
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        upper = key.upper()
+        original = self._index.pop(upper)
+        del self._data[original]
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and key.upper() in self._index
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return "%s(%r)" % (self.__class__.__name__, self._data)
 
 
 def convert_dicts(d, to_class=AttrDictWrapper, from_class=dict):


### PR DESCRIPTION
### Summary

On Windows, env-var lookup is case-insensitive natively, and Python's `os.environ` (an `os._Environ` instance) preserves that semantic. But a plain dict copy of `os.environ` — or any user-built dict — is case-sensitive. \`ActionManager\` previously used the dict as-is, so package commands referencing \`env.Foo\` against \`parent_environ={\"FOO\": \"...\"}\` failed with:

\`\`\`
Referenced undefined environment variable: Foo
\`\`\`

Reported in #2089 by @nrusch with a clean repro.

### Fix

Add a small \`CaseInsensitiveEnvironDict\` wrapper in [\`src/rez/utils/data_utils.py\`](src/rez/utils/data_utils.py) and apply it in [\`ActionManager.__init__\`](src/rez/rex.py) when \`parent_environ\` is provided on Windows. The wrapper:

- Stores keys in their original casing (\`__iter__\`, \`__repr__\` see them unchanged) but indexes case-folded for lookup.
- Resolves duplicate-case keys last-write-wins, matching how \`os.environ\` itself collapses case on Windows.
- Is a strict superset of \`MutableMapping\` so existing call sites (\`__getitem__\`, \`__contains__\`, \`get\`, \`keys\`, plus the \`expandvars(text, environ)\` lookups) all continue to work without modification.

The Windows branch is the only new path:

\`\`\`python
if parent_environ is None:
    self.parent_environ = os.environ        # already case-insensitive on Windows
elif platform_.name == \"windows\" and not isinstance(
    parent_environ, CaseInsensitiveEnvironDict
):
    self.parent_environ = CaseInsensitiveEnvironDict(parent_environ)
else:
    self.parent_environ = parent_environ
\`\`\`

### Non-Windows is a strict no-op

\`platform_.name == \"windows\"\` gates the wrapper. On Linux/macOS the assignment reduces byte-for-byte to the pre-fix logic (\`os.environ\` if None, otherwise pass through unchanged).

### Tests

\`test_parent_environ_case_insensitive_on_windows\` in [\`src/rez/tests/test_rex.py\`](src/rez/tests/test_rex.py):

- Direct lookup: dict has only one casing, every variant resolves.
- \`__contains__\` positive + negative.
- End-to-end rex code: \`getenv(\"SOMEVARIABLE\")\` against \`{\"SomeVariable\": \"covfefe\"}\` followed by \`setenv(\"RESULT\", v)\` — asserts the resulting environ contains the right value.

The test skips cleanly on non-Windows.

### Verification

| Platform | State | Result |
|---|---|---|
| Windows 11 + Python 3.11.9 | Pre-fix | new test FAILS at \`test_rex.py:572\` with \`KeyError: 'SOMEVARIABLE'\` — proves the bug is exercised |
| Windows 11 + Python 3.11.9 | Post-fix | new test PASSES + full 16/16 \`test_rex.py\` suite green |
| Linux (\`python:3.11-slim\` Docker) | Post-fix | 15 passed + 1 skipped (Windows-only test), zero regressions |

### Out of scope

- The fix only addresses the \`ActionManager\` lookup path. Other call sites in rez that consume user-provided env dicts (e.g. \`Popen\` invocations) preserve the existing case-sensitive behavior, since on Windows the underlying \`CreateProcess\` call uppercases the keys it actually applies.
- No public API change; \`parent_environ\`'s type annotation (\`Mapping[str, str] | None\`) is unchanged.