### PR TITLE
Add support for "--variant -1" style syntax for rez-build

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -210,12 +210,15 @@ class BuildProcessHelper(BuildProcess):
                        **kwargs) -> tuple[int, list[str | None]]:
         """Iterate over variants and call a function on each."""
         if variants:
-            present_variants = range(self.package.num_variants)
-            invalid_variants = set(variants) - set(present_variants)
+            n = self.package.num_variants
+            # Valid indices: 0..n-1 and their negative equivalents -n..-1
+            present_variants = set(range(-n, n))
+            invalid_variants = sorted(set(variants) - present_variants)
             if invalid_variants:
                 raise BuildError(
                     "The package does not contain the variants: %s"
-                    % ", ".join(str(x) for x in sorted(invalid_variants)))
+                    % ", ".join(str(v) for v in invalid_variants))
+            variants = sorted({v % n for v in variants})
 
         # iterate over variants
         results = []

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from rez.packages import iter_packages
+from rez.util import resolve_variant_indices
 from rez.exceptions import BuildProcessError, BuildContextResolveError, \
     ReleaseHookCancellingError, RezError, ReleaseError, BuildError, \
     ReleaseVCSError, _NeverError
@@ -210,15 +211,14 @@ class BuildProcessHelper(BuildProcess):
                        **kwargs) -> tuple[int, list[str | None]]:
         """Iterate over variants and call a function on each."""
         if variants:
-            n = self.package.num_variants
-            # Valid indices: 0..n-1 and their negative equivalents -n..-1
-            present_variants = set(range(-n, n))
-            invalid_variants = sorted(set(variants) - present_variants)
-            if invalid_variants:
+            resolved, invalid = resolve_variant_indices(
+                variants, self.package.num_variants
+            )
+            if invalid:
                 raise BuildError(
                     "The package does not contain the variants: %s"
-                    % ", ".join(str(v) for v in invalid_variants))
-            variants = sorted({v % n for v in variants})
+                    % ", ".join(str(v) for v in invalid))
+            variants = sorted(resolved)
 
         # iterate over variants
         results = []

--- a/src/rez/cli/build.py
+++ b/src/rez/cli/build.py
@@ -72,7 +72,8 @@ def setup_parser_common(parser) -> None:
 
     parser.add_argument(
         "--variants", nargs='+', type=int, metavar="INDEX",
-        help="select variants to build (zero-indexed).")
+        help="select variants to build (zero-indexed; negative indices count from the end,"
+             " eg. -1 is the last variant).")
     parser.add_argument(
         "--ba", "--build-args", dest="build_args", metavar="ARGS",
         help="arguments to pass to the build system. Alternatively, list these "

--- a/src/rez/cli/cp.py
+++ b/src/rez/cli/cp.py
@@ -52,7 +52,8 @@ def setup_parser(parser, completions: bool = False) -> None:
         help="dry run mode")
     parser.add_argument(
         "--variants", nargs='+', type=int, metavar="INDEX",
-        help="select variants to copy (zero-indexed).")
+        help="select variants to copy (zero-indexed; negative indices count from the end,"
+             " eg. -1 is the last variant).")
     parser.add_argument(
         "--variant-uri", metavar="URI",
         help="copy variant with the given URI. Ignores --variants.")

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -134,6 +134,17 @@ def copy_package(package: Package,
         )
 
     # determine variants to potentially install
+    if variants is not None:
+        n = package.num_variants
+        # Valid indices: 0..n-1 and their negative equivalents -n..-1
+        present_variants = set(range(-n, n))
+        invalid_variants = sorted(set(variants) - present_variants)
+        if invalid_variants:
+            raise PackageCopyError(
+                "The package does not contain the variants: %s"
+                % ", ".join(str(v) for v in invalid_variants))
+        variants = {v % n for v in variants}
+
     src_variants = []
     for variant in package.iter_variants():
         if variants is None or variant.index in variants:

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -14,6 +14,7 @@ from rez.exceptions import PackageCopyError
 from rez.package_repository import package_repository_manager, PackageRepository
 from rez.packages import Package, Variant
 from rez.serialise import FileFormat
+from rez.util import resolve_variant_indices
 from rez.utils import with_noop
 from rez.utils.base26 import create_unique_base26_symlink
 from rez.utils.sourcecode import IncludeModuleManager
@@ -135,18 +136,12 @@ def copy_package(package: Package,
 
     # determine variants to potentially install
     if variants is not None:
-        n = package.num_variants
-        if n > 0:
-            # Valid indices: 0..n-1 and their negative equivalents -n..-1
-            present_variants = set(range(-n, n))
-            invalid_variants = sorted(set(variants) - present_variants)
-            if invalid_variants:
-                raise PackageCopyError(
-                    "The package does not contain the variants: %s"
-                    % ", ".join(str(v) for v in invalid_variants))
-            variants = {v % n for v in variants}
-        # When n == 0 the package has no explicit variants; variant.index is
-        # None and integer index arithmetic does not apply.
+        resolved, invalid = resolve_variant_indices(variants, package.num_variants)
+        if invalid:
+            raise PackageCopyError(
+                "The package does not contain the variants: %s"
+                % ", ".join(str(v) for v in invalid))
+        variants = resolved
 
     src_variants = []
     for variant in package.iter_variants():

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -136,14 +136,17 @@ def copy_package(package: Package,
     # determine variants to potentially install
     if variants is not None:
         n = package.num_variants
-        # Valid indices: 0..n-1 and their negative equivalents -n..-1
-        present_variants = set(range(-n, n))
-        invalid_variants = sorted(set(variants) - present_variants)
-        if invalid_variants:
-            raise PackageCopyError(
-                "The package does not contain the variants: %s"
-                % ", ".join(str(v) for v in invalid_variants))
-        variants = {v % n for v in variants}
+        if n > 0:
+            # Valid indices: 0..n-1 and their negative equivalents -n..-1
+            present_variants = set(range(-n, n))
+            invalid_variants = sorted(set(variants) - present_variants)
+            if invalid_variants:
+                raise PackageCopyError(
+                    "The package does not contain the variants: %s"
+                    % ", ".join(str(v) for v in invalid_variants))
+            variants = {v % n for v in variants}
+        # When n == 0 the package has no explicit variants; variant.index is
+        # None and integer index arithmetic does not apply.
 
     src_variants = []
     for variant in package.iter_variants():

--- a/src/rez/tests/test_build.py
+++ b/src/rez/tests/test_build.py
@@ -203,6 +203,52 @@ class TestBuild(TestBase, TempdirMixin):
         stdout = proc.communicate()[0]
         self.assertEqual('Oh hai!', stdout.decode("utf-8").strip())
 
+    @per_available_shell()
+    @install_dependent()
+    def test_build_negative_variants(self, shell) -> None:
+        """Test building with negative variant indices."""
+        config.override("default_shell", shell)
+        self.inject_python_repo()
+
+        # Build dependencies first (bah requires build_util and foo)
+        self._test_build_build_util()
+        self._test_build_floob()
+        self._test_build_foo()
+
+        # bah has 2 variants: [foo-1.0] and [foo-1.1]
+        working_dir = os.path.join(self.src_root, "bah", "2.1")
+        builder = self._create_builder(working_dir)
+
+        # -1 should build only the last variant (index 1)
+        num_built = builder.build(clean=True, variants=[-1])
+        self.assertEqual(num_built, 1)
+
+        # -2 should build only the first variant (index 0)
+        num_built = builder.build(clean=True, variants=[-2])
+        self.assertEqual(num_built, 1)
+
+        # [1, -1] refers to the same variant; deduplication should yield 1 build
+        num_built = builder.build(clean=True, variants=[1, -1])
+        self.assertEqual(num_built, 1)
+
+        # mixed positive and negative indices (distinct variants)
+        num_built = builder.build(clean=True, variants=[0, -1])
+        self.assertEqual(num_built, 2)
+
+        # invalid: -3 on a 2-variant package should raise BuildError
+        # and the error message should name the invalid index
+        with self.assertRaises(BuildError) as exc:
+            builder.build(clean=True, variants=[-3])
+        self.assertIn("-3", str(exc.exception))
+
+        # multiple invalid indices should all appear in the error, sorted
+        with self.assertRaises(BuildError) as exc:
+            builder.build(clean=True, variants=[-3, 5])
+        error_msg = str(exc.exception)
+        self.assertIn("-3", error_msg)
+        self.assertIn("5", error_msg)
+        self.assertLess(error_msg.index("-3"), error_msg.index("5"))
+
     def test_set_standard_vars_escaping(self) -> None:
         """Test that set_standard_vars properly escapes environment variables."""
         # Create a test package directory with special characters in description

--- a/src/rez/tests/test_copy_package.py
+++ b/src/rez/tests/test_copy_package.py
@@ -16,6 +16,7 @@ from rez.build_system import create_build_system
 from rez.resolved_context import ResolvedContext
 from rez.packages import get_latest_package
 from rez.package_copy import copy_package
+from rez.exceptions import PackageCopyError
 from rez.version import VersionRange
 from rez.tests.util import TestBase, TempdirMixin
 
@@ -330,3 +331,63 @@ class TestCopyPackage(TestBase, TempdirMixin):
         # this can only match if the include module was copied with the package
         environ = ctxt.get_environ(parent_environ={})
         self.assertEqual(environ.get("EEK"), "2")
+
+    def test_9(self) -> None:
+        """Package copy with negative variant indices."""
+        self._reset_dest_repository()
+
+        # bah has 2 variants: index 0 ([foo-1.0]) and index 1 ([foo-1.1])
+        src_pkg = self._get_src_pkg("bah", "2.1")
+
+        # -1 should copy only the last variant (index 1)
+        result = copy_package(
+            package=src_pkg,
+            dest_repository=self.dest_install_root,
+            variants=[-1]
+        )
+        self._assert_copied(result, 1, 0)
+        # verify the correct source variant was selected
+        self.assertEqual(result["copied"][0][0].index, 1)
+
+        # -2 should copy only the first variant (index 0)
+        self._reset_dest_repository()
+        result = copy_package(
+            package=src_pkg,
+            dest_repository=self.dest_install_root,
+            variants=[-2]
+        )
+        self._assert_copied(result, 1, 0)
+        # verify the correct source variant was selected
+        self.assertEqual(result["copied"][0][0].index, 0)
+
+        # -1 and 1 refer to the same variant; only one copy should be made
+        self._reset_dest_repository()
+        result = copy_package(
+            package=src_pkg,
+            dest_repository=self.dest_install_root,
+            variants=[-1, 1]
+        )
+        self._assert_copied(result, 1, 0)
+
+        # invalid: -3 on a 2-variant package should raise PackageCopyError
+        # and the error message should name the invalid index
+        self._reset_dest_repository()
+        with self.assertRaises(PackageCopyError) as exc:
+            copy_package(
+                package=src_pkg,
+                dest_repository=self.dest_install_root,
+                variants=[-3]
+            )
+        self.assertIn("-3", str(exc.exception))
+
+        # multiple invalid indices should all appear in the error, sorted
+        with self.assertRaises(PackageCopyError) as exc:
+            copy_package(
+                package=src_pkg,
+                dest_repository=self.dest_install_root,
+                variants=[-3, 5]
+            )
+        error_msg = str(exc.exception)
+        self.assertIn("-3", error_msg)
+        self.assertIn("5", error_msg)
+        self.assertLess(error_msg.index("-3"), error_msg.index("5"))

--- a/src/rez/tests/test_copy_package.py
+++ b/src/rez/tests/test_copy_package.py
@@ -391,3 +391,18 @@ class TestCopyPackage(TestBase, TempdirMixin):
         self.assertIn("-3", error_msg)
         self.assertIn("5", error_msg)
         self.assertLess(error_msg.index("-3"), error_msg.index("5"))
+
+    def test_10(self) -> None:
+        """Copy a no-variant package using variants=[None] (e.g. from bundle_context)."""
+        self._reset_dest_repository()
+
+        # floob has no variants; iter_variants() yields one variant with index=None
+        src_pkg = self._get_src_pkg("floob", "1.2.0")
+        result = copy_package(
+            package=src_pkg,
+            dest_repository=self.dest_install_root,
+            variants=[None]
+        )
+
+        # The single null-variant should have been copied without error
+        self._assert_copied(result, 1, 0)

--- a/src/rez/tests/test_util.py
+++ b/src/rez/tests/test_util.py
@@ -8,7 +8,7 @@ unit tests for 'util' module
 import os
 import sys
 from rez.tests.util import TestBase, TempdirMixin
-from rez.util import load_module_from_file
+from rez.util import load_module_from_file, resolve_variant_indices
 
 
 class TestLoadModuleFromFile(TestBase, TempdirMixin):
@@ -36,3 +36,52 @@ class TestLoadModuleFromFile(TestBase, TempdirMixin):
 
         load_module_from_file(module, os.path.join(self.root, filename))
         self.assertEqual(sys.modules.get(module), None, msg='Module was found in sys.modules')
+
+
+class TestResolveVariantIndices(TestBase):
+    """Unit tests for resolve_variant_indices()."""
+
+    def test_positive_indices_passthrough(self) -> None:
+        resolved, invalid = resolve_variant_indices([0, 1], 2)
+        self.assertEqual(resolved, {0, 1})
+        self.assertEqual(invalid, [])
+
+    def test_negative_index_last(self) -> None:
+        resolved, invalid = resolve_variant_indices([-1], 3)
+        self.assertEqual(resolved, {2})
+        self.assertEqual(invalid, [])
+
+    def test_negative_index_first(self) -> None:
+        resolved, invalid = resolve_variant_indices([-3], 3)
+        self.assertEqual(resolved, {0})
+        self.assertEqual(invalid, [])
+
+    def test_duplicate_positive_and_negative(self) -> None:
+        """1 and -1 on a 2-variant package both resolve to index 1."""
+        resolved, invalid = resolve_variant_indices([1, -1], 2)
+        self.assertEqual(resolved, {1})
+        self.assertEqual(invalid, [])
+
+    def test_mixed_positive_and_negative(self) -> None:
+        resolved, invalid = resolve_variant_indices([0, -1], 3)
+        self.assertEqual(resolved, {0, 2})
+        self.assertEqual(invalid, [])
+
+    def test_invalid_index_too_large(self) -> None:
+        resolved, invalid = resolve_variant_indices([5], 2)
+        self.assertEqual(invalid, [5])
+
+    def test_invalid_index_too_negative(self) -> None:
+        resolved, invalid = resolve_variant_indices([-3], 2)
+        self.assertEqual(invalid, [-3])
+
+    def test_multiple_invalid_sorted(self) -> None:
+        """Invalid indices are returned sorted for deterministic error messages."""
+        resolved, invalid = resolve_variant_indices([-3, 5], 2)
+        self.assertEqual(invalid, [-3, 5])
+
+    def test_zero_num_variants_passthrough(self) -> None:
+        """When the package has no explicit variants the input is returned unchanged."""
+        resolved, invalid = resolve_variant_indices([0], 0)
+        self.assertEqual(resolved, {0})
+        self.assertEqual(invalid, [])

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -201,3 +201,28 @@ def load_module_from_file(name: str, filepath: str) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def resolve_variant_indices(
+    variants: list[int], num_variants: int
+) -> tuple[set[int], list[int]]:
+    """Resolve possibly-negative variant indices to canonical non-negative ones.
+
+    Args:
+        variants: Requested variant indices (may include negatives).
+        num_variants: Total number of variants in the package.
+
+    Returns:
+        A 2-tuple of:
+        - resolved (set[int]): Canonical non-negative indices.
+        - invalid (list[int]): Any indices outside [-num_variants, num_variants-1],
+          sorted for deterministic error messages. Empty when all indices are valid.
+          When num_variants is 0 the package has no explicit variants; the
+          input is returned unchanged and invalid is always empty.
+    """
+    if num_variants <= 0:
+        return set(variants), []
+    present = set(range(-num_variants, num_variants))
+    invalid = sorted(set(variants) - present)
+    resolved = {v % num_variants for v in variants}
+    return resolved, invalid


### PR DESCRIPTION
This pull request adds support for specifying negative variant indices (e.g., --variants -1) in rez build and copy workflows. 
Negative indices are now accepted to select variants counting backward from the end, mirroring Python’s negative indexing convention.

