### PR TITLE
Fix PowerShell command failure status

### DIFF
--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -286,6 +286,24 @@ class TestShells(TestBase, TempdirMixin):
                 # should bubble up through the rez shell as a 0 exit status.
                 self.assertEqual(p.returncode, 0)
 
+    @unittest.skipIf(platform_.name != "windows", "PowerShell return-code handling is Windows-specific")
+    def test_powershell_command_not_found_returncode(self) -> None:
+        shells = [shell for shell in ("powershell", "pwsh") if shell in get_available_shells()]
+        if not shells:
+            self.skipTest("PowerShell unavailable or disabled")
+
+        r = self._create_context([])
+        for shell in shells:
+            with self.subTest(shell=shell):
+                with r.execute_shell(
+                    shell=shell,
+                    command="NoSuchRezCommand2073",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ) as p:
+                    p.wait()
+                self.assertEqual(p.returncode, 1)
+
     @per_available_shell()
     def test_norc(self, shell) -> None:
         sh = create_shell(shell)

--- a/src/rezplugins/shell/_utils/powershell_base.py
+++ b/src/rezplugins/shell/_utils/powershell_base.py
@@ -164,10 +164,11 @@ class PowerShellBase(Shell):
         # See https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode?view=powershell-7.5#description  # noqa
         #
         executor.command(
+            "$_rez_shell_command_status = $?\n"
             "if ((Test-Path variable:LASTEXITCODE) -and $LASTEXITCODE) {\n"
             "  exit $LASTEXITCODE\n"
             "}\n"
-            "if (! $?) {\n"
+            "if (! $_rez_shell_command_status) {\n"
             "  exit 1\n"
             "}"
         )


### PR DESCRIPTION
## Summary
- preserve `$?` before checking `LASTEXITCODE` in generated PowerShell startup scripts
- return exit code 1 when a PowerShell command fails before setting `LASTEXITCODE`
- add a Windows regression test for missing-command failures in both `powershell` and `pwsh`

## Test plan
- `pytest src/rez/tests/test_shells.py::TestShells::test_powershell_command_not_found_returncode -q`
- `pytest src/rez/tests/test_shells.py::TestShells::test_pwsh_lastexitcode_gui -q`
- `flake8 src/rezplugins/shell/_utils/powershell_base.py src/rez/tests/test_shells.py`
- manual `execute_shell` check: missing command returns 1 for `powershell` and `pwsh`; `hello_world -q -r 66` still returns 66 for both

Closes #2073