### PR TITLE
Add inline flag to rez-interpret

### DIFF
--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -15,8 +15,8 @@ def setup_parser(parser, completions: bool = False) -> None:
     formats = get_shell_types() + ['dict', 'table']
 
     parser.add_argument(
-        "-c", "--cmd", action="store_true",
-        help="interpret FILE as a command string")
+        "-c", "--command", action="store_true",
+        help="interpret FILE as a code string")
     parser.add_argument(
         "-f", "--format", type=str, choices=formats,
         help="print output in the given format. If None, the current shell "
@@ -32,7 +32,7 @@ def setup_parser(parser, completions: bool = False) -> None:
         "will be treated this way")
     FILE_action = parser.add_argument(
         "FILE", type=str,
-        help='file containing rex code to execute')
+        help='file (or code string with -c) containing rex code to execute')
 
     if completions:
         from rez.cli._complete_util import FilesCompleter
@@ -48,7 +48,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     from rez.rex import RexExecutor, Python
     from pprint import pformat
 
-    if opts.cmd:
+    if opts.command:
         code = opts.FILE
         filename = None
     else:

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -34,7 +34,6 @@ def setup_parser(parser, completions: bool = False) -> None:
         "FILE", type=str,
         help='file containing rex code to execute')
 
-
     if completions:
         from rez.cli._complete_util import FilesCompleter
         from rez.vendor.argcomplete.completers import EnvironCompleter

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -15,6 +15,9 @@ def setup_parser(parser, completions: bool = False) -> None:
     formats = get_shell_types() + ['dict', 'table']
 
     parser.add_argument(
+        "-c", "--cmd", action="store_true",
+        help="interpret FILE as command string")
+    parser.add_argument(
         "-f", "--format", type=str, choices=formats,
         help="print output in the given format. If None, the current shell "
         "language (%s) is used" % system.shell)
@@ -28,7 +31,7 @@ def setup_parser(parser, completions: bool = False) -> None:
         "reference. If this is set to the special value 'all', all variables "
         "will be treated this way")
     FILE_action = parser.add_argument(
-        "FILE", type=str,
+        "FILE", type=str, nargs="?", default="",
         help='file containing rex code to execute')
 
     if completions:
@@ -45,8 +48,11 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     from rez.rex import RexExecutor, Python
     from pprint import pformat
 
-    with open(opts.FILE) as f:
-        code = f.read()
+    if opts.cmd:
+        code = opts.FILE
+    else:
+        with open(opts.FILE) as f:
+            code = f.read()
 
     interp = None
     if opts.format is None:

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -50,8 +50,10 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     if opts.cmd:
         code = opts.FILE
+        filename = None
     else:
-        with open(opts.FILE) as f:
+        filename = opts.FILE
+        with open(filename) as f:
             code = f.read()
 
     interp = None
@@ -73,7 +75,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
                      parent_environ=parent_env,
                      parent_variables=parent_vars)
 
-    ex.execute_code(code, filename=opts.FILE)
+    ex.execute_code(code, filename=filename)
 
     o = ex.get_output()
     if isinstance(o, dict):

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -16,7 +16,7 @@ def setup_parser(parser, completions: bool = False) -> None:
 
     parser.add_argument(
         "-c", "--cmd", action="store_true",
-        help="interpret FILE as command string")
+        help="interpret FILE as a command string")
     parser.add_argument(
         "-f", "--format", type=str, choices=formats,
         help="print output in the given format. If None, the current shell "

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -31,8 +31,9 @@ def setup_parser(parser, completions: bool = False) -> None:
         "reference. If this is set to the special value 'all', all variables "
         "will be treated this way")
     FILE_action = parser.add_argument(
-        "FILE", type=str, nargs="?", default="",
+        "FILE", type=str,
         help='file containing rex code to execute')
+
 
     if completions:
         from rez.cli._complete_util import FilesCompleter


### PR DESCRIPTION
Currently, `rez-interpret` only accepts a valid file path as its argument. 

This change adds the `-c` flag which allows the user to pass programs as strings from the command line.