### PR TITLE
fix: windows case sensitivity in pkg cache variants uri

### DIFF
--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -11,6 +11,7 @@ from rezplugins.package_repository import filesystem
 from rez.packages import create_package
 from rez.tests.util import TestBase, TempdirMixin
 from rez.utils.platform_ import platform_
+from rez.version import Version
 
 
 class TestFilesystemPackageRepository(TestBase, TempdirMixin):
@@ -39,3 +40,79 @@ class TestFilesystemPackageRepository(TestBase, TempdirMixin):
         pkg_repository._create_variant(variant, overrides={})
         with self.assertRaises(filesystem.PackageRepositoryError):
             pkg_repository._create_variant(case_mismatch_variant, overrides={})
+
+
+@unittest.skipIf(
+    platform_.name != "windows",
+    "URI normcase bug only manifests on Windows where os.path.normcase is not a no-op.",
+)
+class TestFilesystemRepoUriCaseSensitivity(TestBase, TempdirMixin):
+    """get_package_from_uri and get_variant_from_uri must find packages when
+    the package name or version contains uppercase letters.
+
+    Root cause: get_package_from_uri applies os.path.normcase to the entire URI
+    before slicing out pkg_name and pkg_ver_str. Windows normcase lowercases
+    the whole string, so '1.0B' becomes '1.0b' and 'FooBar' becomes 'foobar'.
+    The subsequent get_package call (version equality check) and _get_family
+    case-guard then both return None.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+        cls.settings = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def _make_repo(self):
+        pool = filesystem.ResourcePool(cache_size=None)
+        return filesystem.FileSystemPackageRepository(self.root, pool)
+
+    def _install(self, repo, name, version_str):
+        data = {"version": version_str} if version_str else {}
+        package = create_package(name, data=data)
+        variant = next(package.iter_variants())
+        return repo._create_variant(variant, overrides={})
+
+    def test_get_package_from_uri_uppercase_version(self):
+        """get_package_from_uri finds a package whose version contains uppercase letters."""
+        repo = self._make_repo()
+        installed = self._install(repo, "foo", "1.0B")
+        pkg_uri = installed.parent.uri
+
+        result = repo.get_package_from_uri(pkg_uri)
+        self.assertIsNotNone(
+            result,
+            "get_package_from_uri returned None for %r — "
+            "version '1.0B' was normcased to '1.0b' before lookup" % pkg_uri,
+        )
+        self.assertEqual(result.version, Version("1.0B"))
+
+    def test_get_package_from_uri_uppercase_name(self):
+        """get_package_from_uri finds a package whose name contains uppercase letters."""
+        repo = self._make_repo()
+        installed = self._install(repo, "FooBar", "1.0")
+        pkg_uri = installed.parent.uri
+
+        result = repo.get_package_from_uri(pkg_uri)
+        self.assertIsNotNone(
+            result,
+            "get_package_from_uri returned None for %r — "
+            "name 'FooBar' was normcased to 'foobar' before lookup" % pkg_uri,
+        )
+        self.assertEqual(result.name, "FooBar")
+
+    def test_get_variant_from_uri_uppercase_version(self):
+        """get_variant_from_uri finds a variant whose version contains uppercase letters."""
+        repo = self._make_repo()
+        installed = self._install(repo, "foo", "1.0B")
+        variant_uri = installed.uri
+
+        result = repo.get_variant_from_uri(variant_uri)
+        self.assertIsNotNone(
+            result,
+            "get_variant_from_uri returned None for %r — "
+            "version '1.0B' was normcased to '1.0b' before lookup" % variant_uri,
+        )

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -601,12 +601,14 @@ class FileSystemPackageRepository(PackageRepository):
         - /svr/packages/mypkg/package.py  # (unversioned package - rare)
         - /svr/packages/mypkg/package.py<1.0.0>  # ("combined" package type - rare)
         """
-        uri = os.path.normcase(uri)
+        norm_uri = os.path.normcase(uri)
 
         prefix = self.location + os.path.sep
-        if not is_subdirectory(uri, prefix):
+        if not is_subdirectory(norm_uri, prefix):
             return None
 
+        # Slice from the original uri, not norm_uri: normcase lowercases on Windows,
+        # which would corrupt pkg_name/pkg_ver_str for mixed-case packages. See #2101.
         part = uri[len(prefix):]  # eg 'mypkg/1.0.0/package.py'
         parts = part.split(os.path.sep)
         pkg_name = parts[0]


### PR DESCRIPTION
Closes #2101 .

Explanation:

`get_package_from_uri` in the filesystem package repository applied `os.path.normcase` to the entire URI before slicing out the package name and version. On Windows, `normcase` lowercases the whole string, silently corrupting mixed-case names (`FooBar` -> `foobar`) and versions (`1.0B` -> `1.0b`) before they were used for lookup, causing both to return `None`.

Fix:

We scope the `normcase` usage to the `is_subdirectory` boundary check only. The subsequent name/version extraction slices from the original URI, preserving caller-supplied casing.

Disclosure:

This PR was AI-assisted with Claude Code, Sonnet 4.6, primarily for diagnostics, logic-tracing, documentation and edge-case verification.