### PR TITLE
feat: add ephemerals to the list of objects available in late functions

### DIFF
--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -293,7 +293,7 @@ is ``True``:
 * **testing**: see :rex:attr:`testing`;
 * **request**: see :rex:attr:`request`;
 * **implicits**: see :rex:attr:`implicits`;
-* **ephemerals**: see :attr:`ephemerals`.
+* **ephemerals**: see :rex:attr:`ephemerals`.
 
 The following objects are available in **all** cases:
 

--- a/docs/source/package_definition.rst
+++ b/docs/source/package_definition.rst
@@ -292,7 +292,8 @@ is ``True``:
 * **building**: see :rex:attr:`building`;
 * **testing**: see :rex:attr:`testing`;
 * **request**: see :rex:attr:`request`;
-* **implicits**: see :rex:attr:`implicits`.
+* **implicits**: see :rex:attr:`implicits`;
+* **ephemerals**: see :attr:`ephemerals`.
 
 The following objects are available in **all** cases:
 

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -9,7 +9,6 @@ from rez.package_resources import PackageFamilyResource, PackageResource, \
     VariantResource, package_family_schema, package_schema, variant_schema, \
     package_release_keys, late_requires_schema
 from rez.package_serialise import dump_package_data
-from rez.rex_bindings import EphemeralsBinding
 from rez.utils import reraise
 from rez.utils.sourcecode import SourceCode
 from rez.utils.data_utils import cached_property

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -186,7 +186,6 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
         else:
             g["in_context"] = lambda: True
             g["context"] = self.context
-            g["ephemerals"] = EphemeralsBinding(self.context.resolved_ephemerals or [])
 
             # 'request', 'system' etc
             bindings = self.context._get_pre_resolve_bindings()

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -9,6 +9,7 @@ from rez.package_resources import PackageFamilyResource, PackageResource, \
     VariantResource, package_family_schema, package_schema, variant_schema, \
     package_release_keys, late_requires_schema
 from rez.package_serialise import dump_package_data
+from rez.rex_bindings import EphemeralsBinding
 from rez.utils import reraise
 from rez.utils.sourcecode import SourceCode
 from rez.utils.data_utils import cached_property
@@ -185,6 +186,7 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
         else:
             g["in_context"] = lambda: True
             g["context"] = self.context
+            g["ephemerals"] = EphemeralsBinding(self.context.resolved_ephemerals or [])
 
             # 'request', 'system' etc
             bindings = self.context._get_pre_resolve_bindings()

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -2049,6 +2049,7 @@ class ResolvedContext(object):
                 "testing": self.testing,
                 "request": RequirementsBinding(self._package_requests),
                 "implicits": RequirementsBinding(self.implicit_packages),
+                "ephemerals": EphemeralsBinding(self.resolved_ephemerals or []),
                 "intersects": intersects
             }
 
@@ -2134,7 +2135,6 @@ class ResolvedContext(object):
             executor.bind(k, v)
 
         executor.bind("resolve", VariantsBinding(variant_bindings))
-        executor.bind("ephemerals", EphemeralsBinding(ephemerals))
 
         #
         # -- apply each resolved package to the execution context

--- a/src/rez/resolver.py
+++ b/src/rez/resolver.py
@@ -180,7 +180,7 @@ class Resolver(object):
 
     @property
     def resolved_ephemerals(self) -> list[Requirement] | None:
-        """Get the list of resolved ewphemerals.
+        """Get the list of resolved ephemerals.
 
         Returns:
             List of `Requirement` objects, or None if the resolve has not


### PR DESCRIPTION
Late binding functions have direct access to `implicits`.  To make late binding functions more consistent add `ephemerals`.

Closes: #1739