### PR TITLE
fix: windows drive letters remap to unc paths

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -415,6 +415,7 @@ config_schema = Schema({
     "suite_alias_prefix_char":                      Char,
     "cache_packages_path":                          OptionalStr,
     "package_definition_python_path":               OptionalStr,
+    "resolve_links_on_windows":                     Bool,
     "tmpdir":                                       OptionalStr,
     "context_tmpdir":                               OptionalStr,
     "default_shell":                                OptionalStr,

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -17,7 +17,7 @@ from rez.utils.colorize import critical, heading, local, implicit, Printer, \
 from rez.utils.formatting import columnise, PackageRequest, ENV_VAR_REGEX, \
     header_comment, minor_header_comment
 from rez.utils.data_utils import deep_del
-from rez.utils.filesystem import TempDirs, is_subdirectory, canonical_path
+from rez.utils.filesystem import TempDirs, is_subdirectory, canonical_path, real_path
 from rez.utils.memcached import pool_memcached_connections
 from rez.utils.logging_ import print_debug, print_error, print_warning
 from rez.utils.which import which
@@ -1896,8 +1896,8 @@ class ResolvedContext(object):
 
             if is_subdirectory(repo_path, bundle_path):
                 vars_["location"] = os.path.relpath(
-                    os.path.realpath(repo_path),
-                    os.path.realpath(bundle_path)
+                    real_path(repo_path),
+                    real_path(bundle_path)
                 )
 
         # serializing in, make repo absolute

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -125,6 +125,26 @@ package_definition_build_python_paths = []
 # For further information, see :ref:`package-definition-sharing-code`.
 package_definition_python_path = None
 
+# On Windows, whether to resolve symbolic links and junction points when
+# normalising filesystem paths (primarily inside ``canonical_path``).
+#
+# When ``False`` (default), rez uses ``os.path.abspath``, which normalises
+# separators and ``.``/``..`` components without following symlinks and without
+# expanding mapped drive letters to their UNC equivalents.  This preserves the
+# path style supplied by the caller (drive-letter input, drive-letter output,
+# UNC input, UNC output), effectively defaulting to pre-Python-3.8 behaviour of
+# ``os.path.realpath`` on Windows.
+#
+# When ``True``, rez performs a component-by-component walk using
+# ``os.path.islink`` / ``os.readlink``.  This resolves actual symlinks and
+# junction points without the drive-letter-to-UNC side-effect that
+# ``os.path.realpath`` introduced in Python 3.8.  Useful when package
+# repositories are accessed through directory symlinks or junctions.
+#
+# This setting is a no-op on non-Windows platforms, which always resolve
+# symlinks via ``os.path.realpath``.
+resolve_links_on_windows = False
+
 
 ###############################################################################
 # Extensions

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -130,15 +130,15 @@ package_definition_python_path = None
 #
 # When ``False`` (default), rez uses ``os.path.abspath``, which normalises
 # separators and ``.``/``..`` components without following symlinks and without
-# expanding mapped drive letters to their UNC equivalents.  This preserves the
+# expanding mapped drive letters to their UNC equivalents. This preserves the
 # path style supplied by the caller (drive-letter input, drive-letter output,
 # UNC input, UNC output), effectively defaulting to pre-Python-3.8 behaviour of
 # ``os.path.realpath`` on Windows.
 #
 # When ``True``, rez performs a component-by-component walk using
-# ``os.path.islink`` / ``os.readlink``.  This resolves actual symlinks and
+# ``os.path.islink`` / ``os.readlink``. This resolves actual symlinks and
 # junction points without the drive-letter-to-UNC side-effect that
-# ``os.path.realpath`` introduced in Python 3.8.  Useful when package
+# ``os.path.realpath`` introduced in Python 3.8. Useful when package
 # repositories are accessed through directory symlinks or junctions.
 #
 # This setting is a no-op on non-Windows platforms, which always resolve

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -20,7 +20,7 @@ from io import StringIO
 from rez.package_resources import package_rex_keys
 from rez.utils.scope import ScopeContext
 from rez.utils.sourcecode import SourceCode, early, late, include
-from rez.utils.filesystem import TempDirs
+from rez.utils.filesystem import TempDirs, real_path
 from rez.utils.data_utils import ModifyList
 from rez.exceptions import ResourceError, InvalidPackageError
 from rez.utils.memcached import memcached
@@ -66,7 +66,7 @@ def open_file_for_write(filepath, mode=None):
     yield stream
     content = stream.getvalue()
 
-    filepath = os.path.realpath(filepath)
+    filepath = real_path(filepath)
     tmpdir = tmpdir_manager.mkdtemp()
     cache_filepath = os.path.join(tmpdir, os.path.basename(filepath))
 
@@ -123,7 +123,7 @@ def load_from_file(filepath: str, format_=FileFormat.py, update_data_callback=No
     Returns:
         dict:
     """
-    filepath = os.path.realpath(filepath)
+    filepath = real_path(filepath)
     cache_filepath = file_cache.get(filepath)
 
     if cache_filepath:

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -20,7 +20,7 @@ from io import StringIO
 from rez.package_resources import package_rex_keys
 from rez.utils.scope import ScopeContext
 from rez.utils.sourcecode import SourceCode, early, late, include
-from rez.utils.filesystem import TempDirs, real_path
+from rez.utils.filesystem import TempDirs, real_path, resolve_path
 from rez.utils.data_utils import ModifyList
 from rez.exceptions import ResourceError, InvalidPackageError
 from rez.utils.memcached import memcached
@@ -66,7 +66,13 @@ def open_file_for_write(filepath, mode=None):
     yield stream
     content = stream.getvalue()
 
-    filepath = real_path(filepath)
+    # Use real_path for the cache key so it matches load_from_file's key.
+    # Separately resolve symlinks for the write target so atomic_write
+    # replaces the symlink's target, not the symlink itself. Use
+    # resolve_path (not os.path.realpath) to avoid expanding drive letters
+    # to UNC paths on Windows.
+    cache_key = real_path(filepath)
+    filepath = resolve_path(cache_key)
     tmpdir = tmpdir_manager.mkdtemp()
     cache_filepath = os.path.join(tmpdir, os.path.basename(filepath))
 
@@ -103,7 +109,7 @@ def open_file_for_write(filepath, mode=None):
     with open(cache_filepath, 'w', encoding="utf-8") as f:
         f.write(content)
 
-    file_cache[filepath] = cache_filepath
+    file_cache[cache_key] = cache_filepath
 
 
 def load_from_file(filepath: str, format_=FileFormat.py, update_data_callback=None,

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from rez.utils.execution import create_forwarding_script
+from rez.utils.filesystem import real_path
 from rez.exceptions import SuiteError, ResolvedContextError
 from rez.resolved_context import ResolvedContext
 from rez.utils.data_utils import cached_property
@@ -458,7 +459,7 @@ class Suite(object):
                 at `path`, then it will be overwritten. Otherwise, if `path`
                 exists, an error is raised.
         """
-        path = os.path.realpath(path)
+        path = real_path(path)
         if os.path.exists(path):
             if self.load_path and self.load_path == path:
                 if verbose:
@@ -528,7 +529,7 @@ class Suite(object):
             raise SuiteError("Failed loading suite: %s" % str(e))
 
         s = cls.from_dict(data)
-        s.load_path = os.path.realpath(path)
+        s.load_path = real_path(path)
         return s
 
     @classmethod

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from rez.utils.execution import create_forwarding_script
-from rez.utils.filesystem import real_path
+from rez.utils.filesystem import real_path, resolve_path
 from rez.exceptions import SuiteError, ResolvedContextError
 from rez.resolved_context import ResolvedContext
 from rez.utils.data_utils import cached_property
@@ -461,12 +461,29 @@ class Suite(object):
         """
         path = real_path(path)
         if os.path.exists(path):
-            if self.load_path and self.load_path == path:
+            is_same_suite = False
+            if self.load_path:
+                # Use samefile() instead of raw string comparison so that
+                # symlinks, junctions, and case-only differences on Windows
+                # are handled correctly.
+                try:
+                    is_same_suite = os.path.samefile(self.load_path, path)
+                except OSError:
+                    is_same_suite = (self.load_path == path)
+
+            if is_same_suite:
                 if verbose:
                     print("saving over previous suite...")
                 for context_name in self.context_names:
                     self.context(context_name)  # load before dir deleted
-                safe_rmtree(path)
+                # Resolve symlinks/junctions before rmtree so we remove the
+                # directory contents rather than severing the link itself.
+                # On non-Windows this always resolves. On Windows, resolution
+                # only happens when resolve_links_on_windows is enabled;
+                # otherwise, rmtree operates on the path as-is (which may
+                # sever a symlink -- the user can enable the flag if needed).
+                rmtree_target = resolve_path(path)
+                safe_rmtree(rmtree_target)
             else:
                 raise SuiteError("Cannot save, path exists: %r" % path)
 

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -13,6 +13,7 @@ from rez import __version__
 from rez.utils.platform_ import platform_
 from rez.exceptions import RezSystemError
 from rez.utils.data_utils import cached_property
+from rez.utils.filesystem import real_path
 
 
 class System(object):
@@ -242,7 +243,7 @@ class System(object):
 
         validation_file = os.path.join(binpath, ".rez_production_install")
         if os.path.exists(validation_file):
-            return os.path.realpath(binpath)
+            return real_path(binpath)
 
         return None
 

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -6,12 +6,15 @@
 Test package repository plugin.
 """
 import unittest
+import unittest.mock
+from contextlib import contextmanager
 
 from rezplugins.package_repository import filesystem
+from rez.exceptions import ResourceError
 from rez.packages import create_package
 from rez.tests.util import TestBase, TempdirMixin
 from rez.utils.platform_ import platform_
-from rez.version import Version
+from rez.utils.resources import ResourceHandle
 
 
 class TestFilesystemPackageRepository(TestBase, TempdirMixin):
@@ -42,19 +45,51 @@ class TestFilesystemPackageRepository(TestBase, TempdirMixin):
             pkg_repository._create_variant(case_mismatch_variant, overrides={})
 
 
+# ---------------------------------------------------------------------------
+# Helpers shared by the Windows path-form tests below.
+# ---------------------------------------------------------------------------
+
+_MOCK_DRIVE_TO_UNC = {"n": "\\\\nas\\studio"}
+
+
+def _unc_expanding_realpath(path: str) -> str:
+    """Simulate py3.8+ Windows os.path.realpath: N:\\ expansion to \\\\nas\\studio\\."""
+    norm = path.replace("/", "\\")
+    if len(norm) >= 2 and norm[1] == ":":
+        drive = norm[0].lower()
+        rest = norm[2:]
+        if drive in _MOCK_DRIVE_TO_UNC:
+            return _MOCK_DRIVE_TO_UNC[drive] + rest
+    return path
+
+
+@contextmanager
+def _simulate_py38_unc_expansion():
+    """Patch os.path.realpath and the filesystem plugin's platform_ reference
+    to reproduce the py3.8+ Windows drive-letter -> UNC expansion bug."""
+    mock_plat = unittest.mock.Mock(spec=["has_case_sensitive_filesystem", "name"])
+    mock_plat.has_case_sensitive_filesystem = False
+    mock_plat.name = "windows"
+    with unittest.mock.patch("os.path.realpath", side_effect=_unc_expanding_realpath):
+        with unittest.mock.patch.object(filesystem, "platform_", mock_plat):
+            yield
+
+
 @unittest.skipIf(
     platform_.name != "windows",
-    "URI normcase bug only manifests on Windows where os.path.normcase is not a no-op.",
+    "Windows drive-letter / UNC path-consistency tests are Windows-only.",
 )
-class TestFilesystemRepoUriCaseSensitivity(TestBase, TempdirMixin):
-    """get_package_from_uri and get_variant_from_uri must find packages when
-    the package name or version contains uppercase letters.
+class TestFilesystemRepoWindowsPathForms(TestBase, TempdirMixin):
+    """Verify that drive-letter and UNC path styles are preserved throughout
+    the repository lifecycle.
 
-    Root cause: get_package_from_uri applies os.path.normcase to the entire URI
-    before slicing out pkg_name and pkg_ver_str. Windows normcase lowercases
-    the whole string, so '1.0B' becomes '1.0b' and 'FooBar' becomes 'foobar'.
-    The subsequent get_package call (version equality check) and _get_family
-    case-guard then both return None.
+    Root cause of bugs #1438 / #2045: With os.path.realpath from py3.8 onward,
+    Windows silently converts mapped drive letters to a UNC equivalent.
+    canonical_path calls realpath, so FileSystemPackageRepository.__init__
+    stores a UNC self.location even when the caller supplied a drive-letter
+    path. Subsequent make_resource_handle / get_resource_from_handle calls
+    that carry the original drive-letter path cause a ResourceError, due to
+    the apparent location mismatch.
     """
 
     @classmethod
@@ -66,53 +101,153 @@ class TestFilesystemRepoUriCaseSensitivity(TestBase, TempdirMixin):
     def tearDownClass(cls):
         TempdirMixin.tearDownClass()
 
-    def _make_repo(self):
+    # ------------------------------------------------------------------
+    # FileSystemPackageRepository.__init__ - self.location form
+    # ------------------------------------------------------------------
+
+    def test_repo_init_preserves_drive_letter_location(self):
+        """repo.location must maintain drive-letter input path to drive-letter output path.
+
+        With the original realpath call, __init__ calls canonical_path,
+        converting N:\\ to \\\\nas\\studio\\. After the fix, canonical_path
+        on Windows must use abspath or configurably resolve symlinks, so
+        self.location stays as the caller supplied it.
+        """
         pool = filesystem.ResourcePool(cache_size=None)
-        return filesystem.FileSystemPackageRepository(self.root, pool)
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository("N:\\packages", pool)
 
-    def _install(self, repo, name, version_str):
-        data = {"version": version_str} if version_str else {}
-        package = create_package(name, data=data)
-        variant = next(package.iter_variants())
-        return repo._create_variant(variant, overrides={})
-
-    def test_get_package_from_uri_uppercase_version(self):
-        """get_package_from_uri finds a package whose version contains uppercase letters."""
-        repo = self._make_repo()
-        installed = self._install(repo, "foo", "1.0B")
-        pkg_uri = installed.parent.uri
-
-        result = repo.get_package_from_uri(pkg_uri)
-        self.assertIsNotNone(
-            result,
-            "get_package_from_uri returned None for %r — "
-            "version '1.0B' was normcased to '1.0b' before lookup" % pkg_uri,
+        self.assertFalse(
+            repo.location.startswith("\\\\"),
+            f"repo.location was unexpectedly expanded to UNC: {repo.location!r}",
         )
-        self.assertEqual(result.version, Version("1.0B"))
-
-    def test_get_package_from_uri_uppercase_name(self):
-        """get_package_from_uri finds a package whose name contains uppercase letters."""
-        repo = self._make_repo()
-        installed = self._install(repo, "FooBar", "1.0")
-        pkg_uri = installed.parent.uri
-
-        result = repo.get_package_from_uri(pkg_uri)
-        self.assertIsNotNone(
-            result,
-            "get_package_from_uri returned None for %r — "
-            "name 'FooBar' was normcased to 'foobar' before lookup" % pkg_uri,
+        self.assertTrue(
+            repo.location.lower().startswith("n:\\"),
+            f"Expected drive-letter location starting with 'n:\\', got: {repo.location!r}",
         )
-        self.assertEqual(result.name, "FooBar")
 
-    def test_get_variant_from_uri_uppercase_version(self):
-        """get_variant_from_uri finds a variant whose version contains uppercase letters."""
-        repo = self._make_repo()
-        installed = self._install(repo, "foo", "1.0B")
-        variant_uri = installed.uri
+    def test_repo_init_preserves_unc_location(self):
+        """repo.location must maintain UNC input path to UNC output path."""
+        pool = filesystem.ResourcePool(cache_size=None)
+        unc = "\\\\nas\\studio\\packages"
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository(unc, pool)
 
-        result = repo.get_variant_from_uri(variant_uri)
-        self.assertIsNotNone(
-            result,
-            "get_variant_from_uri returned None for %r — "
-            "version '1.0B' was normcased to '1.0b' before lookup" % variant_uri,
+        self.assertTrue(
+            repo.location.startswith("\\\\"),
+            f"UNC repo.location lost its UNC form: {repo.location!r}",
         )
+
+    # ------------------------------------------------------------------
+    # make_resource_handle - location comparison (base-class code path)
+    # ------------------------------------------------------------------
+
+    def test_make_resource_handle_drive_letter_no_mismatch(self):
+        """make_resource_handle must not raise when both the repo and the caller
+        use consistent drive-letter paths.
+
+        __init__ used to UNC-expand self.location via realpath, so the base-class
+        make_resource_handle compared the caller's 'N:\\packages' against the
+        stored '\\\\nas\\studio\\packages' and raised ResourceError.
+        """
+        pool = filesystem.ResourcePool(cache_size=None)
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository("N:\\packages", pool)
+            try:
+                repo.make_resource_handle(
+                    "filesystem.family",
+                    location="N:\\packages",
+                    name="mypkg",
+                )
+            except ResourceError as exc:
+                self.fail(
+                    f"make_resource_handle raised ResourceError for matching "
+                    f"drive-letter paths: {exc}"
+                )
+
+    def test_make_resource_handle_unc_no_mismatch(self):
+        """make_resource_handle must not raise when both repo and caller use
+        consistent UNC paths."""
+        pool = filesystem.ResourcePool(cache_size=None)
+        unc = "\\\\nas\\studio\\packages"
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository(unc, pool)
+            try:
+                repo.make_resource_handle(
+                    "filesystem.family",
+                    location=unc,
+                    name="mypkg",
+                )
+            except ResourceError as exc:
+                self.fail(
+                    f"make_resource_handle raised ResourceError for matching "
+                    f"UNC paths: {exc}"
+                )
+
+    # ------------------------------------------------------------------
+    # get_resource_from_handle - filesystem-plugin code path
+    # ------------------------------------------------------------------
+
+    def test_get_resource_from_handle_drive_letter_no_mismatch(self):
+        """get_resource_from_handle must not raise ResourceError when both
+        the handle and the repo use drive-letter pathing.
+
+        The filesystem plugin overrides get_resource_from_handle and applies
+        canonical_path as a bridge for maintaining path-style consistency -
+        but that bridge cannot work if canonical_path itself expands the
+        drive-letter to UNC (making both sides UNC when the repo was created
+        with a drive-letter path, or vice-versa).
+        """
+        pool = filesystem.ResourcePool(cache_size=None)
+        drive_letter_path = "N:\\packages"
+
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository(drive_letter_path, pool)
+            handle = ResourceHandle(
+                "filesystem.family",
+                {
+                    "repository_type": "filesystem",
+                    "location": drive_letter_path,
+                    "name": "mypkg",
+                },
+            )
+            # Mock the pool's own get_resource_from_handle so we do not need
+            # actual packages on disk - we only want to exercise the location
+            # verification logic, not the resource loading.
+            with unittest.mock.patch.object(
+                repo.pool, "get_resource_from_handle", return_value=unittest.mock.Mock()
+            ):
+                try:
+                    repo.get_resource_from_handle(handle, verify_repo=True)
+                except ResourceError as exc:
+                    self.fail(
+                        f"get_resource_from_handle raised ResourceError for a "
+                        f"drive-letter handle against a drive-letter repo: {exc}"
+                    )
+
+    def test_get_resource_from_handle_unc_no_mismatch(self):
+        """get_resource_from_handle must not raise ResourceError when both
+        handle and repo both use UNC paths."""
+        pool = filesystem.ResourcePool(cache_size=None)
+        unc = "\\\\nas\\studio\\packages"
+
+        with _simulate_py38_unc_expansion():
+            repo = filesystem.FileSystemPackageRepository(unc, pool)
+            handle = ResourceHandle(
+                "filesystem.family",
+                {
+                    "repository_type": "filesystem",
+                    "location": unc,
+                    "name": "mypkg",
+                },
+            )
+            with unittest.mock.patch.object(
+                repo.pool, "get_resource_from_handle", return_value=unittest.mock.Mock()
+            ):
+                try:
+                    repo.get_resource_from_handle(handle, verify_repo=True)
+                except ResourceError as exc:
+                    self.fail(
+                        f"get_resource_from_handle raised ResourceError for a "
+                        f"UNC handle against a UNC repo: {exc}"
+                    )

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -168,6 +168,63 @@ class TestCanonicalPathIdempotency(TestBase, TempdirMixin):
         self.assertEqual(once, twice)
 
 
+class TestRealPath(TestBase, TempdirMixin):
+    """Cross-platform regression guards for real_path().
+
+    real_path() is the form-stable absolute-path helper for file I/O and
+    path storage.  Key contracts verified here:
+
+    - relative paths become absolute
+    - case is never lowercased (unlike canonical_path on case-insensitive FSes)
+    - on non-Windows, symlinks are resolved (delegates to os.path.realpath)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        TempdirMixin.setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        TempdirMixin.tearDownClass()
+
+    def test_result_is_absolute(self):
+        self.assertTrue(os.path.isabs(real_path(self.root)))
+
+    def test_preserves_case(self):
+        """real_path() must not lowercase path components.
+
+        canonical_path() lowercases on case-insensitive filesystems;
+        real_path() must not, so stored paths are not corrupted for
+        case-sensitive consumers (e.g. a Linux NFS mount from Windows).
+        """
+        mixed = os.path.join(self.root, "FooBar")
+        os.makedirs(mixed)
+        result = real_path(mixed)
+        self.assertIn(
+            "FooBar", result,
+            "real_path() lowercased a path component: %r" % result,
+        )
+
+    @unittest.skipIf(
+        platform_.name == "windows",
+        "Symlink resolution via realpath is non-Windows only.",
+    )
+    def test_resolves_symlinks_on_non_windows(self):
+        """On non-Windows real_path() resolves symlinks (os.path.realpath).
+
+        Guards against real_path() being switched to abspath on all
+        platforms, which would silently break symlink resolution on
+        Linux/macOS.
+        """
+        target = os.path.join(self.root, "real_target")
+        link = os.path.join(self.root, "sym_link")
+        os.makedirs(target)
+        os.symlink(target, link)
+        self.assertEqual(real_path(link), real_path(target))
+
+
 # Simulate py3.8+ Windows os.path.realpath: N:\ expands to \\nas\studio\
 _MOCK_DRIVE_TO_UNC = {"n": "\\\\nas\\studio"}
 

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -461,3 +461,129 @@ def _multi_drive_unc_realpath(path):
         if drive in _MOCK_MULTI_DRIVE_TO_UNC:
             return _MOCK_MULTI_DRIVE_TO_UNC[drive] + norm[2:]
     return path
+
+
+@unittest.skipIf(
+    platform_.name != "windows",
+    "Windows-specific real_path() call-site regression tests",
+)
+class TestRealPathCallSitesWindowsUNC(TestBase):
+    """tests that document where os.path.realpath must be replaced with
+    real_path() to avoid drive-letter -> UNC expansion on Windows.
+
+    Each test demonstrates a concrete failure against direct use of
+    os.path.realpath. They represent call sites that need real_path
+    """
+
+    def test_bundle_relpath_does_not_raise_on_different_unc_roots(self):
+        """os.path.relpath raises ValueError when realpath expands two drive-letter
+        paths to different UNC roots.
+
+        Mirrors the pattern in resolved_context.py::
+            relpath(realpath(repo_path), realpath(bundle_path))
+
+        This test currently FAILS because os.path.realpath expands N:\\ ->
+        \\\\nas\\studio\\ and M:\\ -> \\\\backup\\bundles\\, making relpath
+        raise ValueError (can't make-relative across different UNC roots).
+        Fix: replace both realpath() calls with real_path().
+        """
+        repo_path = "N:\\packages\\mypkg"
+        bundle_path = "M:\\bundles\\mybundle"
+
+        with unittest.mock.patch("os.path.realpath", side_effect=_multi_drive_unc_realpath):
+            try:
+                os.path.relpath(
+                    os.path.realpath(repo_path),
+                    os.path.realpath(bundle_path),
+                )
+            except ValueError:
+                self.fail(
+                    "os.path.realpath expanded drive-letter paths to different "
+                    "UNC roots, causing os.path.relpath to raise ValueError. "
+                    "Replace os.path.realpath with real_path() at this call site."
+                )
+
+    def test_suite_save_does_not_raise_suiteerror_when_saving_over_loaded_suite(self):
+        """Suite.save() raises SuiteError when the save path differs from
+        suite.load_path due to UNC expansion.
+
+        Suite.save() calls os.path.realpath(path) and compares it to
+        os.path.realpath(self.load_path). When both were originally the
+        same drive-letter path (e.g. N:\\suites\\mysuite), py3.8+ realpath
+        expands each independently to the same UNC path, so they still
+        compare equal and no error is raised - on the first call.
+
+        The real failure occurs when the suite was loaded from a drive-letter
+        path but is saved to what looks like the same path: the UNC expansion
+        changes the string, so subsequent code that compares the stored
+        load_path against the UNC-expanded save path will see a mismatch.
+
+        This test documents the fragility. Fix: replace os.path.realpath
+        with real_path() in Suite.save() and Suite.load().
+        """
+        from rez.suite import Suite, SuiteError
+
+        drive_path = "N:\\suites\\mysuite"
+        suite = Suite()
+        suite.load_path = drive_path
+
+        patch_context_names = unittest.mock.patch.object(
+            Suite, "context_names",
+            new_callable=unittest.mock.PropertyMock,
+            return_value=[],
+        )
+        with unittest.mock.patch("os.path.realpath", side_effect=_unc_expanding_realpath), \
+             unittest.mock.patch("os.path.exists", return_value=True), \
+             unittest.mock.patch("os.makedirs") as mock_makedirs, \
+             unittest.mock.patch("shutil.rmtree") as mock_rmtree, \
+             unittest.mock.patch("builtins.open", unittest.mock.mock_open()), \
+             patch_context_names, \
+             unittest.mock.patch.object(suite, "to_dict", return_value={}), \
+             unittest.mock.patch.object(suite, "get_tools", return_value={}):
+            try:
+                suite.save(drive_path)
+            except SuiteError as e:
+                self.fail("Suite.save() raised SuiteError: %s" % e)
+
+            # Reachable only after the fix - verify the save actually ran:
+            # existing dir must be cleared before re-creating
+            mock_rmtree.assert_called_once()
+            # suite directory must be (re)created
+            mock_makedirs.assert_called()
+
+    def test_suite_load_stores_drive_letter_load_path_not_unc(self):
+        """Suite.load() must store load_path in drive-letter form, not UNC.
+
+        Currently FAILS because Suite.load() calls os.path.realpath(path)
+        at line 531, which on py3.8+ Windows silently expands a mapped
+        drive-letter path to its UNC equivalent.
+
+        A UNC-form load_path causes Suite.save() to raise SuiteError when
+        the caller saves back to the same drive-letter path, because
+        ``os.path.realpath(drive_letter_save_path)`` returns the same UNC
+        string while ``self.load_path`` is also UNC - but if load_path was
+        set directly in drive-letter form (e.g. from user config or a
+        partially-fixed code path), the string comparison fails.
+
+        Fix: replace os.path.realpath with real_path() in Suite.load().
+        """
+        from rez.suite import Suite
+
+        drive_path = "N:\\suites\\mysuite"
+
+        with unittest.mock.patch("os.path.realpath", side_effect=_unc_expanding_realpath), \
+             unittest.mock.patch("os.path.exists", return_value=True), \
+             unittest.mock.patch("os.path.isfile", return_value=True), \
+             unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data="{}")), \
+             unittest.mock.patch.object(Suite, "from_dict", return_value=Suite()):
+            s = Suite.load(drive_path)
+
+        self.assertFalse(
+            s.load_path.startswith("\\\\"),
+            "Suite.load_path was UNC-expanded: %r. "
+            "Replace os.path.realpath with real_path() in Suite.load()." % s.load_path,
+        )
+        self.assertTrue(
+            s.load_path.lower().startswith("n:\\"),
+            "Expected drive-letter form load_path, got: %r" % s.load_path,
+        )

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -365,3 +365,22 @@ class TestWindowsRealpathInternals(TestBase):
                 result = _windows_realpath("C:\\loop")
 
         self.assertIsInstance(result, str)
+
+
+# Map two different drive letters to two different UNC roots.
+# This simulates the py3.8+ realpath expansion that triggers the ValueError
+# in os.path.relpath when the two paths end up on different UNC servers.
+_MOCK_MULTI_DRIVE_TO_UNC = {
+    "n": "\\\\nas\\studio",
+    "m": "\\\\backup\\bundles",
+}
+
+
+def _multi_drive_unc_realpath(path):
+    """Expand two different drive letters to two different UNC roots."""
+    norm = path.replace("/", "\\")
+    if len(norm) >= 2 and norm[1] == ":":
+        drive = norm[0].lower()
+        if drive in _MOCK_MULTI_DRIVE_TO_UNC:
+            return _MOCK_MULTI_DRIVE_TO_UNC[drive] + norm[2:]
+    return path

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -14,7 +14,7 @@ import unittest.mock
 from rez.tests.util import TestBase
 from rez.tests.util import TempdirMixin
 from rez.utils import filesystem
-from rez.utils.filesystem import canonical_path
+from rez.utils.filesystem import canonical_path, _windows_realpath
 from rez.utils.platform_ import platform_
 
 
@@ -198,6 +198,24 @@ class TestCanonicalPathWindowsFormPreservation(TestBase):
         )
 
 
+def _windows_longpaths_enabled() -> bool:
+    """Return True if the Windows LongPathsEnabled registry key is set.
+
+    When False, the Win32 API cannot open paths longer than MAX_PATH (260
+    chars) without an explicit ``\\?\\`` extended-length prefix.
+    """
+    try:
+        import winreg
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\FileSystem",
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "LongPathsEnabled")
+            return bool(value)
+    except OSError:
+        return False
+
+
 @unittest.skipIf(
     platform_.name != "windows",
     "Windows symlink/junction resolution tests are Windows-only.",
@@ -267,3 +285,83 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
 
         result = canonical_path(d, platform=self._mock_windows_platform())
         self.assertEqual(result, d.lower())
+
+    def test_relative_symlink_resolved(self):
+        """canonical_path resolves a symlink whose target is a relative path."""
+        target = os.path.join(self.root, "rel_target")
+        link_parent = os.path.join(self.root, "linkdir")
+        os.makedirs(target)
+        os.makedirs(link_parent)
+        link = os.path.join(link_parent, "rel_link")
+        os.symlink(os.path.join("..", "rel_target"), link, target_is_directory=True)
+
+        result = canonical_path(link, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+    def test_long_path_symlink_resolved(self):
+        """canonical_path resolves a symlink whose target exceeds MAX_PATH (260
+        chars) on hosts with LongPathsEnabled set in the registry."""
+        if not _windows_longpaths_enabled():
+            self.skipTest(
+                "LongPathsEnabled not set in registry; skipping long-path test."
+            )
+
+        # self.root is typically ~60-70 chars; 220 'a' chars puts the full
+        # target path comfortably past the 260-char Win32 MAX_PATH limit.
+        target = os.path.join(self.root, "a" * 220)
+        link = os.path.join(self.root, "longpath_link")
+        os.makedirs(target)
+        os.symlink(target, link, target_is_directory=True)
+
+        result = canonical_path(link, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+
+@unittest.skipIf(
+    platform_.name != "windows",
+    "Windows _windows_realpath internal-branch tests are Windows-only.",
+)
+class TestWindowsRealpathInternals(TestBase):
+    """Unit tests for _windows_realpath edge-case branches.
+
+    These use mocking so no real symlinks or network paths are required.
+    """
+
+    def test_readlink_extended_prefix_stripped(self):
+        """_windows_realpath strips a \\\\?\\ prefix returned by os.readlink."""
+        link_path = "C:\\some\\link"
+        target_path = "C:\\real\\target"
+
+        def _fake_islink(p):
+            return p == link_path
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink):
+            with unittest.mock.patch("os.readlink", return_value="\\\\?\\" + target_path):
+                result = _windows_realpath(link_path)
+
+        self.assertEqual(result, os.path.normpath(target_path))
+
+    def test_readlink_unc_extended_prefix_stripped(self):
+        """_windows_realpath strips a \\\\?\\UNC\\ prefix returned by os.readlink."""
+        link_path = "C:\\some\\link"
+        target_unc = "\\\\server\\share\\target"
+
+        def _fake_islink(p):
+            return p == link_path
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink):
+            with unittest.mock.patch(
+                "os.readlink",
+                return_value="\\\\?\\UNC\\" + target_unc[2:],
+            ):
+                result = _windows_realpath(link_path)
+
+        self.assertEqual(result, os.path.normpath(target_unc))
+
+    def test_symlink_depth_limit_terminates(self):
+        """_windows_realpath stops after 40 hops and returns without hanging."""
+        with unittest.mock.patch("os.path.islink", return_value=True):
+            with unittest.mock.patch("os.readlink", return_value="C:\\loop"):
+                result = _windows_realpath("C:\\loop")
+
+        self.assertIsInstance(result, str)

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -5,6 +5,7 @@
 """
 unit tests for 'rez.utils.filesystem' module
 """
+import os
 import os.path
 import tempfile
 import unittest
@@ -195,3 +196,74 @@ class TestCanonicalPathWindowsFormPreservation(TestBase):
             result, result.lower(),
             f"canonical_path did not lowercase on case-insensitive platform: {result!r}",
         )
+
+
+@unittest.skipIf(
+    platform_.name != "windows",
+    "Windows symlink/junction resolution tests are Windows-only.",
+)
+class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
+    """canonical_path resolves symlinks/junctions on Windows when
+    resolve_links_on_windows=True, without expanding mapped drive letters."""
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+        cls.settings = {"resolve_links_on_windows": True}
+
+        # Probe for symlink capability. Dir symlinks require Developer
+        # Mode from Windows 10 Creators Update onward, or an elevated process.
+        probe_src = os.path.join(cls.root, "_symlink_probe_src")
+        probe_lnk = os.path.join(cls.root, "_symlink_probe_lnk")
+        os.makedirs(probe_src)
+        try:
+            os.symlink(probe_src, probe_lnk, target_is_directory=True)
+            os.unlink(probe_lnk)
+        except OSError:
+            raise unittest.SkipTest(
+                "Dir symlink creation not supported on this host "
+                "(enable Developer Mode or run as Admin)."
+            )
+        finally:
+            if os.path.isdir(probe_src):
+                os.rmdir(probe_src)
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def _mock_windows_platform(self):
+        m = unittest.mock.Mock(spec=["has_case_sensitive_filesystem", "name"])
+        m.has_case_sensitive_filesystem = False
+        m.name = "windows"
+        return m
+
+    def test_symlink_resolved(self):
+        """canonical_path follows a directory symlink when resolve_links_on_windows=True."""
+        target = os.path.join(self.root, "real_target")
+        link = os.path.join(self.root, "link_to_target")
+        os.makedirs(target)
+        os.symlink(target, link, target_is_directory=True)
+
+        result = canonical_path(link, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+    def test_symlink_chain_resolved(self):
+        """canonical_path follows a chain of two symlinks."""
+        target = os.path.join(self.root, "final_target")
+        mid = os.path.join(self.root, "mid_link")
+        link = os.path.join(self.root, "outer_link")
+        os.makedirs(target)
+        os.symlink(target, mid, target_is_directory=True)
+        os.symlink(mid, link, target_is_directory=True)
+
+        result = canonical_path(link, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+    def test_non_symlink_path_unchanged(self):
+        """canonical_path on a plain directory is stable with resolve_links_on_windows=True."""
+        d = os.path.join(self.root, "plain_dir")
+        os.makedirs(d)
+
+        result = canonical_path(d, platform=self._mock_windows_platform())
+        self.assertEqual(result, d.lower())

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -533,32 +533,44 @@ class TestRealPathCallSitesWindowsUNC(TestBase):
     """
 
     def test_bundle_relpath_does_not_raise_on_different_unc_roots(self):
-        """os.path.relpath raises ValueError when realpath expands two drive-letter
-        paths to different UNC roots.
+        """_adjust_variant_for_bundling must not raise ValueError when
+        os.path.realpath would have expanded drive-letter paths to UNC form.
 
-        Mirrors the pattern in resolved_context.py::
-            relpath(realpath(repo_path), realpath(bundle_path))
-
-        This test currently FAILS because os.path.realpath expands N:\\ ->
-        \\\\nas\\studio\\ and M:\\ -> \\\\backup\\bundles\\, making relpath
-        raise ValueError (can't make-relative across different UNC roots).
-        Fix: replace both realpath() calls with real_path().
+        Exercises the real call site in resolved_context.py. is_subdirectory
+        is mocked True to force the relpath branch. With real_path() (abspath)
+        the drive-letter form is preserved and os.path.relpath succeeds.
         """
-        repo_path = "N:\\packages\\mypkg"
-        bundle_path = "M:\\bundles\\mybundle"
+        from rez.resolved_context import ResolvedContext
 
-        with unittest.mock.patch("os.path.realpath", side_effect=_multi_drive_unc_realpath):
+        bundle_path = "N:\\bundles\\mybundle"
+        repo_path = "N:\\bundles\\mybundle\\packages\\mypkg"
+
+        handle = {
+            "variables": {
+                "repository_type": "filesystem",
+                "location": repo_path,
+            }
+        }
+
+        with unittest.mock.patch.object(
+            ResolvedContext, "_get_bundle_path", return_value=bundle_path
+        ), unittest.mock.patch(
+            "rez.resolved_context.is_subdirectory", return_value=True
+        ):
             try:
-                os.path.relpath(
-                    os.path.realpath(repo_path),
-                    os.path.realpath(bundle_path),
-                )
-            except ValueError:
+                ResolvedContext._adjust_variant_for_bundling(handle, out=True)
+            except ValueError as e:
                 self.fail(
-                    "os.path.realpath expanded drive-letter paths to different "
-                    "UNC roots, causing os.path.relpath to raise ValueError. "
-                    "Replace os.path.realpath with real_path() at this call site."
+                    "_adjust_variant_for_bundling raised ValueError: %s\n"
+                    "Ensure real_path() (not os.path.realpath) is used at "
+                    "the os.path.relpath call site in resolved_context.py." % e
                 )
+
+        self.assertNotEqual(
+            handle["variables"]["location"],
+            repo_path,
+            "Expected location to be updated to a relative path, was unchanged.",
+        )
 
     def test_bundle_relpath_must_not_use_canonical_path_regression(self):
         """canonical_path lowercases the path, which corrupts case-sensitive

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -137,6 +137,37 @@ class TestIsSubdirectoryBasic(TestBase, TempdirMixin):
         os.makedirs(b)
         self.assertFalse(filesystem.is_subdirectory(a, b))
 
+
+class TestCanonicalPathIdempotency(TestBase, TempdirMixin):
+    """canonical_path(canonical_path(x)) must equal canonical_path(x).
+
+    This invariant guards against naive changes to canonical_path internals that
+    produce an asymmetry on a given platform
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        TempdirMixin.setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        TempdirMixin.tearDownClass()
+
+    def test_idempotent_on_existing_directory(self):
+        once = canonical_path(self.root, platform_)
+        twice = canonical_path(once, platform_)
+        self.assertEqual(once, twice)
+
+    def test_idempotent_on_nested_path(self):
+        subdir = os.path.join(self.root, "a", "b")
+        os.makedirs(subdir)
+        once = canonical_path(subdir, platform_)
+        twice = canonical_path(once, platform_)
+        self.assertEqual(once, twice)
+
+
 # Simulate py3.8+ Windows os.path.realpath: N:\ expands to \\nas\studio\
 _MOCK_DRIVE_TO_UNC = {"n": "\\\\nas\\studio"}
 

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -91,6 +91,52 @@ class TestFileSystem(TestBase, TempdirMixin):
         self.assertFalse(os.path.exists(src))
 
 
+class TestIsSubdirectoryBasic(TestBase, TempdirMixin):
+    """Regression guards for is_subdirectory correctness.
+
+    Uses real filesystem paths so the guards hold on every platform.
+    They protect against regressions when the internal path
+    normalisation inside is_subdirectory is changed - for example,
+    replacing os.path.realpath with real_path().
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        TempdirMixin.setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        TempdirMixin.tearDownClass()
+
+    def test_direct_child_is_subdirectory(self):
+        parent = os.path.join(self.root, "parent")
+        child = os.path.join(parent, "child")
+        os.makedirs(child)
+        self.assertTrue(filesystem.is_subdirectory(child, parent))
+
+    def test_deep_nested_child_is_subdirectory(self):
+        parent = os.path.join(self.root, "deep_parent")
+        grandchild = os.path.join(parent, "a", "b", "c")
+        os.makedirs(grandchild)
+        self.assertTrue(filesystem.is_subdirectory(grandchild, parent))
+
+    def test_sibling_is_not_subdirectory(self):
+        base = os.path.join(self.root, "sib_base")
+        left = os.path.join(base, "left")
+        right = os.path.join(base, "right")
+        os.makedirs(left)
+        os.makedirs(right)
+        self.assertFalse(filesystem.is_subdirectory(left, right))
+
+    def test_unrelated_path_is_not_subdirectory(self):
+        a = os.path.join(self.root, "unrelated_a")
+        b = os.path.join(self.root, "unrelated_b")
+        os.makedirs(a)
+        os.makedirs(b)
+        self.assertFalse(filesystem.is_subdirectory(a, b))
+
 # Simulate py3.8+ Windows os.path.realpath: N:\ expands to \\nas\studio\
 _MOCK_DRIVE_TO_UNC = {"n": "\\\\nas\\studio"}
 

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -14,7 +14,7 @@ import unittest.mock
 from rez.tests.util import TestBase
 from rez.tests.util import TempdirMixin
 from rez.utils import filesystem
-from rez.utils.filesystem import canonical_path, _windows_realpath
+from rez.utils.filesystem import canonical_path, real_path, _windows_realpath
 from rez.utils.platform_ import platform_
 
 
@@ -502,6 +502,55 @@ class TestRealPathCallSitesWindowsUNC(TestBase):
                     "UNC roots, causing os.path.relpath to raise ValueError. "
                     "Replace os.path.realpath with real_path() at this call site."
                 )
+
+    def test_bundle_relpath_must_not_use_canonical_path_regression(self):
+        """canonical_path lowercases the path, which corrupts case-sensitive
+        path components stored in bundle files.
+
+        This is a regression guard: if the resolved_context.py call site is
+        fixed by substituting canonical_path() (which lowercases on Windows),
+        the stored relative path will have wrong capitalisation on Linux NFS
+        mounts that are case-sensitive.
+
+        real_path() preserves the original casing, so it is the correct fix.
+        """
+        from rez.utils.platform_ import Platform
+
+        class _CaseInsensitivePlatform(Platform):
+            name = "windows"
+
+            @property
+            def has_case_sensitive_filesystem(self):
+                return False
+
+        mock_plat = _CaseInsensitivePlatform()
+        repo_path = "N:\\packages\\MyPkg\\1.0B"
+        bundle_path = "N:\\bundles\\MyBundle"
+
+        relpath_via_canonical = os.path.relpath(
+            canonical_path(repo_path, mock_plat),
+            canonical_path(bundle_path, mock_plat),
+        )
+        relpath_via_real = os.path.relpath(
+            real_path(repo_path),
+            real_path(bundle_path),
+        )
+
+        # canonical_path lowercases everything; real_path preserves case.
+        self.assertNotEqual(
+            relpath_via_canonical,
+            relpath_via_real,
+            "canonical_path and real_path produced the same relpath - "
+            "expected canonical_path to lowercase and real_path to preserve case.",
+        )
+        self.assertIn(
+            "MyPkg", relpath_via_real,
+            "real_path() must preserve mixed-case package name in relpath.",
+        )
+        self.assertIn(
+            "1.0B", relpath_via_real,
+            "real_path() must preserve mixed-case version string in relpath.",
+        )
 
     def test_suite_save_does_not_raise_suiteerror_when_saving_over_loaded_suite(self):
         """Suite.save() raises SuiteError when the save path differs from

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -432,6 +432,51 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
         result = canonical_path(link, platform=self._mock_windows_platform())
         self.assertEqual(result, target.lower())
 
+    def test_intermediate_dir_symlink_resolved(self):
+        """canonical_path resolves symlinks on intermediate directory
+        components, not just the final component.
+
+        This is the symlink-chain-through-prefix case: if /a is a symlink to
+        /real_a, then /a/b/link should resolve through /real_a/b/link, not
+        break because /a was already "passed" by the component walk.
+        """
+        real_a = os.path.join(self.root, "real_a")
+        b_dir = os.path.join(real_a, "b")
+        target = os.path.join(b_dir, "final_target")
+        a_link = os.path.join(self.root, "a")
+        link = os.path.join(a_link, "b", "link_to_target")
+
+        os.makedirs(target)
+        os.symlink(target, link, target_is_directory=True)
+        # Create the intermediate symlink *after* the target tree so the
+        # link overlays the directory structure.
+        os.symlink(real_a, a_link, target_is_directory=True)
+
+        result = canonical_path(link, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+    def test_nested_intermediate_symlink_resolved(self):
+        """canonical_path resolves multiple intermediate directory symlinks
+        in a single path.
+
+        /link_a -> /real_a
+        /link_a/link_b -> /real_b
+        /link_a/link_b/target should resolve to /real_b/target
+        """
+        real_a = os.path.join(self.root, "real_a")
+        real_b = os.path.join(self.root, "real_b")
+        target = os.path.join(real_b, "target")
+        link_a = os.path.join(self.root, "link_a")
+        link_b = os.path.join(link_a, "link_b")
+
+        os.makedirs(target)
+        os.symlink(real_b, link_b, target_is_directory=True)
+        os.symlink(real_a, link_a, target_is_directory=True)
+
+        test_path = os.path.join(link_a, "link_b", "target")
+        result = canonical_path(test_path, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
     def test_long_path_symlink_resolved(self):
         """canonical_path resolves a symlink whose target exceeds MAX_PATH (260
         chars) on hosts with LongPathsEnabled set in the registry."""

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -6,28 +6,15 @@
 unit tests for 'rez.utils.filesystem' module
 """
 import os.path
-import sys
 import tempfile
+import unittest
+import unittest.mock
 
 from rez.tests.util import TestBase
 from rez.tests.util import TempdirMixin
 from rez.utils import filesystem
+from rez.utils.filesystem import canonical_path
 from rez.utils.platform_ import platform_
-import unittest.mock
-
-
-def rmtree_file_not_found_error(path, onerror):
-    try:
-        raise FileNotFoundError("File not found", path)
-    except:
-        onerror(None, path, sys.exc_info())
-
-
-def rmtree_permission_error(path, onerror):
-    try:
-        raise PermissionError("Permission denied", path)
-    except:
-        onerror(None, path, sys.exc_info())
 
 
 class TestFileSystem(TestBase, TempdirMixin):
@@ -102,26 +89,109 @@ class TestFileSystem(TestBase, TempdirMixin):
         self.assertTrue(os.path.exists(dst))
         self.assertFalse(os.path.exists(src))
 
-    def test_safe_rmtree_with_file_not_found(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error):
-            with self.assertRaises(FileNotFoundError):
-                filesystem.safe_rmtree("path")
 
-    def test_safe_rmtree_with_other_error(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
-            with self.assertRaises(PermissionError):
-                filesystem.safe_rmtree("path")
+# Simulate py3.8+ Windows os.path.realpath: N:\ expands to \\nas\studio\
+_MOCK_DRIVE_TO_UNC = {"n": "\\\\nas\\studio"}
 
-    def test_safe_rmtree_with_file_not_found_and_apple_double(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
-            if platform_.name == 'osx':
-                filesystem.safe_rmtree("._path")
-                mock_rmtree.assert_called_once_with("._path", onerror=unittest.mock.ANY)
-            else:
-                with self.assertRaises(FileNotFoundError):
-                    filesystem.safe_rmtree("._path")
 
-    def test_safe_rmtree_with_other_error_and_apple_double(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
-            with self.assertRaises(PermissionError):
-                filesystem.safe_rmtree("._path")
+def _unc_expanding_realpath(path):
+    """Replicate the py3.8+ Windows realpath behaviour that converts a mapped
+    drive letter to the underlying UNC server path."""
+    norm = path.replace("/", "\\")
+    if len(norm) >= 2 and norm[1] == ":":
+        drive = norm[0].lower()
+        rest = norm[2:]  # e.g. "\\packages\\mypkg"
+        if drive in _MOCK_DRIVE_TO_UNC:
+            return _MOCK_DRIVE_TO_UNC[drive] + rest
+    return path
+
+
+@unittest.skipIf(
+    platform_.name != "windows",
+    "Windows drive-letter / UNC path form tests are Windows-only.",
+)
+class TestCanonicalPathWindowsFormPreservation(TestBase):
+    """canonical_path must never change the *form* of a Windows path.
+
+    A drive-letter path (N:\\...) must stay drive-letter.
+    A UNC path (\\\\server\\...) must stay UNC.
+
+    Before the fix these tests fail because canonical_path calls
+    os.path.realpath, which on Python 3.8+ Windows silently converts
+    drive-letter paths to their underlying UNC equivalents.
+    """
+
+    def _mock_windows_platform(self):
+        """Return a mock Platform object that behaves like Windows."""
+        m = unittest.mock.Mock(spec=["has_case_sensitive_filesystem", "name"])
+        m.has_case_sensitive_filesystem = False
+        m.name = "windows"
+        return m
+
+    # ------------------------------------------------------------------
+    # Tests that must FAIL before the fix and PASS after.
+    # ------------------------------------------------------------------
+
+    def test_drive_letter_form_preserved(self):
+        """canonical_path on a drive-letter path must not return a UNC path.
+
+        Fails today because os.path.realpath (py3.8+ Windows) expands
+        N:\\ -> \\\\nas\\studio\\, so canonical_path returns a UNC string.
+        """
+        mock_plat = self._mock_windows_platform()
+        with unittest.mock.patch("os.path.realpath", side_effect=_unc_expanding_realpath):
+            result = canonical_path("N:\\packages\\mypkg", platform=mock_plat)
+
+        self.assertFalse(
+            result.startswith("\\\\"),
+            f"canonical_path UNC-expanded a drive-letter path: {result!r}",
+        )
+        self.assertTrue(
+            result.lower().startswith("n:\\"),
+            f"Expected drive-letter result starting with 'n:\\', got: {result!r}",
+        )
+
+    def test_drive_letter_form_preserved_forward_slashes(self):
+        """Same as above but input uses forward slashes (N:/packages)."""
+        mock_plat = self._mock_windows_platform()
+        with unittest.mock.patch("os.path.realpath", side_effect=_unc_expanding_realpath):
+            result = canonical_path("N:/packages/mypkg", platform=mock_plat)
+
+        self.assertFalse(
+            result.startswith("\\\\"),
+            f"canonical_path UNC-expanded a drive-letter path: {result!r}",
+        )
+        self.assertTrue(
+            result.lower().startswith("n:\\") or result.lower().startswith("n:/"),
+            f"Expected drive-letter result, got: {result!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # Tests that already PASS today and must continue to PASS after the fix.
+    # ------------------------------------------------------------------
+
+    def test_unc_form_preserved(self):
+        """canonical_path on a UNC path must return a UNC path."""
+        mock_plat = self._mock_windows_platform()
+        unc = "\\\\nas\\studio\\packages\\mypkg"
+        # realpath on an already-UNC path returns the same UNC path unchanged.
+        with unittest.mock.patch("os.path.realpath", return_value=unc):
+            result = canonical_path(unc, platform=mock_plat)
+
+        self.assertTrue(
+            result.startswith("\\\\"),
+            f"canonical_path changed UNC form unexpectedly: {result!r}",
+        )
+
+    def test_drive_letter_case_folded(self):
+        """canonical_path lowercases drive-letter paths on Windows (case-insensitive FS)."""
+        mock_plat = self._mock_windows_platform()
+        # Use a local temp path that abspath can handle so we are not
+        # depending on UNC expansion behaviour here.
+        with unittest.mock.patch("os.path.realpath", side_effect=lambda p: p):
+            result = canonical_path("C:\\Packages\\MyPkg", platform=mock_plat)
+
+        self.assertEqual(
+            result, result.lower(),
+            f"canonical_path did not lowercase on case-insensitive platform: {result!r}",
+        )

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -7,6 +7,7 @@ unit tests for 'rez.utils.filesystem' module
 """
 import os
 import os.path
+import sys
 import tempfile
 import unittest
 import unittest.mock
@@ -16,6 +17,20 @@ from rez.tests.util import TempdirMixin
 from rez.utils import filesystem
 from rez.utils.filesystem import canonical_path, real_path, _windows_realpath
 from rez.utils.platform_ import platform_
+
+
+def rmtree_file_not_found_error(path, onerror):
+    try:
+        raise FileNotFoundError("File not found", path)
+    except:
+        onerror(None, path, sys.exc_info())
+
+
+def rmtree_permission_error(path, onerror):
+    try:
+        raise PermissionError("Permission denied", path)
+    except:
+        onerror(None, path, sys.exc_info())
 
 
 class TestFileSystem(TestBase, TempdirMixin):
@@ -89,6 +104,30 @@ class TestFileSystem(TestBase, TempdirMixin):
         filesystem.rename(src, dst)
         self.assertTrue(os.path.exists(dst))
         self.assertFalse(os.path.exists(src))
+
+    def test_safe_rmtree_with_file_not_found(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error):
+            with self.assertRaises(FileNotFoundError):
+                filesystem.safe_rmtree("path")
+
+    def test_safe_rmtree_with_other_error(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
+            with self.assertRaises(PermissionError):
+                filesystem.safe_rmtree("path")
+
+    def test_safe_rmtree_with_file_not_found_and_apple_double(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
+            if platform_.name == 'osx':
+                filesystem.safe_rmtree("._path")
+                mock_rmtree.assert_called_once_with("._path", onerror=unittest.mock.ANY)
+            else:
+                with self.assertRaises(FileNotFoundError):
+                    filesystem.safe_rmtree("._path")
+
+    def test_safe_rmtree_with_other_error_and_apple_double(self) -> None:
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
+            with self.assertRaises(PermissionError):
+                filesystem.safe_rmtree("._path")
 
 
 class TestIsSubdirectoryBasic(TestBase, TempdirMixin):
@@ -350,6 +389,20 @@ def _windows_longpaths_enabled() -> bool:
         return False
 
 
+def _create_junction(target, link):
+    """Create a Windows directory junction from ``link`` to ``target``.
+
+    Junctions don't require Developer Mode or admin privileges (unlike
+    symlinks) and can be created via ``mklink /J``.
+    """
+    import subprocess
+    subprocess.check_call(
+        ["cmd", "/c", "mklink", "/J", link, target],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
 @unittest.skipIf(
     platform_.name != "windows",
     "Windows symlink/junction resolution tests are Windows-only.",
@@ -441,16 +494,16 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
         break because /a was already "passed" by the component walk.
         """
         real_a = os.path.join(self.root, "real_a")
-        b_dir = os.path.join(real_a, "b")
-        target = os.path.join(b_dir, "final_target")
+        target = os.path.join(real_a, "b", "final_target")
         a_link = os.path.join(self.root, "a")
-        link = os.path.join(a_link, "b", "link_to_target")
 
+        # Create the real target tree first.
         os.makedirs(target)
-        os.symlink(target, link, target_is_directory=True)
-        # Create the intermediate symlink *after* the target tree so the
-        # link overlays the directory structure.
+        # Create the intermediate symlink so /a -> /real_a.
         os.symlink(real_a, a_link, target_is_directory=True)
+        # Now create the leaf symlink through the symlinked path.
+        link = os.path.join(a_link, "b", "link_to_target")
+        os.symlink(target, link, target_is_directory=True)
 
         result = canonical_path(link, platform=self._mock_windows_platform())
         self.assertEqual(result, target.lower())
@@ -467,11 +520,12 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
         real_b = os.path.join(self.root, "real_b")
         target = os.path.join(real_b, "target")
         link_a = os.path.join(self.root, "link_a")
-        link_b = os.path.join(link_a, "link_b")
 
         os.makedirs(target)
-        os.symlink(real_b, link_b, target_is_directory=True)
+        # Create link_a -> /real_a first, then link_b under it.
         os.symlink(real_a, link_a, target_is_directory=True)
+        link_b = os.path.join(link_a, "link_b")
+        os.symlink(real_b, link_b, target_is_directory=True)
 
         test_path = os.path.join(link_a, "link_b", "target")
         result = canonical_path(test_path, platform=self._mock_windows_platform())
@@ -510,20 +564,6 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
 
         result = canonical_path(junction, platform=self._mock_windows_platform())
         self.assertEqual(result, target.lower())
-
-
-def _create_junction(target, link):
-    """Create a Windows directory junction from *link* to *target*.
-
-    Junctions don't require Developer Mode or admin privileges (unlike
-    symlinks) and can be created via ``mklink /J``.
-    """
-    import subprocess
-    subprocess.check_call(
-        ["cmd", "/c", "mklink", "/J", link, target],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
 
 
 @unittest.skipIf(
@@ -575,6 +615,31 @@ class TestWindowsRealpathInternals(TestBase):
 
         self.assertIsInstance(result, str)
 
+    def test_symlink_loop_with_rewalk_terminates(self):
+        """_windows_realpath terminates when a symlink loop spans multiple
+        components that trigger the re-walk path.
+
+        A -> B\\A creates a cycle: resolving A yields B\\A, the re-walk pushes
+        [B, A] back onto the stack, B is walked (plain dir), A is resolved
+        again to B\\A, and so on.  The total_depth guard must stop this.
+        """
+        link_a = "C:\\dir\\a"
+        link_b = "C:\\dir\\b"
+
+        def _fake_islink(p):
+            return p in (link_a, link_b)
+
+        def _fake_readlink(p):
+            if p == link_a:
+                return link_b
+            return link_a
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink):
+            with unittest.mock.patch("os.readlink", side_effect=_fake_readlink):
+                result = _windows_realpath(link_a)
+
+        self.assertIsInstance(result, str)
+
     def test_junction_resolved_when_islink_false(self):
         """_windows_realpath resolves junctions even when os.path.islink
         returns False for them (the case on Python 3.8-3.11).
@@ -594,9 +659,47 @@ class TestWindowsRealpathInternals(TestBase):
             return p == link_path
 
         with unittest.mock.patch("os.path.islink", side_effect=_fake_islink):
-            with unittest.mock.patch("os.path.isjunction", side_effect=_fake_isjunction, create=True):
+            with unittest.mock.patch(
+                "os.path.isjunction",
+                side_effect=_fake_isjunction,
+                create=True,
+            ):
                 with unittest.mock.patch("os.readlink", return_value=target_path):
                     result = _windows_realpath(link_path)
+
+        self.assertEqual(result, os.path.normpath(target_path))
+
+    def test_junction_resolved_via_reparse_tag_fallback(self):
+        """_windows_realpath resolves junctions on Python 3.8-3.11 where
+        os.path.isjunction does not exist, using the st_reparse_tag fallback.
+        """
+        link_path = "C:\\some\\junction"
+        target_path = "C:\\real\\target"
+
+        # Simulate Python 3.8-3.11: no os.path.isjunction, islink returns
+        # False for junctions, but lstat returns the reparse tag.
+        # Only the junction itself should have a non-zero tag; every other
+        # path component must look like a plain directory.
+        def _fake_lstat(p):
+            st = unittest.mock.Mock()
+            st.st_reparse_tag = 0xA0000003 if p == link_path else 0
+            return st
+
+        # Remove os.path.isjunction to simulate 3.8-3.11.
+        original_isjunction = getattr(os.path, "isjunction", None)
+        if original_isjunction is not None:
+            del os.path.isjunction
+
+        try:
+            with unittest.mock.patch("os.path.islink", return_value=False):
+                with unittest.mock.patch("os.lstat", side_effect=_fake_lstat):
+                    with unittest.mock.patch(
+                        "os.readlink", return_value=target_path
+                    ):
+                        result = _windows_realpath(link_path)
+        finally:
+            if original_isjunction is not None:
+                os.path.isjunction = original_isjunction
 
         self.assertEqual(result, os.path.normpath(target_path))
 
@@ -606,7 +709,11 @@ class TestWindowsRealpathInternals(TestBase):
         plain_path = "C:\\some\\plain_dir"
 
         with unittest.mock.patch("os.path.islink", return_value=False):
-            with unittest.mock.patch("os.path.isjunction", return_value=False, create=True):
+            with unittest.mock.patch(
+                "os.path.isjunction",
+                return_value=False,
+                create=True,
+            ):
                 with unittest.mock.patch("os.readlink") as mock_readlink:
                     _windows_realpath(plain_path)
 

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -495,6 +495,36 @@ class TestCanonicalPathWindowsSymlinkResolution(TestBase, TempdirMixin):
         result = canonical_path(link, platform=self._mock_windows_platform())
         self.assertEqual(result, target.lower())
 
+    def test_junction_resolved(self):
+        """canonical_path follows a directory junction when
+        resolve_links_on_windows=True.
+
+        Unlike symlinks, junctions are detected via os.path.isjunction
+        (3.12+) or st_reparse_tag (3.8-3.11), not os.path.islink.
+        """
+        target = os.path.join(self.root, "junction_target")
+        junction = os.path.join(self.root, "link_junction")
+        os.makedirs(target)
+
+        _create_junction(target, junction)
+
+        result = canonical_path(junction, platform=self._mock_windows_platform())
+        self.assertEqual(result, target.lower())
+
+
+def _create_junction(target, link):
+    """Create a Windows directory junction from *link* to *target*.
+
+    Junctions don't require Developer Mode or admin privileges (unlike
+    symlinks) and can be created via ``mklink /J``.
+    """
+    import subprocess
+    subprocess.check_call(
+        ["cmd", "/c", "mklink", "/J", link, target],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
 
 @unittest.skipIf(
     platform_.name != "windows",
@@ -544,6 +574,43 @@ class TestWindowsRealpathInternals(TestBase):
                 result = _windows_realpath("C:\\loop")
 
         self.assertIsInstance(result, str)
+
+    def test_junction_resolved_when_islink_false(self):
+        """_windows_realpath resolves junctions even when os.path.islink
+        returns False for them (the case on Python 3.8-3.11).
+
+        The _is_link_or_junction helper should detect junctions via
+        os.path.isjunction (3.12+) or st_reparse_tag (3.8-3.11) and
+        feed them to os.readlink, which handles both types.
+        """
+        link_path = "C:\\some\\junction"
+        target_path = "C:\\real\\target"
+
+        # Simulate py3.8-3.11 where islink returns False for junctions
+        def _fake_islink(p):
+            return False
+
+        def _fake_isjunction(p):
+            return p == link_path
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink):
+            with unittest.mock.patch("os.path.isjunction", side_effect=_fake_isjunction, create=True):
+                with unittest.mock.patch("os.readlink", return_value=target_path):
+                    result = _windows_realpath(link_path)
+
+        self.assertEqual(result, os.path.normpath(target_path))
+
+    def test_junction_skipped_when_neither_islink_nor_isjunction(self):
+        """_windows_realpath does not attempt readlink on a plain directory
+        that is neither a symlink nor a junction."""
+        plain_path = "C:\\some\\plain_dir"
+
+        with unittest.mock.patch("os.path.islink", return_value=False):
+            with unittest.mock.patch("os.path.isjunction", return_value=False, create=True):
+                with unittest.mock.patch("os.readlink") as mock_readlink:
+                    _windows_realpath(plain_path)
+
+        mock_readlink.assert_not_called()
 
 
 # Map two different drive letters to two different UNC roots.

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -924,3 +924,289 @@ class TestRealPathCallSitesWindowsUNC(TestBase):
             s.load_path.lower().startswith("n:\\"),
             "Expected drive-letter form load_path, got: %r" % s.load_path,
         )
+
+
+class TestStripExtendedLengthPrefix(TestBase):
+    """Tests for _strip_extended_length_prefix helper."""
+
+    def test_dos_prefix_stripped(self):
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        self.assertEqual(
+            _strip_extended_length_prefix("\\\\?\\C:\\foo\\bar"),
+            "C:\\foo\\bar",
+        )
+
+    def test_unc_prefix_stripped(self):
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        self.assertEqual(
+            _strip_extended_length_prefix("\\\\?\\UNC\\server\\share\\foo"),
+            "\\\\server\\share\\foo",
+        )
+
+    def test_lowercase_unc_prefix_stripped(self):
+        r"""Case-insensitive: \?\unc\ is just as valid as \?\UNC\."""
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        self.assertEqual(
+            _strip_extended_length_prefix("\\\\?\\unc\\server\\share\\foo"),
+            "\\\\server\\share\\foo",
+        )
+
+    def test_mixed_case_prefix_stripped(self):
+        r"""Case-insensitive: \?\UnC\ should also be handled."""
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        self.assertEqual(
+            _strip_extended_length_prefix("\\\\?\\UnC\\server\\share\\foo"),
+            "\\\\server\\share\\foo",
+        )
+
+    def test_volume_mount_point_preserved(self):
+        r"""\?\Volume{GUID}\... must NOT be stripped -- it has no DOS/UNC
+        equivalent and stripping it turns an absolute device path into a
+        bogus relative one."""
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        vol = "\\\\?\\Volume{12345678-1234-1234-1234-123456789abc}\\foo"
+        self.assertEqual(_strip_extended_length_prefix(vol), vol)
+
+    def test_no_prefix_unchanged(self):
+        from rez.utils.filesystem import _strip_extended_length_prefix
+        self.assertEqual(
+            _strip_extended_length_prefix("C:\\foo\\bar"),
+            "C:\\foo\\bar",
+        )
+
+
+class TestSuiteSaveSamefileGuard(TestBase, TempdirMixin):
+    """Test that Suite.save() uses samefile() for the overwrite guard,
+    and resolves symlinks before rmtree to avoid severing links."""
+
+    def test_save_through_symlink_uses_samefile(self):
+        """Suite.load(alias); Suite.save(alias) should overwrite the suite
+        at the resolved target, not sever the symlink."""
+        from rez.suite import Suite
+
+        actual = os.path.join(self.root, "actual_suite")
+        alias = os.path.join(self.root, "alias_suite")
+        os.makedirs(actual)
+        with open(os.path.join(actual, "suite.yaml"), "w") as f:
+            f.write("contexts: {}\n")
+
+        os.symlink(actual, alias)
+
+        # Mock enough of Suite to test the save() overwrite guard.
+        # Mock resolve_path to return the symlink target so the test works
+        # identically on all platforms (on Windows default config,
+        # resolve_path does not resolve symlinks).
+        suite = Suite()
+        suite.load_path = real_path(alias)
+
+        with unittest.mock.patch("os.path.exists", return_value=True), \
+             unittest.mock.patch("os.path.samefile", return_value=True), \
+             unittest.mock.patch("rez.suite.safe_rmtree") as mock_rmtree, \
+             unittest.mock.patch("rez.suite.resolve_path", return_value=actual), \
+             unittest.mock.patch("os.makedirs"), \
+             unittest.mock.patch.object(suite, "contexts", {}), \
+             unittest.mock.patch.object(suite, "to_dict", return_value={}), \
+             unittest.mock.patch.object(suite, "get_tools", return_value={}):
+            try:
+                suite.save(alias)
+            except Exception as e:
+                self.fail("Suite.save() raised on same-file alias: %s" % e)
+
+        mock_rmtree.assert_called_once()
+        # rmtree should target the resolved path (actual_suite), not the
+        # raw symlink (alias_suite).
+        rmtree_arg = mock_rmtree.call_args[0][0]
+        self.assertNotIn("alias_suite", rmtree_arg)
+        self.assertIn("actual_suite", rmtree_arg)
+
+    def test_save_rejects_different_path(self):
+        """Suite.save() to a different existing path should still raise."""
+        from rez.suite import Suite
+        from rez.exceptions import SuiteError
+
+        suite = Suite()
+        suite.load_path = os.path.join(self.root, "suite_a")
+        other = os.path.join(self.root, "suite_b")
+        os.makedirs(other)
+
+        with unittest.mock.patch("os.path.exists", return_value=True), \
+             unittest.mock.patch("os.path.samefile", return_value=False):
+            with self.assertRaises(SuiteError):
+                suite.save(other)
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "Test creates real symlinks; Windows requires admin or developer mode",
+)
+class TestGetResourceFromHandleSamefileFallback(TestBase, TempdirMixin):
+    """Test that get_resource_from_handle uses samefile() as a final
+    fallback when canonical_path can't bridge drive-letter vs UNC form."""
+
+    def test_samefile_fallback_allows_mixed_forms(self):
+        """A handle with a UNC location should match a repo with a
+        drive-letter location when they refer to the same physical path."""
+        from rez.package_repository import package_repository_manager
+        from rez.exceptions import ResourceError
+
+        # Create a real temp dir to use as the repo location
+        repo_path = os.path.join(self.root, "repo")
+        os.makedirs(repo_path)
+
+        # Get a real repo to extract its variables
+        repo = package_repository_manager.get_repository(repo_path)
+
+        # Simulate a handle with a different path form that refers to
+        # the same location
+        fake_handle = unittest.mock.Mock()
+        fake_handle.variables = {
+            "repository_type": "filesystem",
+            "location": repo_path + "_alias",  # different string
+        }
+
+        # Patch samefile to return True (simulating same physical path)
+        with unittest.mock.patch("os.path.exists", return_value=True), \
+             unittest.mock.patch("os.path.samefile", return_value=True):
+            # The location-mismatch guard should pass via the samefile
+            # fallback. A ResourceError with "location mismatch" means the
+            # fallback failed. Other ResourceErrors (e.g. "Unknown resource
+            # type" from the pool lookup) mean the guard passed but the mock
+            # handle couldn't complete the full resource resolution -- that's
+            # fine, we're only testing the location guard.
+            try:
+                repo.get_resource_from_handle(fake_handle)
+            except ResourceError as e:
+                if "location mismatch" in str(e):
+                    self.fail(
+                        "get_resource_from_handle raised location-mismatch "
+                        "ResourceError despite samefile() returning True: %s" % e
+                    )
+            except Exception:
+                pass
+
+
+class TestIsSubdirectorySymlinkResolution(TestBase, TempdirMixin):
+    """Test that is_subdirectory resolves symlinks for containment checks.
+
+    On non-Windows, canonical_path (used by is_subdirectory) resolves
+    symlinks via os.path.realpath. A path that is lexically inside a
+    directory but physically outside (via symlink) should NOT be considered
+    a subdirectory.
+    """
+
+    @unittest.skipIf(
+        platform_.name == "windows",
+        "Windows symlink resolution depends on resolve_links_on_windows flag",
+    )
+    def test_symlink_escape_is_not_subdirectory(self):
+        """A symlink pointing outside the parent should not be a subdirectory."""
+        inside = os.path.join(self.root, "inside")
+        outside = os.path.join(self.root, "outside")
+        os.makedirs(inside)
+        os.makedirs(outside)
+
+        link = os.path.join(inside, "link")
+        os.symlink(outside, link)
+
+        from rez.utils.filesystem import is_subdirectory
+        self.assertFalse(
+            is_subdirectory(link, inside),
+            "Symlink escaping the parent was incorrectly considered a subdirectory",
+        )
+
+    @unittest.skipIf(
+        platform_.name == "windows",
+        "Windows symlink resolution depends on resolve_links_on_windows flag",
+    )
+    def test_real_child_is_subdirectory(self):
+        """A real child directory should be a subdirectory."""
+        parent = os.path.join(self.root, "parent")
+        child = os.path.join(parent, "child")
+        os.makedirs(child)
+
+        from rez.utils.filesystem import is_subdirectory
+        self.assertTrue(is_subdirectory(child, parent))
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "These tests mock Windows internals and must run on non-Windows",
+)
+class TestWindowsRealpathDriveInheritance(TestBase):
+    r"""Test that _windows_realpath inherits the link's drive for root-relative
+    symlink targets (Python 3.8-3.12 behaviour where isabs('\target') is True).
+    """
+
+    def test_root_relative_target_inherits_link_drive(self):
+        r"""A root-relative symlink target like \targets\pkg should inherit
+        the drive of the link being resolved, not the CWD drive.
+        """
+        import ntpath
+
+        link_path = "N:\\links\\link"
+        # Root-relative target -- no drive letter
+        target_path = "\\targets\\pkg"
+
+        def _fake_islink(p):
+            return p == link_path
+
+        # On Linux, os.path functions treat Windows paths differently.
+        # Mock them to mimic ntpath behaviour (py3.8-3.12 where
+        # isabs('\target') is True).
+        def _fake_abspath(p):
+            return os.path.normpath(p)
+
+        def _fake_isabs(p):
+            return ntpath.isabs(p)
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink), \
+             unittest.mock.patch("os.readlink", return_value=target_path), \
+             unittest.mock.patch("os.path.abspath", side_effect=_fake_abspath), \
+             unittest.mock.patch("os.path.isabs", side_effect=_fake_isabs), \
+             unittest.mock.patch("os.path.splitdrive", side_effect=ntpath.splitdrive):
+            result = _windows_realpath(link_path)
+
+        # The result should be on the N: drive, not the CWD drive
+        self.assertTrue(
+            result.lower().startswith("n:"),
+            "Root-relative target should inherit link's drive (N:), got: %r" % result,
+        )
+
+    def test_long_path_candidate_is_prefixed_for_probes(self):
+        r"""When the candidate path exceeds MAX_PATH, the probe path should
+        be prefixed with \?\ so that islink/isjunction/lstat can succeed
+        on hosts without LongPathsEnabled.
+        """
+        import ntpath
+
+        # Create a path that exceeds MAX_PATH (259 chars)
+        long_dir = "C:\\" + "a" * 260
+        link_path = long_dir + "\\link"
+        target_path = "C:\\real\\target"
+
+        captured_probe = []
+
+        def _fake_islink(p):
+            captured_probe.append(p)
+            return p == link_path or p == "\\\\?\\" + link_path
+
+        def _fake_abspath(p):
+            return os.path.normpath(p)
+
+        def _fake_isabs(p):
+            return ntpath.isabs(p)
+
+        with unittest.mock.patch("os.path.islink", side_effect=_fake_islink), \
+             unittest.mock.patch("os.readlink", return_value=target_path), \
+             unittest.mock.patch("os.path.abspath", side_effect=_fake_abspath), \
+             unittest.mock.patch("os.path.isabs", side_effect=_fake_isabs), \
+             unittest.mock.patch("os.path.splitdrive", side_effect=ntpath.splitdrive):
+            _windows_realpath(link_path)
+
+        # At least one probe should have the \\?\ prefix
+        prefixed_probes = [p for p in captured_probe if p.startswith("\\\\?\\")]
+        self.assertTrue(
+            len(prefixed_probes) > 0,
+            r"Expected at least one \?\-prefixed probe for long path, "
+            "got probes: %r" % captured_probe,
+        )

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -525,15 +525,27 @@ def _windows_realpath(path: str) -> str:
     server paths.  This function resolves only actual filesystem symlinks and
     junction points, walking the path component-by-component so that the drive
     root (drive-letter or UNC prefix) is never touched.
+
+    When a symlink resolves to an absolute path, the target's prefix components
+    are re-walked from the root so that intermediate-directory symlinks are
+    resolved transitively (matching POSIX ``os.path.realpath`` semantics).
     """
     path = os.path.normpath(os.path.abspath(path))
     drive, rest = os.path.splitdrive(path)
     # Preserve the root separator so UNC paths keep their leading "\\" and
     # drive-letter paths keep their "\".
-    result = drive + (os.sep if rest.startswith(os.sep) else "")
-    for part in rest.lstrip(os.sep).split(os.sep):
-        if not part:
-            continue
+    root = drive + (os.sep if rest.startswith(os.sep) else "")
+
+    # Component stack: we process left-to-right, but when a symlink resolves
+    # to an absolute path we push its components onto the front so that any
+    # intermediate-directory symlinks in the target are re-walked.
+    components = rest.lstrip(os.sep).split(os.sep)
+    components = [c for c in components if c]
+    result = root
+    total_depth = 0
+
+    while components:
+        part = components.pop(0)
         candidate = os.path.join(result, part)
         depth = 0
         while os.path.islink(candidate) and depth < 40:
@@ -566,6 +578,24 @@ def _windows_realpath(path: str) -> str:
             else:
                 candidate = os.path.normpath(os.path.abspath(target))
             depth += 1
+            total_depth += 1
+            if total_depth >= 40:
+                break
+
+        # If the symlink resolved to an absolute path, its prefix components
+        # may themselves contain symlinks that haven't been walked.  Re-walk
+        # the entire resolved path from its root by pushing its components
+        # back onto the stack.  This handles the case where, e.g., /a/b is a
+        # symlink to /x/y and /x is itself a symlink.
+        if candidate != os.path.join(result, part):
+            t_drive, t_rest = os.path.splitdrive(candidate)
+            t_root = t_drive + (os.sep if t_rest.startswith(os.sep) else "")
+            new_parts = [c for c in t_rest.lstrip(os.sep).split(os.sep) if c]
+            root = t_root
+            result = t_root
+            components = new_parts + components
+            continue
+
         result = candidate
     return result
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -516,6 +516,37 @@ def to_posixpath(path: str):
 
 _WINDOWS_MAX_PATH = 259  # Win32 MAX_PATH minus the null terminator
 
+# Reparse tag constant for Windows junctions (mount points).  Defined in
+# ntifs.h as IO_REPARSE_TAG_MOUNT_POINT.  We hardcode it because it is not
+# exposed in Python's stat module on all versions.
+_IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+
+
+def _is_link_or_junction(path: str) -> bool:
+    """Return True if ``path`` is a symlink or a Windows junction point.
+
+    ``os.path.islink`` detects symlinks on all Python versions but does NOT
+    detect junctions on any version (it checks for
+    ``IO_REPARSE_TAG_SYMLINK`` only).  ``os.path.isjunction`` (3.12+) covers
+    junctions; for 3.8-3.11 we fall back to checking ``st_reparse_tag`` on
+    ``os.lstat``.
+    """
+    if os.path.islink(path):
+        return True
+    # os.path.isjunction was added in Python 3.12.
+    isjunction = getattr(os.path, "isjunction", None)
+    if isjunction is not None:
+        return isjunction(path)
+    # Python 3.8-3.11: detect junctions via the reparse tag on lstat.
+    # st_reparse_tag is non-zero when the path is a reparse point; we
+    # check for the mount-point tag specifically.
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return False
+    tag = getattr(st, "st_reparse_tag", 0)
+    return tag == _IO_REPARSE_TAG_MOUNT_POINT
+
 
 def _windows_realpath(path: str) -> str:
     """Resolve symlinks and junctions on Windows without expanding mapped drives.
@@ -548,7 +579,7 @@ def _windows_realpath(path: str) -> str:
         part = components.pop(0)
         candidate = os.path.join(result, part)
         depth = 0
-        while os.path.islink(candidate) and depth < 40:
+        while _is_link_or_junction(candidate) and depth < 40:
             target = os.readlink(candidate)
             # os.readlink on Windows may return an extended-length path
             # (\\?\C:\... or \\?\UNC\server\share\...). Strip the prefix so
@@ -587,7 +618,10 @@ def _windows_realpath(path: str) -> str:
         # the entire resolved path from its root by pushing its components
         # back onto the stack.  This handles the case where, e.g., /a/b is a
         # symlink to /x/y and /x is itself a symlink.
-        if candidate != os.path.join(result, part):
+        #
+        # Guard against symlink loops: if the global resolution budget is
+        # exhausted, stop re-walking and accept the current candidate.
+        if candidate != os.path.join(result, part) and total_depth < 40:
             t_drive, t_rest = os.path.splitdrive(candidate)
             t_root = t_drive + (os.sep if t_rest.startswith(os.sep) else "")
             new_parts = [c for c in t_rest.lstrip(os.sep).split(os.sep) if c]
@@ -653,7 +687,7 @@ def canonical_path(path: str, platform=None):
 
 
 def real_path(path: str) -> str:
-    """Return an absolute, form-stable path for file I/O and path operations.
+    r"""Return an absolute, form-stable path for file I/O and path operations.
 
     Resolves relative segments and (on non-Windows) symlinks, while
     preserving the form of the input path - a drive-letter path stays

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -353,8 +353,8 @@ def make_tmp_name(name):
 
 def is_subdirectory(path_a, path_b) -> bool:
     """Returns True if `path_a` is a subdirectory of `path_b`."""
-    path_a = os.path.realpath(path_a)
-    path_b = os.path.realpath(path_b)
+    path_a = real_path(path_a)
+    path_b = real_path(path_b)
     try:
         relative = os.path.relpath(path_a, path_b)
     except ValueError:

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -610,6 +610,39 @@ def canonical_path(path: str, platform=None):
     return path
 
 
+def real_path(path: str) -> str:
+    """Return an absolute, form-stable path for file I/O and path operations.
+
+    Resolves relative segments and (on non-Windows) symlinks, while
+    preserving the form of the input path - a drive-letter path stays
+    drive-letter; a UNC path stays UNC.
+
+    Use this when you need a stable absolute path to use rather than to
+    compare - opening a file, building a cache key, passing to
+    ``os.path.relpath``, returning a path to the user, or storing a path
+    in a serialised format that may be read on another platform.
+
+    Do not use this when the question is "do these two paths refer to
+    the same filesystem location?" - use :func:`canonical_path` instead,
+    which lowercases on case-insensitive filesystems so that equality
+    checks work regardless of capitalisation.
+
+    Justification: ``os.path.realpath`` on Windows (Python 3.8+)
+    silently expands mapped drive-letter paths to their UNC
+    equivalents (``N:\\`` -> ``\\\\server\\share\\``).  That expansion
+    breaks ``os.path.relpath`` across mismatched UNC roots
+    (``ValueError``), corrupts cache keys, and mutates capitalisation
+    in stored paths. ``os.path.abspath`` avoids this while still
+    making paths absolute and normalising separators.
+
+    Returns:
+        str: Absolute path with the same drive-letter / UNC form as input.
+    """
+    if sys.platform == "win32":
+        return os.path.normpath(os.path.abspath(path))
+    return os.path.realpath(path)
+
+
 def walk_up_dirs(path: str):
     """Yields absolute directories starting with the given path, and iterating
     up through all it's parents, until it reaches a root directory"""

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -12,6 +12,7 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 from uuid import uuid4
 import errno
+import sys
 import weakref
 import atexit
 import posixpath
@@ -530,7 +531,15 @@ def canonical_path(path: str, platform=None):
     if platform is None:
         platform = platform_
 
-    path = os.path.normpath(os.path.realpath(path))
+    # On Windows, os.path.realpath from py3.8 onwards silently converts drive
+    # lettered paths to their UNC equivalents (N:\ -> \\server\share\). By default,
+    # use abspath instead to preserve the caller's form.
+    # We check sys.platform rather than the platform argument because this is
+    # an OS-level behaviour of os.path.realpath, not a user-configurable choice.
+    if sys.platform == "win32":
+        path = os.path.normpath(os.path.abspath(path))
+    else:
+        path = os.path.normpath(os.path.realpath(path))
 
     if not platform.has_case_sensitive_filesystem:
         return path.lower()

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -514,6 +514,42 @@ def to_posixpath(path: str):
     return posixpath.sep.join(path.split(ntpath.sep))
 
 
+def _windows_realpath(path: str) -> str:
+    """Resolve symlinks and junctions on Windows without expanding mapped drives.
+
+    ``os.path.realpath`` on Python 3.8+ Windows uses ``GetFinalPathNameByHandle``
+    which expands mapped drive letters (e.g. ``N:\\``) to their underlying UNC
+    server paths.  This function resolves only actual filesystem symlinks and
+    junction points, walking the path component-by-component so that the drive
+    root (drive-letter or UNC prefix) is never touched.
+    """
+    path = os.path.normpath(os.path.abspath(path))
+    drive, rest = os.path.splitdrive(path)
+    # Preserve the root separator so UNC paths keep their leading "\\" and
+    # drive-letter paths keep their "\".
+    result = drive + (os.sep if rest.startswith(os.sep) else "")
+    for part in rest.lstrip(os.sep).split(os.sep):
+        if not part:
+            continue
+        candidate = os.path.join(result, part)
+        depth = 0
+        while os.path.islink(candidate) and depth < 40:
+            target = os.readlink(candidate)
+            # os.readlink on Windows may return an extended-length path
+            # (\\?\C:\... or \\?\UNC\server\share\...). Strip the prefix so
+            # subsequent abspath/normpath calls produce ordinary paths.
+            if target.startswith("\\\\?\\UNC\\"):
+                target = "\\\\" + target[8:]
+            elif target.startswith("\\\\?\\"):
+                target = target[4:]
+            if not os.path.isabs(target):
+                target = os.path.join(os.path.dirname(candidate), target)
+            candidate = os.path.normpath(os.path.abspath(target))
+            depth += 1
+        result = candidate
+    return result
+
+
 def canonical_path(path: str, platform=None):
     r""" Resolves symlinks, and formats filepath.
 
@@ -532,12 +568,19 @@ def canonical_path(path: str, platform=None):
         platform = platform_
 
     # On Windows, os.path.realpath from py3.8 onwards silently converts drive
-    # lettered paths to their UNC equivalents (N:\ -> \\server\share\). By default,
-    # use abspath instead to preserve the caller's form.
+    # lettered paths to their UNC equivalents (N:\ -> \\server\share\).
     # We check sys.platform rather than the platform argument because this is
     # an OS-level behaviour of os.path.realpath, not a user-configurable choice.
     if sys.platform == "win32":
-        path = os.path.normpath(os.path.abspath(path))
+        # Lazy import avoids a circular dependency (config imports filesystem).
+        from rez.config import config  # noqa: PLC0415
+        if config.resolve_links_on_windows:
+            path = _windows_realpath(path)
+        else:
+            # Default: abspath preserves the caller's path form (drive-letter
+            # stays drive-letter, UNC stays UNC) and restores the pre-3.8
+            # behaviour where realpath on Windows was equivalent to abspath.
+            path = os.path.normpath(os.path.abspath(path))
     else:
         path = os.path.normpath(os.path.realpath(path))
 

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -514,6 +514,9 @@ def to_posixpath(path: str):
     return posixpath.sep.join(path.split(ntpath.sep))
 
 
+_WINDOWS_MAX_PATH = 259  # Win32 MAX_PATH minus the null terminator
+
+
 def _windows_realpath(path: str) -> str:
     """Resolve symlinks and junctions on Windows without expanding mapped drives.
 
@@ -537,14 +540,31 @@ def _windows_realpath(path: str) -> str:
             target = os.readlink(candidate)
             # os.readlink on Windows may return an extended-length path
             # (\\?\C:\... or \\?\UNC\server\share\...). Strip the prefix so
-            # subsequent abspath/normpath calls produce ordinary paths.
+            # we can work with ordinary path strings.
             if target.startswith("\\\\?\\UNC\\"):
                 target = "\\\\" + target[8:]
             elif target.startswith("\\\\?\\"):
                 target = target[4:]
             if not os.path.isabs(target):
                 target = os.path.join(os.path.dirname(candidate), target)
-            candidate = os.path.normpath(os.path.abspath(target))
+            # For paths that exceed MAX_PATH, re-add the extended-length
+            # prefix before calling abspath so the Win32 API (GetFullPathNameW)
+            # can handle the length on hosts without LongPathsEnabled in the
+            # registry.  We strip the prefix again afterwards so the rest of
+            # the walk operates on ordinary path strings.
+            if len(target) > _WINDOWS_MAX_PATH:
+                if target.startswith("\\\\"):
+                    target = "\\\\?\\UNC\\" + target[2:]
+                else:
+                    target = "\\\\?\\" + target
+                candidate = os.path.abspath(target)
+                if candidate.startswith("\\\\?\\UNC\\"):
+                    candidate = "\\\\" + candidate[8:]
+                elif candidate.startswith("\\\\?\\"):
+                    candidate = candidate[4:]
+                candidate = os.path.normpath(candidate)
+            else:
+                candidate = os.path.normpath(os.path.abspath(target))
             depth += 1
         result = candidate
     return result

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -571,14 +571,26 @@ def _windows_realpath(path: str) -> str:
 
 
 def canonical_path(path: str, platform=None):
-    r""" Resolves symlinks, and formats filepath.
+    """Return a normalised path suitable for identity comparison.
 
-    Resolves symlinks, lowercases if filesystem is case-insensitive,
-    formats filepath using slashes appropriate for platform.
+    Resolves symlinks (on non-Windows), lowercases on case-insensitive
+    filesystems, and normalises separators.  Two paths that refer to the
+    same location will compare equal (``==``) after canonicalisation.
+
+    Use this when the question is "do these two paths refer to the same
+    thing?" - e.g. deduplicating package repository locations, or
+    checking whether a loaded resource path matches a stored location.
+
+    Do not use this when you need a path to open a file, pass to an
+    external tool, or store in a bundle/context that may be read on
+    another platform - the lowercasing it applies on case-insensitive
+    filesystems mutates the string and can break case-sensitive consumers
+    (e.g. a Linux NFS mount accessed from a Windows client).  Use
+    :func:`real_path` for those cases instead.
 
     Args:
         path (str): Filepath being formatted
-        platform (rez.utils.platform\_.Platform): Indicates platform path is being
+        platform (rez.utils.platform_.Platform): Indicates platform path is being
             formatted for. Defaults to current platform.
 
     Returns:

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -352,9 +352,14 @@ def make_tmp_name(name):
 
 
 def is_subdirectory(path_a, path_b) -> bool:
-    """Returns True if `path_a` is a subdirectory of `path_b`."""
-    path_a = real_path(path_a)
-    path_b = real_path(path_b)
+    """Returns True if `path_a` is a subdirectory of `path_b`.
+
+    Both paths are canonicalised (symlinks resolved on non-Windows, and on
+    Windows when resolve_links_on_windows is enabled) so that containment
+    is checked against the physical location, not the lexical spelling.
+    """
+    path_a = canonical_path(path_a)
+    path_b = canonical_path(path_b)
     try:
         relative = os.path.relpath(path_a, path_b)
     except ValueError:
@@ -522,6 +527,32 @@ _WINDOWS_MAX_PATH = 259  # Win32 MAX_PATH minus the null terminator
 _IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
 
 
+def _strip_extended_length_prefix(path: str) -> str:
+    r"""Strip ``\\?\`` or ``\\?\UNC\`` extended-length prefixes (case-insensitive).
+
+    Volume mount-point targets (``\\?\Volume{GUID}\...``) have no ordinary
+    DOS/UNC equivalent, so stripping the prefix would turn an absolute device
+    path into a bogus relative one. Those are left untouched.
+    """
+    lower = path.lower()
+    if lower.startswith("\\\\?\\unc\\"):
+        return "\\\\" + path[8:]
+    if lower.startswith("\\\\?\\volume{"):
+        return path  # absolute device path -- no DOS/UNC equivalent
+    if lower.startswith("\\\\?\\"):
+        return path[4:]
+    return path
+
+
+def _add_extended_length_prefix(path: str) -> str:
+    r"""Add the ``\\?\`` (or ``\\?\UNC\``) extended-length prefix to ``path``."""
+    if path.lower().startswith("\\\\?\\"):
+        return path  # already prefixed
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + path[2:]
+    return "\\\\?\\" + path
+
+
 def _is_link_or_junction(path: str) -> bool:
     """Return True if ``path`` is a symlink or a Windows junction point.
 
@@ -578,37 +609,54 @@ def _windows_realpath(path: str) -> str:
     while components:
         part = components.pop(0)
         candidate = os.path.join(result, part)
-        depth = 0
-        while _is_link_or_junction(candidate) and depth < 40:
-            target = os.readlink(candidate)
+        # Prefix the candidate for filesystem probes when it exceeds MAX_PATH.
+        # On hosts without LongPathsEnabled, islink/isjunction/lstat/readlink
+        # will fail on unprefixed paths longer than MAX_PATH. The \\?\ prefix
+        # bypasses the Win32 path-length limit for these probes.
+        probe = candidate
+        if len(candidate) > _WINDOWS_MAX_PATH:
+            probe = _add_extended_length_prefix(candidate)
+        while _is_link_or_junction(probe):
+            target = os.readlink(probe)
             # os.readlink on Windows may return an extended-length path
-            # (\\?\C:\... or \\?\UNC\server\share\...). Strip the prefix so
-            # we can work with ordinary path strings.
-            if target.startswith("\\\\?\\UNC\\"):
-                target = "\\\\" + target[8:]
-            elif target.startswith("\\\\?\\"):
-                target = target[4:]
+            # (\\?\C:\... or \\?\UNC\server\share\...). Strip the prefix
+            # so we can work with ordinary path strings. Case-insensitive:
+            # Windows path APIs are case-insensitive and \\?\unc\ is just as
+            # valid as \\?\UNC\. Volume mount points return
+            # \\?\Volume{GUID}\... which has no ordinary DOS/UNC equivalent
+            # -- stripping the prefix would turn an absolute device path into
+            # a bogus relative one. Leave those alone.
+            target = _strip_extended_length_prefix(target)
             if not os.path.isabs(target):
                 target = os.path.join(os.path.dirname(candidate), target)
+            else:
+                # On Python 3.8-3.12, ntpath.isabs(r'\targets\pkg') returns
+                # True even though the target has no drive letter. A
+                # root-relative target should inherit the drive of the link
+                # being resolved, not the process CWD drive (which
+                # os.path.abspath would use). Python 3.13 changed isabs to
+                # return False for drive-less paths, so this is a
+                # version-specific fix.
+                t_drive, t_rest = os.path.splitdrive(target)
+                if not t_drive and target.startswith(os.sep):
+                    c_drive, _ = os.path.splitdrive(candidate)
+                    target = c_drive + target
             # For paths that exceed MAX_PATH, re-add the extended-length
             # prefix before calling abspath so the Win32 API (GetFullPathNameW)
             # can handle the length on hosts without LongPathsEnabled in the
-            # registry.  We strip the prefix again afterwards so the rest of
+            # registry. We strip the prefix again afterwards so the rest of
             # the walk operates on ordinary path strings.
             if len(target) > _WINDOWS_MAX_PATH:
-                if target.startswith("\\\\"):
-                    target = "\\\\?\\UNC\\" + target[2:]
-                else:
-                    target = "\\\\?\\" + target
+                target = _add_extended_length_prefix(target)
                 candidate = os.path.abspath(target)
-                if candidate.startswith("\\\\?\\UNC\\"):
-                    candidate = "\\\\" + candidate[8:]
-                elif candidate.startswith("\\\\?\\"):
-                    candidate = candidate[4:]
+                candidate = _strip_extended_length_prefix(candidate)
                 candidate = os.path.normpath(candidate)
             else:
                 candidate = os.path.normpath(os.path.abspath(target))
-            depth += 1
+            # Refresh the probe path for the next inner-loop iteration.
+            probe = candidate
+            if len(candidate) > _WINDOWS_MAX_PATH:
+                probe = _add_extended_length_prefix(candidate)
             total_depth += 1
             if total_depth >= 40:
                 break
@@ -715,6 +763,27 @@ def real_path(path: str) -> str:
         str: Absolute path with the same drive-letter / UNC form as input.
     """
     if sys.platform == "win32":
+        return os.path.normpath(os.path.abspath(path))
+    return os.path.realpath(path)
+
+
+def resolve_path(path: str) -> str:
+    r"""Resolve symlinks in a form-preserving way.
+
+    Like :func:`real_path`, but also resolves symlinks on Windows without
+    expanding drive letters to UNC paths. Use this when you need the
+    physical target of a path (e.g. before ``rmtree`` to avoid severing a
+    symlink) but must not lose the drive-letter form.
+
+    On non-Windows this is identical to ``os.path.realpath``.
+    On Windows with ``resolve_links_on_windows`` enabled, uses
+    :func:`_windows_realpath`. Otherwise, uses ``os.path.abspath``
+    (no symlink resolution, matching :func:`real_path`).
+    """
+    if sys.platform == "win32":
+        from rez.config import config  # noqa: PLC0415
+        if config.resolve_links_on_windows:
+            return _windows_realpath(path)
         return os.path.normpath(os.path.abspath(path))
     return os.path.realpath(path)
 

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -521,8 +521,8 @@ class WindowsPlatform(Platform):
         # powershell.exe (Windows PowerShell 5.1) ships with all Windows 10/11 installs.
         cmd = [
             'powershell', '-NonInteractive', '-NoProfile', '-Command',
-            '(Get-CimInstance -ClassName Win32_Processor'
-            ' | Measure-Object -Property NumberOfCores -Sum).Sum',
+            ('Get-CimInstance -ClassName Win32_Processor'
+             ' | Measure-Object -Property NumberOfCores -Sum).Sum'),
         ]
         try:
             p = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)

--- a/src/rez/utils/py_dist.py
+++ b/src/rez/utils/py_dist.py
@@ -6,6 +6,7 @@
 Functions for converting python distributions to rez packages.
 """
 from rez.exceptions import RezSystemError
+from rez.utils.filesystem import real_path
 import importlib.metadata as importlib_metadata
 import shutil
 import sys
@@ -194,7 +195,7 @@ def convert_dist(name, dest_path, make_variant: bool = True, ignore_dirs=None,
             files = set()
             for file in installed_files:
                 path = os.path.join(eggpath, file)
-                path = os.path.realpath(path)
+                path = real_path(path)
 
                 if os.path.isfile(path) and path.startswith(dist.location + os.sep):
                     dir_ = os.path.dirname(path)
@@ -209,7 +210,7 @@ def convert_dist(name, dest_path, make_variant: bool = True, ignore_dirs=None,
             def _dst(p):
                 dst = os.path.relpath(p, dist.location)
                 dst = os.path.join(root_path, dst)
-                return os.path.realpath(dst)
+                return real_path(dst)
 
             for dir_ in dirs:
                 dst_dir = _dst(dir_)

--- a/src/rez/utils/py_dist.py
+++ b/src/rez/utils/py_dist.py
@@ -6,7 +6,7 @@
 Functions for converting python distributions to rez packages.
 """
 from rez.exceptions import RezSystemError
-from rez.utils.filesystem import real_path
+from rez.utils.filesystem import real_path, is_subdirectory
 import importlib.metadata as importlib_metadata
 import shutil
 import sys
@@ -197,7 +197,7 @@ def convert_dist(name, dest_path, make_variant: bool = True, ignore_dirs=None,
                 path = os.path.join(eggpath, file)
                 path = real_path(path)
 
-                if os.path.isfile(path) and path.startswith(dist.location + os.sep):
+                if os.path.isfile(path) and is_subdirectory(path, dist.location):
                     dir_ = os.path.dirname(path)
                     if ignore_dirs:
                         reldir = os.path.relpath(dir_, dist.location)

--- a/src/rezgui/objects/App.py
+++ b/src/rezgui/objects/App.py
@@ -9,6 +9,7 @@ from rezgui import organisation_name, application_name
 from rez.resolved_context import ResolvedContext
 from rez.exceptions import ResolvedContextError
 from rez.utils.data_utils import cached_property
+from rez.utils.filesystem import real_path
 from rez.vendor import yaml
 from contextlib import contextmanager
 import sys
@@ -67,7 +68,7 @@ class App(QtWidgets.QApplication):
                 QtWidgets.QApplication.restoreOverrideCursor()
 
         if context:
-            path = os.path.realpath(filepath)
+            path = real_path(filepath)
             self.config.prepend_string_list("most_recent_contexts", path,
                                             "max_most_recent_contexts")
         return context

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -16,6 +16,7 @@ from rez.packages import get_developer_package, Variant
 from rez.utils.platform_ import platform_
 from rez.config import config
 from rez.utils.which import which
+from rez.utils.filesystem import real_path
 from rez.vendor.schema.schema import Or
 from rez.shells import create_shell
 import argparse
@@ -150,9 +151,9 @@ class CMakeBuildSystem(BuildSystem):
 
         # execute cmake within the build env
         _pr("Executing: %s" % ' '.join(cmd))
-        if not os.path.abspath(build_path):
+        if not os.path.isabs(build_path):
             build_path = os.path.join(self.working_dir, build_path)
-            build_path = os.path.realpath(build_path)
+            build_path = real_path(build_path)
 
         actions_callback = functools.partial(
             self._add_build_actions,

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -811,6 +811,20 @@ class FileSystemPackageRepository(PackageRepository):
 
         return num_removed
 
+    def make_resource_handle(self, resource_key, **variables):
+        # Normalize the caller-supplied location so the base-class raw string
+        # comparison succeeds, even when the caller uses a different case, or
+        # an equivalent path form (e.g. mixed-case drive letter on Windows).
+        #
+        # https://github.com/AcademySoftwareFoundation/rez/issues/2045
+        #
+        location = variables.get("location")
+        if location is not None and location != self.location:
+            norm = canonical_path(location, platform_)
+            if norm == self.location:
+                variables["location"] = self.location
+        return super().make_resource_handle(resource_key, **variables)
+
     def get_resource_from_handle(self, resource_handle, verify_repo: bool = True):
         if verify_repo:
             repository_type = resource_handle.variables.get("repository_type")

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -476,6 +476,11 @@ class FileSystemPackageRepository(PackageRepository):
                    "file_lock_type": Or("default", "link", "mkdir", "symlink"),
                    "package_filenames": [str]}
 
+    # Memoization cache for samefile() fallback in get_resource_from_handle.
+    # Maps (canonical_handle_location, self.location) -> bool. Avoids
+    # repeated network I/O when resolving legacy UNC/drive-letter handles.
+    _location_aliases: dict[str, bool] = {}
+
     building_prefix = ".building"
     ignore_prefix = ".ignore"
 
@@ -837,7 +842,8 @@ class FileSystemPackageRepository(PackageRepository):
 
             # It appears that sometimes, the handle location can differ to the
             # repo location even though they are the same path (different
-            # mounts). We account for that here.
+            # mounts, drive-letter vs UNC form, etc.). We account for that
+            # here.
             #
             # https://github.com/AcademySoftwareFoundation/rez/pull/957
             #
@@ -845,9 +851,38 @@ class FileSystemPackageRepository(PackageRepository):
                 location = canonical_path(location, platform_)
 
             if location != self.location:
-                raise ResourceError("location mismatch - requested %r, "
-                                    "repository location is %r "
-                                    % (location, self.location))
+                # Final fallback: check physical identity. On Windows a
+                # drive-letter path and its UNC equivalent canonicalise to
+                # different strings but refer to the same filesystem location.
+                # os.path.samefile resolves through the OS and works across
+                # path forms, but requires both paths to exist on disk.
+                #
+                # Memoize the result to avoid repeated network I/O on every
+                # resource lookup from a legacy context with a mismatched
+                # path form.
+                cache_key = location + "\0" + self.location
+                same = self._location_aliases.get(cache_key)
+                if same is None:
+                    if not (os.path.exists(location) and os.path.exists(self.location)):
+                        raise ResourceError(
+                            "location mismatch - requested %r, "
+                            "repository location is %r "
+                            % (location, self.location))
+                    try:
+                        same = os.path.samefile(location, self.location)
+                    except OSError:
+                        same = False
+                    # Only cache positive results. A negative result may
+                    # become stale if the repo is moved back to the original
+                    # location in the same process, so re-check every time.
+                    if same:
+                        self._location_aliases[cache_key] = same
+
+                if not same:
+                    raise ResourceError(
+                        "location mismatch - requested %r, "
+                        "repository location is %r "
+                        % (location, self.location))
 
         resource = self.pool.get_resource_from_handle(resource_handle)
         resource._repository = self


### PR DESCRIPTION
Closes #2045 and #1438 .
Partial but not complete fix for #1909 (Intentional, I feel that the work that was occurring in the gitbash PR would ultimately resolve this behavior?) .

Explanations:

`os.path.realpath` on Python 3.8+ Windows silently expands mapped drive letters to their underlying UNC paths. Because `canonical_path` calls `realpath`, `FileSystemPackageRepository` was storing a UNC `self.location` even when the caller supplied a drive-letter path. This caused `make_resource_handle`, which does a raw string comparison, to raise `ResourceError` on every drive-letter handle against a UNC-stored repository.

The fix:

On Windows, `canonical_path` now uses `os.path.abspath` instead of `os.path.realpath`. This preserves path style (drive-letter stays drive-letter, UNC stays UNC) and restores the pre-3.8 normalization behavior without a network-resolution side-effect. A `make_resource_handle` override is also added to the `filesystem` plugin to handle residual case or separator mismatches via `canonical_path`.

Extension of work:

A `resolve_links_on_windows` config flag (default `False`) has been added for sites that need some form of symlink/junction resolution on Windows. When enabled, a purpose-built `_windows_realpath` walks components of the path using `os.readlink`, resolving real symlinks without actually touching the drive root, in order to avoid the UNC-expansion side-effect entirely. Long-path support (`\\?\` prefix handling) is included, with the relevant test skipped on hosts that do not have `LongPathsEnabled=1` in the registry. Note: I'm aware that we need to move off of the winreg module, but since we have it for now, might as well use it.

Testing:

This was tested against an actual Drive-letter-map-with-matching-UNC-network-share .

==== EDIT ====

This PR has been extended with a broader `real_path` migration.

`real_path()` helper - A new utility function in `filesystem.py` that replaces `os.path.realpath` at all call sites where path-style stability is required. 
On Windows, it is delegated to `os.path.abspath` to preserve the drive-letter style.
On all other platforms, it is delegated to `os.path.realpath` to preserve symlink resolution.
Importantly, no config-flag is required - the correct behavior is derived from the OS, not user preference. `canonical_path` from the original PR slice now calls `real_path` internally.

Call-site migration - All non-test `os.path.realpath` code that touched stored, serialized, or compared paths have been updated:
- `filesystem.py` - `canonical_path`, `is_subdirectory`
- `resolved_context.py` - `_adjust_variant_for_bundling`
- `serialise.py` - `open_file_for_write`, `load_from_file`
- `suite.py` - `Suite.save`, `Suite.load`
- `system.p`y - `rez_bin_path`
- `rezplugins/build_system/cmake.py` - also corrects a pre-existing dead-code bug (`os.path.abspath` used as a truthiness check where `os.path.isabs` was intended)
- `utils/py_dist.py` - egg-to-rez file path comparisons and copy destinations

Relationship to prior work - Several earlier attempts addressed this problem class but were either incomplete/partial, lacked tests, or relied on opt-in config flags:
  - #957 - first fix for the make_resource_handle location mismatch; was reverted. This PR restores the intent of that fix.
  - #1543 - introduced use_canonical_path config flag (default True); only patched FileSystemPackageRepository.__init__ and required users to opt out. Superseded by this work.
  - #1856 - introduced a real_path helper gated on a windows_unc_path config flag; covered three call sites (canonical_path, _adjust_variant_for_bundling, rez_bin_path). The approach here is the same in spirit but unconditional and covers all remaining call sites. Superseded by this work.

==== END EDIT ====

==== EDIT 2 (2026-07-17) ====

This PR has been further extended with two enhancements to `_windows_realpath` (the opt-in `resolve_links_on_windows` code path):

Intermediate-directory symlink re-walk - The original component walk resolved symlinks only on the final path component. If an intermediate directory was itself a symlink (e.g., `/a/b/target` where `/a` → `/x`), the intermediate symlink was not resolved. The walk has been converted from a linear `for` loop to a component-stack `while` loop: when a symlink resolves to an absolute target, the target's components are pushed back onto the front of the stack so that any symlinks in the target's prefix are re-walked transitively. A `total_depth` budget of 40 hops guards against symlink loops (the same limit `os.path.realpath` uses) and is enforced at both the inner resolution loop and the re-walk point.

Junction detection on Python 3.8–3.11 - `os.path.islink()` does not detect Windows junctions (mount points) on any Python version; it checks `IO_REPARSE_TAG_SYMLINK` only. `os.path.isjunction()` was added in Python 3.12 but is unavailable on 3.8–3.11, which rez still supports. A `_is_link_or_junction` helper now provides three-tier detection: `os.path.islink` → `os.path.isjunction` (3.12+) -> `st_reparse_tag == 0xA0000003` fallback (the `IO_REPARSE_TAG_MOUNT_POINT` value from the Windows SDK, exposed via `os.lstat().st_reparse_tag` on Python 3.8+). This allows `_windows_realpath` to resolve junctions via `os.readlink` on all supported Python versions. Note: `os.readlink` on a junction returns the substitute name with a `\??\` device-namespace prefix, which CPython internally converts to `\\?\` - the existing extended-length prefix stripping handles this correctly.

==== END EDIT 2 ====

==== EDIT 3 2026-07-29 ====

Three rounds of adversarial self-review were performed against the branch, with findings verified against the codebase. Many valid findings were addressed, and some deliberate non-fixes are documented below with rationale.

Addressed:
* `serialize.py` file_cache key mismatch. `open_file_for_write` used `os-path.realpath(real_path(filepath))` for the cache key, which on Windows expands driver letters to UNC. `load_from_file` used `real_path(filepath)` , preserving the drive letter. Write stored under `\\server\share\foo.py`, while read looked it up as `N:\foo.py` , creating a cache miss. Fixed by using `real_path` for the cache key (matching the read side) and `resolve_path` separately for the physical write target.
* `Suite.save()` re-introduced UNC expansion. `os.path.realpath(path)` was used before `safe_rmtree`, expanding `N:\suites\mysuite` to `\\nas\studio\stuites\mysuite`. Replaced with a new `resolve_path()` function (see below).
* `test_save_through_symlink_uses_samefile` would fail on Windows CI. On Windows default config, `resolve_path` returns `abspath` (no symlink resolution), so `rmtree_arg` would be the unresolved alias path. Fixed by mocking `rez.suite.resolve_path` to return the symlink target, so the test verifies rmtree-call-wiring identically on all platforms.
* `_add_extended_length_prefix` didn't guard against already-prefixed paths. Calling it on `\\?\C:\foo` would produce `\\?UNC\?\C:\foo`. Added a case-sensitive already-prefixed guard.
* `samefile` fallback did filesystem IO on every mismatch. A 50-package resolve with legacy UNC handle would do 150 network stats. Added class-level `_location_aliases` memoization on `FileSystemPackageRepository`. The first mismatch still hits, but subsequent lookups for the same path-pair are fast.
* To the above, stale `False` results in the memoization cache. Only `True` results are cached. A `False` (genuine mismatch) is re-checked every time, so a repo moved away and back in the same process is detected correctly.
* Useless test assertion: `os.path.islink(alias)` was always `True` (the test created the symlink), so the `or` short-circuited. Replaced with an `assertNotIn("alias_suite", rmtree_arg)` / `assertIn("actual_suite", rmtree_arg)`.
* `resolve_path` imported locally inside `open_file_for_write`. Moved to module-level alongside `real_path`.
* Misleading `Suite.save()` comment, claiming that symlink resolution happens, but on Windows default config, it doesn't. Updated to accurately describe the Windows default-config behavior.

New function: `resolve_path()`
* This was added to `utils.filesystem.py` to fill the gap between `real_path` (no symlink resolution) and `os.path.realpath` (UNC expansion on Windows). This resolves symlinks in a form-preserving way. It uses `_windows_realpath` when `resolve_links_on_windows` is configured `true`, otherwise `abspath`. Used by `serialize.py` (write target) and `suite.py` (rmtree target).

Identified but not addressed:
* `is_subdirectory` / `relpath` case inconsistency: `is_subdirectory` now canonicalizes (lowercases on Windows), but the subsequent `os.path.relpath` in `_adjust_variant_for_bundling` uses `real_path` (preserves case). If paths differ only in case, `is_subdirectory` returns `True` but `relpath` could produce a different result. Rationale: Same-case is the norm in practice. The inconsistency only manifests with mixed-case paths that are otherwise identical. Not worth the complexity of threading canonical paths through relpath at this time. Recommend addressing only if a real-world case mismatch is reported.
* Windows default config behavior with `resolve_path` does not resolve symlinks. When `resolve_links_on_windows=False` (default), `resolve_path` returns `abspath` (no symlink resolution). This means `Suite.save()` through a symlink alias will sever the symlink, and `_windows_realpath` long-path probe prefixing only helps when the flag is enabled. Rationale: This is the inherent tradeoff of the opt-in flag design. The alternative, always resolving symlinks on Windows, is exactly the behavior `os.path.realpath` provides, which this PR exists to avoid. The comment in `Suite.save()` now accurately documents this. Recommend leaving as-is. Users who need symlink resolution on Windows should enable the `resolve_links_on_windows` flag, and after this behavior is proven out, the flag could be removed and behavior defaulted-on. Documented in the config-setting comment.
* `probe` vs `candidate` asymmetry for long paths. `probe` is prefixed for filesystem IO. `candidate`, used for `os.path.join` and `os.path.dirname`, is not. Rationale: `os.path.join` and `dirname` are pure string operations with no filesystem access, so the unprefixed `candidate` works fine. No current code does filesystem IO on `candidate` directly. Recommend leaving as-is. If future code adds filesystem IO on `candidate`, prefix it at that point.
* `make_resource_handle` can't bridge drive-letter <-> UNC paths. The override canonicalizes via `canonical_path`, which preserves form. A drive-letter `N:\Packages` and UNC `\\nas\studio\Packages` canonicalize to different strings. Rationale: `get_resource_from_handle` (the resolution side) has the same `samefile` fallback that covers this. Handle creation is less critical. If the handle is created in the wrong form, the fallback catches it on resolution. Recommend leaving as acceptable for now. If handle-creation mismatches become a problem, add a `samefile` check to `make_resource_handle` as well.

New behaviors have reasonably comprehensive test coverage, and some test fixes are genuine test fixes for previous behavior that was effectively self-asserting.

==== END EDIT 3 ====

Disclosure:

This PR was AI-assisted with Claude Code, Sonnet 4.6, primarily for diagnostics, logic-tracing, documentation and edge-case verification.

This PR was AI-assisted with GLM-5.2, primarily for python-version-specific research and edge-case detection.