### PR TITLE
fix: address SyntaxWarning from vendored memcached

### DIFF
--- a/src/rez/vendor/README.md
+++ b/src/rez/vendor/README.md
@@ -137,6 +137,7 @@ We could try to move to a more maintained package like pymemcache from
 pinterest. NOTE: A port to redis may be a better option, people are more
 familiar with it and it already has a good python client that supports conn
 pooling.
+Single-character syntax patch on imports to resolve SyntaxWarning on python-3.13+
 </td></tr>
 
 <!-- ######################################################### -->

--- a/src/rez/vendor/memcache/memcache.py
+++ b/src/rez/vendor/memcache/memcache.py
@@ -127,7 +127,7 @@ class Client(threading.local):
     @group Integers: incr, decr
     @group Removal: delete, delete_multi
     @sort: __init__, set_servers, forget_dead_hosts, disconnect_all,
-           debuglog,\ set, set_multi, add, replace, get, get_multi,
+           debuglog, set, set_multi, add, replace, get, get_multi,
            incr, decr, delete, delete_multi
     """
     _FLAG_PICKLE = 1 << 0


### PR DESCRIPTION
Closes #2061 .

Single-character fix for SyntaxWarning on python-3.13+.