### PR TITLE
Fix for zsh-specific env loading behavior

### DIFF
--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -497,15 +497,16 @@ class UnixShell(Shell):
                             files_ = [file_]
 
                         ex = _create_ex()
-                        ex.setenv('HOME', os.environ.get('HOME', ''))
+                        self._write_startup_env(ex)
                         _record_shell(ex, files=files_, bind_rez=bind_rez,
                                       print_msg=bind_rez)
                         _write_shell(ex, os.path.basename(file_))
 
                     if config.debug("shell_startup"):
-                        print_debug("Setting $HOME for new shell to %s" % tmpdir)
+                        print_debug("Setting $%s for new shell to %s"
+                                    % (self._startup_env_var(), tmpdir))
 
-                    executor.setenv("HOME", tmpdir)
+                    executor.setenv(self._startup_env_var(), tmpdir)
 
                     # keep history
                     if self.histfile and self.histvar:
@@ -555,6 +556,23 @@ class UnixShell(Shell):
             raise RezSystemError("Error running command:\n%s\n%s"
                                  % (cmd_str, str(e)))
         return p
+
+    def _startup_env_var(self) -> str:
+        """Environment variable used to redirect shell startup file loading to tmpdir.
+        Shells that support dedicated dotfile directory var (e.g., zsh's ZDOTDIR)
+        should override this and _write_startup_env methods.
+        """
+        return "HOME"
+    
+    def _write_startup_env(self, ex) -> None:
+        """Write env setup into each generated startup file.
+        Default sets HOME to real users's home directory so the user's real
+        dot files can be sourced from within the generated files.
+
+        Args:
+            ex (RexExecutor): shell executor
+        """
+        ex.setenv("HOME", os.environ.get("HOME", ""))
 
     def resetenv(self, key, value, friends=None) -> None:
         self._addline(self.setenv(key, value))

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -572,7 +572,8 @@ class UnixShell(Shell):
         Args:
             ex: shell executor
         """
-        ex.setenv("HOME", os.environ.get("HOME", ""))
+        startup_env_var = self._startup_env_var()
+        ex.setenv(startup_env_var, os.environ.get(startup_env_var, ""))
 
     def resetenv(self, key, value, friends=None) -> None:
         self._addline(self.setenv(key, value))

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -564,13 +564,13 @@ class UnixShell(Shell):
         """
         return "HOME"
 
-    def _write_startup_env(self, ex) -> None:
+    def _write_startup_env(self, ex: RexExecutor) -> None:
         """Write env setup into each generated startup file.
         Default sets HOME to real users's home directory so the user's real
         dot files can be sourced from within the generated files.
 
         Args:
-            ex (RexExecutor): shell executor
+            ex: shell executor
         """
         ex.setenv("HOME", os.environ.get("HOME", ""))
 

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -563,7 +563,7 @@ class UnixShell(Shell):
         should override this and _write_startup_env methods.
         """
         return "HOME"
-    
+
     def _write_startup_env(self, ex) -> None:
         """Write env setup into each generated startup file.
         Default sets HOME to real users's home directory so the user's real

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -13,7 +13,7 @@ from rez.plugin_managers import plugin_manager
 from rez.utils.execution import ExecutableScriptMode, _get_python_script_files
 from rez.utils.platform_ import platform_
 from rez.tests.util import TestBase, TempdirMixin, get_available_shells, \
-    per_available_shell, install_dependent
+    per_available_shell, install_dependent, restore_os_environ
 from rez.bind import hello_world
 from rez.config import config
 import unittest
@@ -652,6 +652,64 @@ class TestShells(TestBase, TempdirMixin):
             with open(exe_path, 'w'):
                 config.override(override_attr, exe_path)
                 assert cls.find_executable(cls.executable_name()) == exe_path
+
+    @unittest.skipIf("zsh" not in get_available_shells(), "zsh is not available")
+    def test_zsh_zshenv(self):
+        """Test fix for issue #2058: rez context fails to load in zsh when
+        ``~/.zshenv`` exists.
+        """
+        config.override("default_shell", "zsh")
+
+        user_home = os.path.join(self.root, "user_home")
+        os.makedirs(user_home)
+
+        # The user's .zshenv records what HOME and ZDOTDIR look like at the
+        # time zsh sources it. We can't use ``command=`` mode to inspect this:
+        # that path bypasses the HOME/ZDOTDIR-hijacking branch entirely and
+        # just inlines the rez context into rez-shell.sh. Only ``stdin`` (or
+        # a fully-interactive launch) exercises the code path that this fix
+        # touches.
+        marker_file = os.path.join(self.root, "zshenv_marker.txt")
+        zshenv_path = os.path.join(user_home, ".zshenv")
+        with open(zshenv_path, "w") as fh:
+            fh.write('echo -n "HOME=$HOME\nZDOTDIR=$ZDOTDIR" > "%s"\n' % marker_file)
+
+        with restore_os_environ():
+            os.environ["HOME"] = user_home
+            os.environ.pop("ZDOTDIR", None)
+
+            r = self._create_context([])
+            p = r.execute_shell(
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+            p.communicate(input="exit")
+            self.assertEqual(p.returncode, 0)
+
+        # The user's .zshenv is sourced twice: once by the outer zsh that
+        # runs rez-shell.sh (before ZDOTDIR is set), and once by the rez
+        # wrapper .zshenv launched by the inner ``zsh -s``. The inner one
+        # runs last and wins, so the marker reflects the env the rez wrapper
+        # exposes to the user's .zshenv.
+        with open(marker_file) as fh:
+            content = fh.read().strip()
+
+        # HOME must be preserved (not silently redirected to rez's tmpdir).
+        self.assertIn("HOME=" + user_home, content)
+
+        # ZDOTDIR must point to the rez wrapper tmpdir, which actually
+        # contains the generated wrapper files.
+        zdotdir = content.split("ZDOTDIR=", 1)[1].strip()
+        self.assertTrue(
+            zdotdir,
+            "ZDOTDIR should be set to the rez wrapper tmpdir, got: %r"
+            % content,
+        )
+        self.assertTrue(
+            os.path.isfile(os.path.join(zdotdir, ".zshenv")),
+            "Expected rez wrapper .zshenv in ZDOTDIR=%s" % zdotdir,
+        )
 
 
 if __name__ == '__main__':

--- a/src/rezplugins/shell/zsh.py
+++ b/src/rezplugins/shell/zsh.py
@@ -113,7 +113,17 @@ class Zsh(SH):
                 txt = '"%s"' % txt
             result += txt
         return result
-
+    
+    def _startup_env_var(self) -> str:
+        """zsh-specific override for HOME shell env var"""
+        return "ZDOTDIR"
+    
+    def _write_startup_env(self, ex) -> None:
+        """ZDOTDIR tells zsh to load dot files from tmpdir
+        without using HOME. Since HOME is always set and correct,
+        there is no need to restore it in the generated startup files.
+        """
+        pass
 
 def register_plugin():
     if platform_.name != "windows":

--- a/src/rezplugins/shell/zsh.py
+++ b/src/rezplugins/shell/zsh.py
@@ -113,17 +113,18 @@ class Zsh(SH):
                 txt = '"%s"' % txt
             result += txt
         return result
-    
+
     def _startup_env_var(self) -> str:
         """zsh-specific override for HOME shell env var"""
         return "ZDOTDIR"
-    
+
     def _write_startup_env(self, ex) -> None:
         """ZDOTDIR tells zsh to load dot files from tmpdir
         without using HOME. Since HOME is always set and correct,
         there is no need to restore it in the generated startup files.
         """
         pass
+
 
 def register_plugin():
     if platform_.name != "windows":


### PR DESCRIPTION
## Original Issue

Fixed #2058 

## Root Cause

zsh runs .zshenv before .zshrc, so the export HOME=/real/home inside the generated .zshenv triggered before rez's .zshrc could be sourced, bypassing the context

## Fix

`ZDOTDIR` is the correct zsh-native mechanism for redirecting dot file loading, and doesn't require touching HOME at all

- Updated `shells.py` UnixShell class to implement default HOME environment var setting for the HOME env var hijack
- Updated `rezplugins/shells/zsh.py` class to re-implement default methods to utilize ZDOTDIR instead

Thanks to @JeanChristopheMorinPerso and @legomir for their initial diagnosis and background info on this problem.