### PR TITLE
Fix rex parent_environ case sensitivity on Windows

### DIFF
--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -189,8 +189,8 @@ class ActionManager(object):
         parent_environ: environment to execute the actions within. If None,
             defaults to the current environment. On Windows, a caller-supplied
             mapping is wrapped in a read-only, case-insensitive snapshot so that
-            env-var lookups match native Windows semantics regardless of key
-            casing (see #2089); `os.environ` and None are used as-is.
+            lookups against it are case-insensitive, matching how ``os.environ``
+            behaves natively (see #2089); `os.environ` and None are used as-is.
         parent_variables: List of variables to append/prepend to, rather than
             overwriting on first reference. If this is set to True instead of a
             list, all variables are treated as parent variables.
@@ -218,6 +218,9 @@ class ActionManager(object):
             self.parent_environ = parent_environ
         self.parent_variables = True if parent_variables is True \
             else set(parent_variables or [])
+        # Variables set during rex execution. Keys are stored verbatim and are
+        # not case-folded on Windows (unlike the parent_environ snapshot above);
+        # that broader normalization is a separate concern, tracked in #2164.
         self.environ = {}
         self.formatter = formatter or str
         self.actions = []
@@ -466,8 +469,9 @@ class _CaseInsensitiveEnvironProxy(Mapping):
     """Read-only, case-insensitive snapshot of an env-var mapping.
 
     Used by `ActionManager` to wrap a caller-supplied `parent_environ`
-    on Windows so rex lookups match native Windows env-var semantics
-    regardless of the casing used to populate the input dict.
+    on Windows so lookups against it are case-insensitive regardless of
+    the casing used to populate the input dict, matching how os.environ
+    behaves natively on Windows.
 
     Keys are normalized (upper-cased) once at construction, so this is a
     point-in-time snapshot: later mutations to the source mapping are not

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -187,7 +187,10 @@ class ActionManager(object):
         interpreter: string or `ActionInterpreter`
             the interpreter to use when executing rex actions
         parent_environ: environment to execute the actions within. If None,
-            defaults to the current environment.
+            defaults to the current environment. On Windows, a caller-supplied
+            mapping is wrapped in a read-only, case-insensitive snapshot so that
+            env-var lookups match native Windows semantics regardless of key
+            casing (see #2089); `os.environ` and None are used as-is.
         parent_variables: List of variables to append/prepend to, rather than
             overwriting on first reference. If this is set to True instead of a
             list, all variables are treated as parent variables.
@@ -204,7 +207,9 @@ class ActionManager(object):
         # behaves that way but a plain dict supplied by the caller does not,
         # so wrap it on the Windows path only. See #2089.
         self.parent_environ: Mapping[str, str]
-        if parent_environ is None:
+        if parent_environ is None or parent_environ is os.environ:
+            # os.environ is already case-insensitive on Windows, so use it
+            # as-is (preserving liveness and identity); None means "current".
             self.parent_environ = os.environ
         elif platform_.name == "windows" and not isinstance(
                 parent_environ, _CaseInsensitiveEnvironProxy):
@@ -458,11 +463,16 @@ class ActionManager(object):
 
 
 class _CaseInsensitiveEnvironProxy(Mapping):
-    """Read-only case-insensitive view over an env-var mapping.
+    """Read-only, case-insensitive snapshot of an env-var mapping.
 
     Used by `ActionManager` to wrap a caller-supplied `parent_environ`
     on Windows so rex lookups match native Windows env-var semantics
     regardless of the casing used to populate the input dict.
+
+    Keys are normalized (upper-cased) once at construction, so this is a
+    point-in-time snapshot: later mutations to the source mapping are not
+    reflected. That matches how `parent_environ` is used in practice (fixed
+    for the lifetime of an executor).
 
     Kept private to this module on purpose; promote to a shared util
     only when a second caller needs it.
@@ -477,13 +487,19 @@ class _CaseInsensitiveEnvironProxy(Mapping):
         return self._data[key.upper()]
 
     def __contains__(self, key):
-        return isinstance(key, str) and key.upper() in self._data
+        return key.upper() in self._data
 
     def __iter__(self):
         return iter(self._data)
 
     def __len__(self):
         return len(self._data)
+
+    def copy(self):
+        # Return a plain dict with normalized (upper-cased) keys, mirroring
+        # os.environ.copy() on Windows. Defensive: lets callers that expect a
+        # dict-like parent_environ (e.g. `self.parent_environ.copy()`) work.
+        return dict(self._data)
 
 
 #===============================================================================

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -12,8 +12,8 @@ from fnmatch import fnmatch
 from enum import Enum
 from contextlib import contextmanager
 from string import Formatter
-from collections.abc import MutableMapping
-from typing import Any, Iterable, Mapping
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Iterable
 
 from rez.system import system
 from rez.config import config
@@ -200,7 +200,17 @@ class ActionManager(object):
         '''
         self.interpreter = interpreter
         self.verbose = verbose
-        self.parent_environ = os.environ if parent_environ is None else parent_environ
+        # On Windows env-var keys are case-insensitive; os.environ already
+        # behaves that way but a plain dict supplied by the caller does not,
+        # so wrap it on the Windows path only. See #2089.
+        self.parent_environ: Mapping[str, str]
+        if parent_environ is None:
+            self.parent_environ = os.environ
+        elif platform_.name == "windows" and not isinstance(
+                parent_environ, _CaseInsensitiveEnvironProxy):
+            self.parent_environ = _CaseInsensitiveEnvironProxy(parent_environ)
+        else:
+            self.parent_environ = parent_environ
         self.parent_variables = True if parent_variables is True \
             else set(parent_variables or [])
         self.environ = {}
@@ -445,6 +455,35 @@ class ActionManager(object):
 
     def _keytoken(self, key):
         return self.interpreter.get_key_token(key)
+
+
+class _CaseInsensitiveEnvironProxy(Mapping):
+    """Read-only case-insensitive view over an env-var mapping.
+
+    Used by `ActionManager` to wrap a caller-supplied `parent_environ`
+    on Windows so rex lookups match native Windows env-var semantics
+    regardless of the casing used to populate the input dict.
+
+    Kept private to this module on purpose; promote to a shared util
+    only when a second caller needs it.
+    """
+    def __init__(self, data):
+        # keys are upper-cased once on the way in; same shape as
+        # os.environ on Windows. Last write wins on case collisions,
+        # which mirrors how os.environ resolves them too.
+        self._data = {k.upper(): v for k, v in data.items()}
+
+    def __getitem__(self, key):
+        return self._data[key.upper()]
+
+    def __contains__(self, key):
+        return isinstance(key, str) and key.upper() in self._data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
 
 
 #===============================================================================

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -189,8 +189,8 @@ class ActionManager(object):
         parent_environ: environment to execute the actions within. If None,
             defaults to the current environment. On Windows, a caller-supplied
             mapping is wrapped in a read-only, case-insensitive snapshot so that
-            lookups against it are case-insensitive, matching how ``os.environ``
-            behaves natively (see #2089); `os.environ` and None are used as-is.
+            lookups against it are case-insensitive, matching how :data:`os.environ`
+            behaves natively (see #2089); :data:`os.environ` and None are used as-is.
         parent_variables: List of variables to append/prepend to, rather than
             overwriting on first reference. If this is set to True instead of a
             list, all variables are treated as parent variables.
@@ -468,14 +468,14 @@ class ActionManager(object):
 class _CaseInsensitiveEnvironProxy(Mapping):
     """Read-only, case-insensitive snapshot of an env-var mapping.
 
-    Used by `ActionManager` to wrap a caller-supplied `parent_environ`
+    Used by :class:`ActionManager` to wrap a caller-supplied ``parent_environ``
     on Windows so lookups against it are case-insensitive regardless of
-    the casing used to populate the input dict, matching how os.environ
+    the casing used to populate the input dict, matching how :data:`os.environ`
     behaves natively on Windows.
 
     Keys are normalized (upper-cased) once at construction, so this is a
     point-in-time snapshot: later mutations to the source mapping are not
-    reflected. That matches how `parent_environ` is used in practice (fixed
+    reflected. That matches how ``parent_environ`` is used in practice (fixed
     for the lifetime of an executor).
 
     Kept private to this module on purpose; promote to a shared util

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -13,6 +13,7 @@ from rez.rex_bindings import VersionBinding, VariantBinding, VariantsBinding, \
 from rez.exceptions import RexError, RexUndefinedVariableError
 from rez.config import config
 import unittest
+from unittest import mock
 from rez.version import Version
 from rez.version import Requirement
 from rez.tests.util import TestBase
@@ -581,9 +582,9 @@ class TestRex(TestBase):
                      "parent_environ passthrough is non-Windows behaviour")
     def test_parent_environ_identity_passthrough_on_non_windows(self) -> None:
         """On non-Windows, a caller dict is used as-is (no wrapping). #2089."""
-        env = {"SomeVariable": "covfefe"}
-        ex = self._create_executor(env)
-        self.assertIs(ex.manager.parent_environ, env)
+        parent_env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(parent_env)
+        self.assertIs(ex.manager.parent_environ, parent_env)
 
     @unittest.skipIf(platform_.name != "windows", "Windows-only behaviour")
     def test_parent_environ_case_insensitive_on_windows(self) -> None:
@@ -594,8 +595,8 @@ class TestRex(TestBase):
         such a dict as parent_environ used to break env.<MixedCase>
         lookups inside commands(). We now wrap on the Windows side.
         """
-        env = {"SomeVariable": "covfefe"}
-        ex = self._create_executor(env)
+        parent_env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(parent_env)
 
         # any casing of the key resolves
         self.assertEqual(ex.manager.parent_environ["SomeVariable"], "covfefe")
@@ -607,13 +608,47 @@ class TestRex(TestBase):
         # end-to-end via the real package-commands entrypoint: rex references
         # a different casing than the caller's dict, exercised through both
         # execute_function and execute_code (what commands() actually run).
-        # Pre-fix this raised RexUndefinedVariableError.
+        # Pre-fix this raised RexUndefinedVariableError. Note: the caller dict
+        # is named `parent_env`, not `env`, so the nested rex function does not
+        # close over it and shadow the rex `env` builtin.
         def _rex() -> None:
             env.RESULT = env.SOMEVARIABLE  # noqa: F821 - rex builtin
 
         self._test(
             func=_rex,
-            env={"SomeVariable": "covfefe"},
+            env=parent_env,
+            expected_actions=[Setenv("RESULT", "covfefe")],
+            expected_output={"RESULT": "covfefe"},
+        )
+
+    def test_parent_environ_os_environ_passthrough(self) -> None:
+        """Explicit os.environ is used as-is (identity), never wrapped or
+        copied -- it is already case-insensitive on Windows. #2089.
+        """
+        ex = self._create_executor(os.environ)
+        self.assertIs(ex.manager.parent_environ, os.environ)
+
+    @mock.patch.object(platform_, "name", "windows")
+    def test_parent_environ_case_insensitive_windows_mocked(self) -> None:
+        """Companion to test_parent_environ_case_insensitive_on_windows that
+        runs on every host by mocking the platform, so the Windows-only
+        wrapping branch keeps CI coverage (and local validation) off Windows
+        too. #2089.
+        """
+        from rez.rex import _CaseInsensitiveEnvironProxy
+
+        parent_env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(parent_env)
+        self.assertIsInstance(
+            ex.manager.parent_environ, _CaseInsensitiveEnvironProxy)
+        self.assertEqual(ex.manager.parent_environ["SOMEVARIABLE"], "covfefe")
+
+        def _rex() -> None:
+            env.RESULT = env.SOMEVARIABLE  # noqa: F821 - rex builtin
+
+        self._test(
+            func=_rex,
+            env=parent_env,
             expected_actions=[Setenv("RESULT", "covfefe")],
             expected_output={"RESULT": "covfefe"},
         )

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -547,6 +547,39 @@ class TestRex(TestBase):
         self.assertRaises(RuntimeError,  # no default
                           intersects, ephemerals.get_range("foo.bar"), "0")
 
+    def test_parent_environ_case_insensitive_on_windows(self):
+        """Regression for #2089.
+
+        On Windows env vars are case-insensitive; os.environ already
+        behaves that way, but a plain dict copy of it doesn't. Passing
+        such a dict as parent_environ used to break env.<MixedCase>
+        lookups inside commands(). We now wrap on the Windows side.
+        """
+        from rez.utils.platform_ import platform_
+        if platform_.name != "windows":
+            self.skipTest("Windows-only behaviour")
+
+        env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(env)
+
+        # any casing of the key resolves
+        self.assertEqual(ex.manager.parent_environ["SomeVariable"], "covfefe")
+        self.assertEqual(ex.manager.parent_environ["SOMEVARIABLE"], "covfefe")
+        self.assertEqual(ex.manager.parent_environ["somevariable"], "covfefe")
+        self.assertIn("SOMEVARIABLE", ex.manager.parent_environ)
+        self.assertNotIn("OtherVariable", ex.manager.parent_environ)
+
+        # end-to-end: rex code references a different casing than the
+        # caller's dict and the lookup must succeed (pre-fix this
+        # raised RexUndefinedVariableError)
+        def _rex():
+            v = getenv("SOMEVARIABLE")  # noqa: F821 - rex builtin
+            setenv("RESULT", v)         # noqa: F821 - rex builtin
+
+        ex2 = self._create_executor({"SomeVariable": "covfefe"})
+        ex2.execute_function(_rex)
+        self.assertEqual(ex2.get_output().get("RESULT"), "covfefe")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -17,6 +17,7 @@ from rez.version import Version
 from rez.version import Requirement
 from rez.tests.util import TestBase
 from rez.utils.backcompat import convert_old_commands
+from rez.utils.platform_ import platform_
 from rez.package_repository import package_repository_manager
 from rez.packages import iter_package_families
 import inspect
@@ -547,7 +548,45 @@ class TestRex(TestBase):
         self.assertRaises(RuntimeError,  # no default
                           intersects, ephemerals.get_range("foo.bar"), "0")
 
-    def test_parent_environ_case_insensitive_on_windows(self):
+    def test_case_insensitive_environ_proxy(self) -> None:
+        """Unit-test the case-normalizing proxy directly (platform independent).
+
+        Runs on every host so the core logic behind the #2089 fix has real
+        CI coverage even though the ActionManager wiring is Windows-only.
+        """
+        from rez.rex import _CaseInsensitiveEnvironProxy
+
+        proxy = _CaseInsensitiveEnvironProxy({"SomeVariable": "covfefe"})
+        for key in ("SomeVariable", "SOMEVARIABLE", "somevariable"):
+            self.assertEqual(proxy[key], "covfefe")
+            self.assertIn(key, proxy)
+        self.assertNotIn("OtherVariable", proxy)
+        self.assertRaises(KeyError, lambda: proxy["OtherVariable"])
+
+        # copy() yields a plain dict with normalized (upper-cased) keys,
+        # mirroring os.environ.copy() on Windows.
+        copied = proxy.copy()
+        self.assertIsInstance(copied, dict)
+        self.assertEqual(copied, {"SOMEVARIABLE": "covfefe"})
+
+        # normalized iteration / length
+        self.assertEqual(len(proxy), 1)
+        self.assertEqual(set(proxy), {"SOMEVARIABLE"})
+
+        # last-write-wins on case collision, mirroring os.environ
+        collided = _CaseInsensitiveEnvironProxy({"Foo": "a", "FOO": "b"})
+        self.assertEqual(collided["foo"], "b")
+
+    @unittest.skipIf(platform_.name == "windows",
+                     "parent_environ passthrough is non-Windows behaviour")
+    def test_parent_environ_identity_passthrough_on_non_windows(self) -> None:
+        """On non-Windows, a caller dict is used as-is (no wrapping). #2089."""
+        env = {"SomeVariable": "covfefe"}
+        ex = self._create_executor(env)
+        self.assertIs(ex.manager.parent_environ, env)
+
+    @unittest.skipIf(platform_.name != "windows", "Windows-only behaviour")
+    def test_parent_environ_case_insensitive_on_windows(self) -> None:
         """Regression for #2089.
 
         On Windows env vars are case-insensitive; os.environ already
@@ -555,10 +594,6 @@ class TestRex(TestBase):
         such a dict as parent_environ used to break env.<MixedCase>
         lookups inside commands(). We now wrap on the Windows side.
         """
-        from rez.utils.platform_ import platform_
-        if platform_.name != "windows":
-            self.skipTest("Windows-only behaviour")
-
         env = {"SomeVariable": "covfefe"}
         ex = self._create_executor(env)
 
@@ -569,16 +604,19 @@ class TestRex(TestBase):
         self.assertIn("SOMEVARIABLE", ex.manager.parent_environ)
         self.assertNotIn("OtherVariable", ex.manager.parent_environ)
 
-        # end-to-end: rex code references a different casing than the
-        # caller's dict and the lookup must succeed (pre-fix this
-        # raised RexUndefinedVariableError)
-        def _rex():
-            v = getenv("SOMEVARIABLE")  # noqa: F821 - rex builtin
-            setenv("RESULT", v)         # noqa: F821 - rex builtin
+        # end-to-end via the real package-commands entrypoint: rex references
+        # a different casing than the caller's dict, exercised through both
+        # execute_function and execute_code (what commands() actually run).
+        # Pre-fix this raised RexUndefinedVariableError.
+        def _rex() -> None:
+            env.RESULT = env.SOMEVARIABLE  # noqa: F821 - rex builtin
 
-        ex2 = self._create_executor({"SomeVariable": "covfefe"})
-        ex2.execute_function(_rex)
-        self.assertEqual(ex2.get_output().get("RESULT"), "covfefe")
+        self._test(
+            func=_rex,
+            env={"SomeVariable": "covfefe"},
+            expected_actions=[Setenv("RESULT", "covfefe")],
+            expected_output={"RESULT": "covfefe"},
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2089

On Windows, environment variable keys are case-insensitive natively. `os.environ` preserves that contract through Python's `os._Environ` wrapper, but a plain `dict` copy of it (or any user-built dict) does not. Until now, `ActionManager` consumed whatever `Mapping` the caller passed as-is, so a package whose `commands()` referenced `env.SomeVariable` against a `parent_environ` that held the same variable under a different casing would raise:

```
Error in commands in package '...':
Referenced undefined environment variable: SomeVariable
```

Issue #2089 has a clean reproducer that follows exactly this shape: `dict(os.environ)` is passed to `ResolvedContext.get_environ`, and a package looks up `env.SomeVariable` while the dict only has `SOMEVARIABLE`.

The fix wraps a caller-supplied `parent_environ` in a small read-only, case-normalized snapshot (`_CaseInsensitiveEnvironProxy`), gated on `platform_.name == "windows"`. `os.environ` and `None` are used as-is (they are already case-insensitive on Windows), so their identity and liveness are preserved. On Linux and macOS a caller-supplied mapping retains the existing identity passthrough. Keys are upper-cased once at construction, i.e. a point-in-time snapshot, which matches how `parent_environ` is fixed for an executor's lifetime; iteration matches what `os.environ` yields on Windows, and when the input contains keys that differ only by case the last one encountered wins, mirroring how `os.environ` collapses duplicates. The proxy also exposes `.copy()` (returning a plain dict with upper-cased keys) for callers that expect a dict-like `parent_environ`. The `not isinstance(...)` guard in the gate keeps wrapping idempotent.

Tests:
- `test_case_insensitive_environ_proxy` unit-tests the proxy directly and runs on every platform, so the core normalization logic has real CI coverage: get/contains across casings, missing-key `KeyError`, `.copy()`, iteration/length, and last-write-wins collisions.
- `test_parent_environ_case_insensitive_on_windows` (Windows-only via `@unittest.skipIf`) drives the real package-commands entrypoint — `env.<MixedCase>` — through both `execute_function` and `execute_code` via the `_test` helper, alongside direct `parent_environ[...]` lookups across casings.
- `test_parent_environ_identity_passthrough_on_non_windows` (non-Windows) asserts `ex.manager.parent_environ is env` to guard against accidental wrapping.

Verified locally on Linux: `python -m unittest rez.tests.test_rex` → 17 passed + 1 Windows-only skip. The full `rez-selftest`, `flake8`, and `mypy` matrix runs in CI.

Scope: this makes lookups against a caller-supplied `parent_environ` case-insensitive on Windows — the exact #2089 reproducer. Variables set *within* rex code (`ActionManager.environ`) are stored verbatim and are not case-folded; that is a separate, pre-existing gap and intentionally out of scope here — tracked in #2164.

Reported by @nrusch. Independent diagnosis previously posted in #2093 (closed because the author could not satisfy the EasyCLA/DCO requirement, not for technical reasons).

Disclosure: Claude Code (Opus 4.8) used for adversarial review, edge-case analysis, test design, and implementation of the review feedback.
