### PR TITLE
Improve AMQP Context Tracking connection error handling

### DIFF
--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -19,14 +19,13 @@ module_root_path = __path__[0]  # noqa
 
 # TODO: Revamp logging. For now, this is here for backwards compatibility
 def _init_logging() -> None:
+    import logging
     logging_conf = os.getenv("REZ_LOGGING_CONF")
     if logging_conf:
-        import logging
         import logging.config
         logging.config.fileConfig(logging_conf, disable_existing_loggers=False)
         return
 
-    import logging
     from rez.utils.colorize import ColorizedStreamHandler
 
     formatter = logging.Formatter(

--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -24,13 +24,6 @@ def _init_logging() -> None:
         import logging
         import logging.config
         logging.config.fileConfig(logging_conf, disable_existing_loggers=False)
-        # Suppress pika unless the external config explicitly configured it.
-        # Without this, noisy pika ERROR logs can leak through when the broker
-        # is unreachable. Users who want pika logs can set rez.vendor.pika in
-        # their logging config, which will leave level != NOTSET here.
-        pika_logger = logging.getLogger("rez.vendor.pika")
-        if pika_logger.level == logging.NOTSET:
-            pika_logger.setLevel(logging.CRITICAL)
         return
 
     import logging

--- a/src/rez/__init__.py
+++ b/src/rez/__init__.py
@@ -21,8 +21,16 @@ module_root_path = __path__[0]  # noqa
 def _init_logging() -> None:
     logging_conf = os.getenv("REZ_LOGGING_CONF")
     if logging_conf:
+        import logging
         import logging.config
         logging.config.fileConfig(logging_conf, disable_existing_loggers=False)
+        # Suppress pika unless the external config explicitly configured it.
+        # Without this, noisy pika ERROR logs can leak through when the broker
+        # is unreachable. Users who want pika logs can set rez.vendor.pika in
+        # their logging config, which will leave level != NOTSET here.
+        pika_logger = logging.getLogger("rez.vendor.pika")
+        if pika_logger.level == logging.NOTSET:
+            pika_logger.setLevel(logging.CRITICAL)
         return
 
     import logging
@@ -38,6 +46,10 @@ def _init_logging() -> None:
     logger.propagate = False
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
+
+    # Suppress pika vendor library logs unless context_tracking debug is on.
+    # set_pika_log_level() in amqp.py will override this to DEBUG if needed.
+    logging.getLogger("rez.vendor.pika").setLevel(logging.CRITICAL)
 
 
 _init_logging()

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -663,6 +663,10 @@ package_preprocess_mode = "override"
 # to just print the message to standard out instead, for testing purposes.
 # Otherwise, ``{host}[:{port}]`` is expected.
 #
+# If the broker is unreachable and :data:`context_tracking_host` is set, a warning
+# is printed. If :data:`context_tracking_host` is empty (the default), connection
+# failures are suppressed entirely (expected when tracking is not configured).
+#
 # If any items are present in :data:`context_tracking_extra_fields`, they are added
 # to the payload. If any extra field contains references to unknown env-vars, or
 # is set to an empty string (possibly due to var expansion), it is removed from
@@ -742,7 +746,9 @@ debug_resolve_memcache = False
 # ``memcached -vv`` as the server)
 debug_memcache = False
 
-# Print debugging info when an AMPQ server is used in context tracking
+# Print debugging info when an AMQP server is used in context tracking.
+# Also enables DEBUG-level logging from the pika AMQP library (rez.vendor.pika),
+# which is otherwise suppressed to avoid noise from connection attempts.
 debug_context_tracking = False
 
 # Print debugging info related to shell startup

--- a/src/rez/tests/test_amqp.py
+++ b/src/rez/tests/test_amqp.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+Tests for rez.utils.amqp
+"""
+import logging
+import os
+import socket
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from rez.tests.util import TestBase
+from rez.utils.amqp import _publish_message, parse_host_and_port, set_pika_log_level
+from rez.vendor.pika.exceptions import AMQPConnectionError
+
+
+class TestParseHostAndPort(TestBase):
+    """Tests for parse_host_and_port()."""
+
+    def test_host_only(self) -> None:
+        host, port = parse_host_and_port("mybroker.example.com")
+        self.assertEqual(host, "mybroker.example.com")
+        self.assertIsNone(port)
+
+    def test_host_and_port(self) -> None:
+        host, port = parse_host_and_port("localhost:5672")
+        self.assertEqual(host, "localhost")
+        self.assertEqual(port, 5672)
+
+    def test_amqp_scheme(self) -> None:
+        host, port = parse_host_and_port("amqp://mybroker.example.com:5672")
+        self.assertEqual(host, "mybroker.example.com")
+        self.assertEqual(port, 5672)
+
+    def test_host_only_no_port_in_url(self) -> None:
+        host, port = parse_host_and_port("mybroker.example.com")
+        self.assertEqual(host, "mybroker.example.com")
+        self.assertIsNone(port)
+
+
+class TestPublishMessageStdout(TestBase):
+    """Tests for _publish_message() with host='stdout'."""
+
+    def test_stdout_returns_true(self) -> None:
+        result = _publish_message(
+            host="stdout",
+            amqp_settings={},
+            routing_key="REZ.CONTEXT",
+            data={"action": "created"}
+        )
+        self.assertTrue(result)
+
+
+class TestPublishMessageConnectionFailure(TestBase):
+    """Tests for _publish_message() broker connection failure handling."""
+
+    _amqp_settings = {
+        "userid": "",
+        "password": "",
+        "connect_timeout": 1,
+        "exchange_name": "rez",
+        "exchange_routing_key": "REZ.CONTEXT",
+        "message_delivery_mode": 1,
+    }
+
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_socket_error_returns_false(self, mock_conn, _mock_params) -> None:
+        """socket.error on connect should return False, not raise."""
+        mock_conn.side_effect = socket.error("connection refused")
+        result = _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        self.assertFalse(result)
+
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_amqp_connection_error_returns_false(self, mock_conn, _mock_params) -> None:
+        """AMQPConnectionError on connect should return False, not raise."""
+        mock_conn.side_effect = AMQPConnectionError("broker refused")
+        result = _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        self.assertFalse(result)
+
+    @patch("rez.utils.amqp.print_warning")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_warning_printed_when_host_configured(self, mock_conn, _mock_params, mock_warn) -> None:
+        """When host arg is non-empty and broker is unreachable, print_warning."""
+        mock_conn.side_effect = socket.error("connection refused")
+        _publish_message(
+            host="mybroker:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        mock_warn.assert_called_once()
+        self.assertIn("Cannot connect", mock_warn.call_args[0][0])
+
+    @patch("rez.utils.amqp.print_debug")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_debug_printed_when_no_host_and_debug_enabled(self, mock_conn, _mock_params, mock_debug) -> None:
+        """Empty host + debug_context_tracking on: print_debug is called."""
+        mock_conn.side_effect = socket.error("connection refused")
+        self.update_settings({"debug_context_tracking": True})
+        _publish_message(
+            host="",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        mock_debug.assert_called_once()
+        self.assertIn("Cannot connect", mock_debug.call_args[0][0])
+
+    @patch("rez.utils.amqp.print_debug")
+    @patch("rez.utils.amqp.print_warning")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_silent_when_no_host_and_debug_disabled(self, mock_conn, _mock_params, mock_warn, mock_debug) -> None:
+        """Empty host + debug_context_tracking off: no logging at all."""
+        mock_conn.side_effect = socket.error("connection refused")
+        self.update_settings({"debug_context_tracking": False})
+        _publish_message(
+            host="",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        mock_debug.assert_not_called()
+        mock_warn.assert_not_called()
+
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_successful_publish_returns_true(self, mock_conn, _mock_params) -> None:
+        """Successful connection and publish returns True."""
+        mock_channel = MagicMock()
+        mock_conn.return_value.channel.return_value = mock_channel
+        result = _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={"action": "created"}
+        )
+        self.assertTrue(result)
+        mock_channel.basic_publish.assert_called_once()
+
+    @patch("rez.utils.amqp.print_error")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_publish_failure_returns_false(self, mock_conn, _mock_params, _mock_error) -> None:
+        """Exception during basic_publish returns False."""
+        mock_conn.return_value.channel.return_value.basic_publish.side_effect = Exception("publish error")
+        result = _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        self.assertFalse(result)
+
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_credentials_passed_when_userid_set(self, mock_conn, _mock_params) -> None:
+        """When userid is set in amqp_settings, PlainCredentials are used."""
+        mock_channel = MagicMock()
+        mock_conn.return_value.channel.return_value = mock_channel
+        settings_with_creds = dict(self._amqp_settings, userid="guest", password="guest")
+        result = _publish_message(
+            host="localhost:5672",
+            amqp_settings=settings_with_creds,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        self.assertTrue(result)
+        # ConnectionParameters should have been called with a credentials kwarg
+        call_kwargs = _mock_params.call_args[1]
+        self.assertIn("credentials", call_kwargs)
+
+    @patch("rez.utils.amqp.set_pika_log_level")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_set_pika_log_level_called_when_debug_enabled(self, mock_conn, _mock_params, mock_set_level) -> None:
+        """set_pika_log_level() is called inside _publish_message when debug_context_tracking is on."""
+        mock_channel = MagicMock()
+        mock_conn.return_value.channel.return_value = mock_channel
+        self.update_settings({"debug_context_tracking": True})
+        _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        mock_set_level.assert_called_once()
+
+    @patch("rez.utils.amqp.set_pika_log_level")
+    @patch("rez.utils.amqp.ConnectionParameters")
+    @patch("rez.utils.amqp.BlockingConnection")
+    def test_set_pika_log_level_not_called_when_debug_disabled(self, mock_conn, _mock_params, mock_set_level) -> None:
+        """set_pika_log_level() is NOT called when debug_context_tracking is off."""
+        mock_channel = MagicMock()
+        mock_conn.return_value.channel.return_value = mock_channel
+        self.update_settings({"debug_context_tracking": False})
+        _publish_message(
+            host="localhost:5672",
+            amqp_settings=self._amqp_settings,
+            routing_key="REZ.CONTEXT",
+            data={}
+        )
+        mock_set_level.assert_not_called()
+
+
+class TestSetPikaLogLevel(TestBase):
+    """Tests for set_pika_log_level()."""
+
+    def test_sets_debug_when_context_tracking_debug_on(self) -> None:
+        self.update_settings({"debug_context_tracking": True})
+        set_pika_log_level()
+        self.assertEqual(
+            logging.getLogger("rez.vendor.pika").level,
+            logging.DEBUG
+        )
+
+    def test_no_change_when_context_tracking_debug_off(self) -> None:
+        """When debug_context_tracking is off, level should not be changed to DEBUG."""
+        logger = logging.getLogger("rez.vendor.pika")
+        logger.setLevel(logging.CRITICAL)
+        self.update_settings({"debug_context_tracking": False})
+        set_pika_log_level()
+        # Level should remain CRITICAL (not promoted to DEBUG)
+        self.assertNotEqual(logger.level, logging.DEBUG)
+
+
+class TestInitLogging(TestBase):
+    """Tests for the REZ_LOGGING_CONF branch in rez._init_logging()."""
+
+    # Minimal logging.config.fileConfig-compatible INI
+    _LOGGING_INI = (
+        "[loggers]\nkeys=root\n"
+        "[handlers]\nkeys=console\n"
+        "[formatters]\nkeys=\n"
+        "[logger_root]\nlevel=WARNING\nhandlers=console\n"
+        "[handler_console]\nclass=StreamHandler\nlevel=WARNING"
+        "\nformatter=\nargs=(sys.stderr,)\n"
+    )
+
+    def _write_logging_conf(self) -> str:
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ini", delete=False
+        )
+        f.write(self._LOGGING_INI)
+        f.close()
+        return f.name
+
+    def test_logging_conf_suppresses_pika_when_not_configured(self) -> None:
+        """REZ_LOGGING_CONF branch: pika logger is set to CRITICAL when not
+        explicitly configured by the external config file."""
+        from rez import _init_logging
+
+        conf_path = self._write_logging_conf()
+        try:
+            pika_logger = logging.getLogger("rez.vendor.pika")
+            # Restore initial state.
+            pika_logger.setLevel(logging.NOTSET)
+
+            with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
+                _init_logging()
+
+            self.assertEqual(pika_logger.level, logging.CRITICAL)
+        finally:
+            os.unlink(conf_path)
+
+    def test_logging_conf_leaves_pika_level_when_already_configured(self) -> None:
+        """REZ_LOGGING_CONF branch: pika logger level is left alone when the
+        external config explicitly set it (level != NOTSET)."""
+        from rez import _init_logging
+
+        conf_path = self._write_logging_conf()
+        try:
+            pika_logger = logging.getLogger("rez.vendor.pika")
+            # simulate explicit config.
+            pika_logger.setLevel(logging.DEBUG)
+
+            with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
+                _init_logging()
+
+            self.assertNotEqual(pika_logger.level, logging.CRITICAL)
+        finally:
+            os.unlink(conf_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/rez/tests/test_amqp.py
+++ b/src/rez/tests/test_amqp.py
@@ -111,7 +111,9 @@ class TestPublishMessageConnectionFailure(TestBase):
     @patch("rez.utils.amqp.print_debug")
     @patch("rez.utils.amqp.ConnectionParameters")
     @patch("rez.utils.amqp.BlockingConnection")
-    def test_debug_printed_when_no_host_and_debug_enabled(self, mock_conn, _mock_params, mock_debug, _mock_set_level) -> None:
+    def test_debug_printed_when_no_host_and_debug_enabled(
+        self, mock_conn, _mock_params, mock_debug, _mock_set_level
+    ) -> None:
         """Empty host + debug_context_tracking on: print_debug is called."""
         mock_conn.side_effect = socket.error("connection refused")
         self.update_settings({"debug_context_tracking": True})

--- a/src/rez/tests/test_amqp.py
+++ b/src/rez/tests/test_amqp.py
@@ -262,39 +262,21 @@ class TestInitLogging(TestBase):
         f.close()
         return f.name
 
-    def test_logging_conf_suppresses_pika_when_not_configured(self) -> None:
-        """REZ_LOGGING_CONF branch: pika logger is set to CRITICAL when not
-        explicitly configured by the external config file."""
+    def test_logging_conf_does_not_suppress_pika(self) -> None:
+        """REZ_LOGGING_CONF branch: rez does not touch the pika logger level.
+        The user's config file is solely responsible for configuring it."""
         from rez import _init_logging
 
         conf_path = self._write_logging_conf()
         try:
             pika_logger = logging.getLogger("rez.vendor.pika")
-            # Restore initial state.
             pika_logger.setLevel(logging.NOTSET)
 
             with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
                 _init_logging()
 
-            self.assertEqual(pika_logger.level, logging.CRITICAL)
-        finally:
-            os.unlink(conf_path)
-
-    def test_logging_conf_leaves_pika_level_when_already_configured(self) -> None:
-        """REZ_LOGGING_CONF branch: pika logger level is left alone when the
-        external config explicitly set it (level != NOTSET)."""
-        from rez import _init_logging
-
-        conf_path = self._write_logging_conf()
-        try:
-            pika_logger = logging.getLogger("rez.vendor.pika")
-            # simulate explicit config.
-            pika_logger.setLevel(logging.DEBUG)
-
-            with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
-                _init_logging()
-
-            self.assertNotEqual(pika_logger.level, logging.CRITICAL)
+            # rez should not have changed it; stays at NOTSET
+            self.assertEqual(pika_logger.level, logging.NOTSET)
         finally:
             os.unlink(conf_path)
 

--- a/src/rez/tests/test_amqp.py
+++ b/src/rez/tests/test_amqp.py
@@ -107,10 +107,11 @@ class TestPublishMessageConnectionFailure(TestBase):
         mock_warn.assert_called_once()
         self.assertIn("Cannot connect", mock_warn.call_args[0][0])
 
+    @patch("rez.utils.amqp.set_pika_log_level")
     @patch("rez.utils.amqp.print_debug")
     @patch("rez.utils.amqp.ConnectionParameters")
     @patch("rez.utils.amqp.BlockingConnection")
-    def test_debug_printed_when_no_host_and_debug_enabled(self, mock_conn, _mock_params, mock_debug) -> None:
+    def test_debug_printed_when_no_host_and_debug_enabled(self, mock_conn, _mock_params, mock_debug, _mock_set_level) -> None:
         """Empty host + debug_context_tracking on: print_debug is called."""
         mock_conn.side_effect = socket.error("connection refused")
         self.update_settings({"debug_context_tracking": True})
@@ -223,22 +224,20 @@ class TestPublishMessageConnectionFailure(TestBase):
 class TestSetPikaLogLevel(TestBase):
     """Tests for set_pika_log_level()."""
 
-    def test_sets_debug_when_context_tracking_debug_on(self) -> None:
+    @patch("rez.utils.amqp.logging.getLogger")
+    def test_sets_debug_when_context_tracking_debug_on(self, mock_get_logger) -> None:
         self.update_settings({"debug_context_tracking": True})
         set_pika_log_level()
-        self.assertEqual(
-            logging.getLogger("rez.vendor.pika").level,
-            logging.DEBUG
-        )
+        mock_get_logger.assert_called_with("rez.vendor.pika")
+        mock_get_logger.return_value.setLevel.assert_called_with(logging.DEBUG)
 
-    def test_no_change_when_context_tracking_debug_off(self) -> None:
+    @patch("rez.utils.amqp.logging.getLogger")
+    def test_no_change_when_context_tracking_debug_off(self, mock_get_logger) -> None:
         """When debug_context_tracking is off, level should not be changed to DEBUG."""
-        logger = logging.getLogger("rez.vendor.pika")
-        logger.setLevel(logging.CRITICAL)
         self.update_settings({"debug_context_tracking": False})
         set_pika_log_level()
-        # Level should remain CRITICAL (not promoted to DEBUG)
-        self.assertNotEqual(logger.level, logging.DEBUG)
+        # setLevel should not be called at all
+        mock_get_logger.return_value.setLevel.assert_not_called()
 
 
 class TestInitLogging(TestBase):
@@ -262,23 +261,27 @@ class TestInitLogging(TestBase):
         f.close()
         return f.name
 
-    def test_logging_conf_does_not_suppress_pika(self) -> None:
+    @patch("logging.config.fileConfig")
+    def test_logging_conf_does_not_suppress_pika(self, mock_file_config) -> None:
         """REZ_LOGGING_CONF branch: rez does not touch the pika logger level.
         The user's config file is solely responsible for configuring it."""
         from rez import _init_logging
 
         conf_path = self._write_logging_conf()
-        try:
-            pika_logger = logging.getLogger("rez.vendor.pika")
-            pika_logger.setLevel(logging.NOTSET)
+        self.addCleanup(os.unlink, conf_path)
 
-            with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
-                _init_logging()
+        pika_logger = logging.getLogger("rez.vendor.pika")
+        original_level = pika_logger.level
+        self.addCleanup(pika_logger.setLevel, original_level)
+        pika_logger.setLevel(logging.NOTSET)
 
-            # rez should not have changed it; stays at NOTSET
-            self.assertEqual(pika_logger.level, logging.NOTSET)
-        finally:
-            os.unlink(conf_path)
+        with patch.dict(os.environ, {"REZ_LOGGING_CONF": conf_path}):
+            _init_logging()
+
+        # fileConfig was called with the correct arguments
+        mock_file_config.assert_called_with(conf_path, disable_existing_loggers=False)
+        # rez should not have changed the pika logger level
+        self.assertEqual(pika_logger.level, logging.NOTSET)
 
 
 if __name__ == "__main__":

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -158,9 +158,11 @@ def on_exit() -> None:
 
 
 def parse_host_and_port(url):
+    # Prepend // unless the URL already has a scheme (e.g. "amqp://").
+    # A bare "host:port" string causes urlsplit to misparse the hostname.
+    if "://" not in url and not url.startswith("//"):
+        url = "//" + url
     _url = urllib.parse.urlsplit(url)
-    if not _url.scheme:
-        _url = urllib.parse.urlsplit("//" + url)
     host = _url.hostname
     port = _url.port
 

--- a/src/rez/utils/amqp.py
+++ b/src/rez/utils/amqp.py
@@ -11,10 +11,11 @@ import logging
 import urllib.parse
 import queue
 
-from rez.utils.logging_ import print_error
+from rez.utils.logging_ import print_debug, print_error, print_warning
 from rez.vendor.pika.adapters.blocking_connection import BlockingConnection
 from rez.vendor.pika.connection import ConnectionParameters
 from rez.vendor.pika.credentials import PlainCredentials
+from rez.vendor.pika.exceptions import AMQPConnectionError
 from rez.vendor.pika.spec import BasicProperties
 from rez.config import config
 
@@ -68,7 +69,8 @@ def _publish_message(host, amqp_settings, routing_key, data) -> bool:
         print("Published to %s: %s" % (routing_key, data))
         return True
 
-    set_pika_log_level()
+    if config.debug("context_tracking"):
+        set_pika_log_level()
 
     conn_kwargs = dict()
 
@@ -77,6 +79,7 @@ def _publish_message(host, amqp_settings, routing_key, data) -> bool:
         "connection_name": "rez.publish.%s" % socket.gethostname()
     }
 
+    original_host = host
     host, port = parse_host_and_port(url=host)
     conn_kwargs["host"] = host
     if port is not None:
@@ -101,8 +104,13 @@ def _publish_message(host, amqp_settings, routing_key, data) -> bool:
 
     try:
         conn = BlockingConnection(params)
-    except socket.error as e:
-        print_error("Cannot connect to the message broker: %s" % e)
+    except (socket.error, AMQPConnectionError) as e:
+        if original_host:
+            # Host was explicitly passed in. This is an unexpected failure.
+            print_warning("Cannot connect to the message broker: %s" % e)
+        elif config.debug("context_tracking"):
+            # No host configured, only display this in debug.
+            print_debug("Cannot connect to the message broker: %s" % e)
         return False
 
     try:
@@ -164,5 +172,3 @@ def set_pika_log_level() -> None:
 
     if config.debug("context_tracking"):
         logging.getLogger(mod_name).setLevel(logging.DEBUG)
-    else:
-        logging.getLogger(mod_name).setLevel(logging.WARNING)


### PR DESCRIPTION
@JeanChristopheMorinPerso and I were discussing this over https://github.com/AcademySoftwareFoundation/rez/issues/1968


Pika's vendor library was emitting ERROR-level log messages whenever a broker connection failed, even when context tracking was not configured. This produced spurious output in normal rez usage.

### Changes:

- init.py: Set rez.vendor.pika logger to CRITICAL at startup, silencing all pika output by default.
 
- amqp.py:

  - Only call set_pika_log_level() when debug_context_tracking is enabled, rather than unconditionally on every publish attempt.
  - Also catch AMQPConnectionError (in addition to socket.error) on connection failure pika can raise either depending on the failure mode.
  - Downgrade connection failure message from ERROR to WARNING when context_tracking_host is explicitly set (unexpected failure), or to DEBUG when it is not (normal/expected when tracking is not configured).
  - Remove the dead else branch in set_pika_log_level() that reset to WARNING and the CRITICAL default is now set centrally in init.py.
  - rezconfig.py: Document the warning/debug behaviour on broker unreachability, and note that debug_context_tracking also enables pika DEBUG logging.


Here's the new behavior with this change after pointing context_tracking_host to a fake host:
```
rez-env dev_build
13:11:39 WARNING  Cannot connect to the message broker: [Errno -2] Name or service not known
```

To enabling context_tracking to see the full stacktrace: 
```
setenv REZ_DEBUG_CONTEXT_TRACKING 1
or
set debug_context_tracking to True in rezconfig. 
```

```
Exception in thread Thread-1 (_publish_messages_async):
Traceback (most recent call last):
  File "/mmfs1/sasha/pipeline/rez_packages/python/3.11.12.a1/platform-linux/arch-x86_64/os-Rocky-8.7/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/mmfs1/sasha/pipeline/rez_packages/python/3.11.12.a1/platform-linux/arch-x86_64/os-Rocky-8.7/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/mmfs1/sasha/home/ben.hawkyard/rez/lib/python3.11/site-packages/rez/utils/amqp.py", line 133, in _publish_messages_async
    _publish_message(**kwargs)
  File "/mmfs1/sasha/home/ben.hawkyard/rez/lib/python3.11/site-packages/rez/utils/amqp.py", line 103, in _publish_message
    conn = BlockingConnection(params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mmfs1/sasha/home/ben.hawkyard/rez/lib/python3.11/site-packages/rez/vendor/pika/adapters/blocking_connection.py", line 361, in __init__
    self._impl = self._create_connection(parameters, _impl_class)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mmfs1/sasha/home/ben.hawkyard/rez/lib/python3.11/site-packages/rez/vendor/pika/adapters/blocking_connection.py", line 452, in _create_connection
    raise self._reap_last_connection_workflow_error(error)
rez.vendor.pika.exceptions.AMQPConnectionError
```
