### PR TITLE
Improve release script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,15 +44,12 @@ To merge a PR to the `main` branch and release a new version:
 3. Update the version in [src/rez/utils/_version.py](src/rez/utils/_version.py)
 4. Update [the changelog](CHANGELOG.md). A handy utility is provided to help you do this.
 
-   To use it, run the following command, replacing X, Y, Z etc with all pull request
-   and issue numbers associated with the release:
    ```bash
-   python ./release-rez.py -c $(git log <previous version>..HEAD --oneline | rev | cut -d'#' -f 1 | rev | sed 's/)//g' | tr '\n', ' ')
+   python release-rez.py changelog
    ```
-   (replace `<previous version>` with the last release we did).
 
    This command prints the changelog entry to stdout, which you can then paste in
-   to the top of CHANGELOG.md.
+   to the top of [CHANGELOG.md](CHANGELOG.md).
 
    Do not keep the output as is. Go over each entry and classify them. You can also
    do editorial changes to make them clearer.
@@ -61,27 +58,24 @@ To merge a PR to the `main` branch and release a new version:
    our contributors, explain what the release means, highlight big changes, etc.
 5. Run `git shortlog -sne --all` and update the [mailmap](.mailmap) if needed.
 6. Commit and create a PR. Then ask your peers from the TSC to review it.
-7. Make sure that all tests in CI are passing before merging.
+7. Make sure that all CI are passing before merging.
 8. Merge in the UI.
 9. Switch your local branch to the main branch and pull.
 10. Make sure that you are on the main branch and that you have pulled the changes.
 11. Create and push the tag
-   Note that the script can also create the release, but I recommend against it for now.
-   It's better to manually create the release and review the changes yourself to make
-   sure that all contributors are properly tagged.
    ```bash
-   python ./release-rez.py -s tag
+   python ./release-rez.py tag
    ```
-13. Go to https://github.com/AcademySoftwareFoundation/rez/releases/new and create the release.
-    The release name should be `<version> (<date>)` where `<version>` is NOT prefixed with `v`.
-    For the release notes, just copy/paste the ones you created in the CHANGELOG, including the
-    `[Source] | [Diff]` header.
-
-    If you are unsure, look at the past releases or ask your teammates.
-14. Hit the "Publish release" button.
-15. Go to https://github.com/AcademySoftwareFoundation/rez/actions/workflows/pypi.yaml and
+12. Look at the tests on GHA for main and the tag. Make sure they all pass.
+13. Create the release.
+    ```bash
+    python release-rez.py release
+    ```
+    The command will show you what the release will look like (tag, title, release notes).
+    It will ask if if you really want to release.
+14. Go to https://github.com/AcademySoftwareFoundation/rez/actions/workflows/pypi.yaml and
     monitor the release. You will see a new run. Go take a look at the logs and make sure
     that the upload to PyPI works.
-16. Go to https://rez.readthedocs.io/en/stable/ and make sure that the stable version
+15. Go to https://rez.readthedocs.io/en/stable/ and make sure that the stable version
     matches the version you just published.
-17. Relax and enjoy!
+16. Relax and enjoy!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,7 +72,7 @@ To merge a PR to the `main` branch and release a new version:
     python release-rez.py release
     ```
     The command will show you what the release will look like (tag, title, release notes).
-    It will ask if if you really want to release.
+    It will ask if you really want to release.
 14. Go to https://github.com/AcademySoftwareFoundation/rez/actions/workflows/pypi.yaml and
     monitor the release. You will see a new run. Go take a look at the logs and make sure
     that the upload to PyPI works.

--- a/release-rez.py
+++ b/release-rez.py
@@ -199,7 +199,7 @@ def create_github_release_notes():
     print("Created release notes: " + url)
 
 
-def generate_changelog_entry(issue_nums):
+def generate_changelog_entry():
     # parse previous release out of changelog
     changelog = parse_topmost_changelog()
 
@@ -211,11 +211,37 @@ def generate_changelog_entry(issue_nums):
         )
         sys.exit(1)
 
+    # Discover PRs from commits between the previous tag and HEAD.
+    # For each commit, ask GitHub which PR(s) contain it, and merge the
+    # resulting PR numbers into any issue/PR numbers passed in by the caller.
+    discovered_prs = set()
+
+    response = github_request("get", "compare/%s...HEAD" % previous_version)
+    response.raise_for_status()
+    response_content = response.json()
+    commits = response_content.get("commits", [])
+    if len(commits) < response_content.get("total_commits"):
+        raise ValueError("List of commits is paginated")
+
+    for commit in commits:
+        sha = commit["sha"]
+        pr_response = github_request("get", "commits/%s/pulls" % sha)
+        pr_response.raise_for_status()
+        for pr in pr_response.json():
+            discovered_prs.add(pr["number"])
+
+    if verbose:
+        sys.stderr.write(
+            "Discovered %d PR(s) from %d commit(s) between %s and HEAD: %s\n"
+            % (len(discovered_prs), len(commits), previous_version,
+               sorted(discovered_prs))
+        )
+
     # get issues and PRs from cli
     pr_lines = []
     issue_lines = []
 
-    for issue_num in sorted(issue_nums):
+    for issue_num in sorted(discovered_prs):
         # note that 'issues' endpoint also returns PRs
         response = github_request(
             "get",

--- a/release-rez.py
+++ b/release-rez.py
@@ -68,15 +68,15 @@ def get_github_repo_owner():
     return remote[1].split(":")[-1].split("/", maxsplit=1)[0]
 
 
-_repo_owner = get_github_repo_owner()
-repo_name = f"{_repo_owner}/rez"
-github_baseurl = "github.com/%s" % repo_name
+# Will be set under if __main__
+repo_name = ""
+github_baseurl = ""
 verbose = False
 
 # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 # requires 'public_repo' access
 #
-github_token = os.environ["GITHUB_RELEASE_REZ_TOKEN"]
+github_token = ""
 
 
 def run_command(*nargs):
@@ -361,6 +361,19 @@ if __name__ == "__main__":
         "tag": create_and_push_tag,
         "release": create_github_release,
     }
+
+    _repo_owner = get_github_repo_owner()
+    repo_name = f"{_repo_owner}/rez"
+    github_baseurl = "github.com/%s" % repo_name
+
+    github_token = os.environ.get("GITHUB_RELEASE_REZ_TOKEN")
+
+    if not github_token:
+        print(
+            "GITHUB_RELEASE_REZ_TOKEN environment variable must be set to a valid GH API token",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     check_on_main()
 

--- a/release-rez.py
+++ b/release-rez.py
@@ -182,6 +182,25 @@ def create_github_release():
         body=changelog["body"]
     )
 
+    print("\033[1mTag\033[0m:", data["tag_name"])
+    print("\033[1mName\033[0m:", data["name"])
+    print("\033[1mBody\033[0m:")
+    print(data["body"])
+    print()
+    answer = None
+    while answer is None:
+        answer_ = input("Does this look good? [y/n]")
+        if answer_.lower() not in ["y", "n"]:
+            continue
+
+        answer = answer_
+
+    if answer == "n":
+        print("Aborting release!")
+        return
+
+    print("Proceeding with the release")
+
     # create the release on github
     response = github_request(
         "post",

--- a/release-rez.py
+++ b/release-rez.py
@@ -13,6 +13,7 @@ from datetime import date
 from shlex import quote
 import subprocess
 import sys
+import re
 
 try:
     import requests
@@ -79,11 +80,23 @@ def parse_topmost_changelog():
             # eg: ## 2.38.0 (2019-07-20)
             if parts and parts[0] == "##":
                 if result.get("version"):
+                    for index, line in enumerate(body_lines):
+                        # Replace the user URL to a github handle. This will allow GH to properly
+                        # attribute and tag all contributors on the release page.
+                        # [user](https://github.com/user) > @user
+                        line = re.sub(r"\[([^\]]+)\]\(https://github\.com/\1\)", r"@\1", line)
+                        # Now replace all links to rez GH issues and PR with `#<number>`.
+                        # This is purely cosmetic. It at least makes the output cleaner.
+                        # [\#1234](https://github.com/AcademySoftwareFoundation/rez/pull/1234) > #1234.
+                        line = re.sub(r'\[\\#(\d+)\]\(https://github\.com/AcademySoftwareFoundation/rez/(pull|issues)/\1\)', r'#\1', line)
+                        body_lines[index] = line
+
                     result["body"] = ''.join(body_lines).strip()
                     return result
 
-                result["version"] = parts[1]
-                result["name"] = ' '.join(parts[1:])
+                # The version in our changelog is prefixed with `v`. Get rid of that.
+                result["version"] = parts[1].lstrip("v")
+                result["name"] = ' '.join(parts[1:]).lstrip("v")
 
             elif result.get("version"):
                 # GitHub seems to treat separate lines in the md as line breaks,

--- a/release-rez.py
+++ b/release-rez.py
@@ -159,11 +159,14 @@ def check_on_main():
 
 
 def create_and_push_tag():
+    check_on_main()
     run_command("git", "tag", _rez_version)
     run_command("git", "push", "origin", _rez_version)
 
 
 def create_github_release():
+    check_on_main()
+
     # check if latest release notes already match current version
     response = github_request("get", "releases/latest")
     response.raise_for_status()
@@ -374,8 +377,6 @@ if __name__ == "__main__":
             file=sys.stderr,
         )
         sys.exit(1)
-
-    check_on_main()
 
     command = command_map.get(opts.subcommand)
     if command:

--- a/release-rez.py
+++ b/release-rez.py
@@ -150,16 +150,12 @@ def check_on_main():
         sys.exit(1)
 
 
-def push_codebase():
-    run_command("git", "push")
-
-
 def create_and_push_tag():
     run_command("git", "tag", _rez_version)
     run_command("git", "push", "origin", _rez_version)
 
 
-def create_github_release_notes():
+def create_github_release():
     # check if latest release notes already match current version
     response = github_request("get", "releases/latest")
     response.raise_for_status()
@@ -307,36 +303,43 @@ def generate_changelog_entry():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", help="Don't run any destructive actions")
     parser.add_argument(
-        "-s", "--step", choices=("push", "tag", "release_notes"),
-        help="Just run one step of the release process")
-    parser.add_argument(
-        "-c", "--changelog", nargs='*', metavar="ISSUE", type=int,
-        help="Generate changelog entry to be added to CHANGELOG.md")
-    parser.add_argument(
-        "-v", "--verbose", action="store_true",
-        help="Verbose mode")
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose mode",
+    )
+
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    changelog_parser = subparsers.add_parser(
+        "changelog",
+        help="Generate the changelog entry and print to stdout"
+    )
+
+    subparsers.add_parser(
+        "tag",
+        help="Tag and push the tag"
+    )
+
+    subparsers.add_parser(
+        "release",
+        help="Create the release"
+    )
 
     opts = parser.parse_args()
     verbose = opts.verbose
 
-    if opts.changelog is not None:
-        issue_nums = opts.changelog
-        generate_changelog_entry(issue_nums)
-        sys.exit(0)
-
-    print("Releasing rez-%s..." % _rez_version)
-
-    def doit(step):
-        return (opts.step is None) or (step == opts.step)
+    command_map = {
+        "changelog": generate_changelog_entry,
+        "tag": create_and_push_tag,
+        "release": create_github_release,
+    }
 
     check_on_main()
 
-    if doit("push"):
-        push_codebase()
-
-    if doit("tag"):
-        create_and_push_tag()
-
-    if doit("release_notes"):
-        create_github_release_notes()
+    command = command_map.get(opts.subcommand)
+    if command:
+        command()
+    else:
+        raise RuntimeError(f"Add {opts.subcommand!r} to command_map")

--- a/release-rez.py
+++ b/release-rez.py
@@ -61,8 +61,8 @@ def get_github_repo_owner():
 
 
 _repo_owner = get_github_repo_owner()
-github_baseurl = "github.com/repos/%s/rez" % _repo_owner
-github_baseurl2 = "github.com/%s/rez" % _repo_owner
+repo_name = f"{_repo_owner}/rez"
+github_baseurl = "github.com/%s" % repo_name
 verbose = False
 
 # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
@@ -86,7 +86,7 @@ def run_command(*nargs):
 
 
 def github_request(method, endpoint, headers=None, **kwargs):
-    url = "https://api.%s/%s" % (github_baseurl, endpoint)
+    url = f"https://api.github.com/repos/{repo_name}/{endpoint}"
     headers = (headers or {}).copy()
     headers["Authorization"] = "token " + github_token
     return requests.request(method, url, headers=headers, **kwargs)
@@ -256,7 +256,7 @@ def generate_changelog_entry(issue_nums):
 
     print(
         "[Source](https://%s/tree/%s) | [Diff](https://%s/compare/%s...%s)" %
-        (github_baseurl2, _rez_version, github_baseurl2, previous_version, _rez_version)
+        (github_baseurl, _rez_version, github_baseurl, previous_version, _rez_version)
     )
 
     print("")

--- a/release-rez.py
+++ b/release-rez.py
@@ -31,10 +31,33 @@ from rez.utils._version import _rez_version
 def get_github_repo_owner():
     out = subprocess.check_output(["git", "remote", "-v"], text=True)
 
-    # eg git@github.com:jbloggs/rez.git, https://github.com/jbloggs/rez.git
-    remote_url = out.split()[1]
-    parts = remote_url.replace('/', ' ').replace(':', ' ').split()
-    return parts[-2]
+    # The output looks like this:
+    # chadrik git@github.com:chadrik/rez (fetch)
+    # chadrik git@github.com:chadrik/rez (push)
+    # origin  git@github.com:JeanChristopheMorinPerso/rez.git (fetch)
+    # origin  git@github.com:JeanChristopheMorinPerso/rez.git (push)
+    # upstream        git@github.com:AcademySoftwareFoundation/rez.git (fetch)
+    # upstream        git@github.com:AcademySoftwareFoundation/rez.git (push)
+
+    remotes: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        remotes.append(line.split()[0:2])
+
+    if len(set([remote[1] for remote in remotes])) > 1:
+        print(
+            "More than one remote are configured. The script doesn't support multiple remotes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    remote = remotes[0]
+    if remote[0] != "origin":
+        print(
+            f"Rename name is {remote[0]!r}. Was expecting 'origin'",
+            file=sys.stderr,
+        )
+
+    return remote[1].split(":")[-1].split("/", maxsplit=1)[0]
 
 
 _repo_owner = get_github_repo_owner()

--- a/release-rez.py
+++ b/release-rez.py
@@ -56,6 +56,14 @@ def get_github_repo_owner():
             f"Rename name is {remote[0]!r}. Was expecting 'origin'",
             file=sys.stderr,
         )
+        sys.exit(1)
+
+    if not remote[1].startswith("git@github.com"):
+        print(
+            f"Remote URL must use the SSH protocal and start with 'git@github.com'. Current remote: {remote[1]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     return remote[1].split(":")[-1].split("/", maxsplit=1)[0]
 
@@ -322,14 +330,13 @@ def generate_changelog_entry():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dry-run", help="Don't run any destructive actions")
     parser.add_argument(
         "-v", "--verbose",
         action="store_true",
         help="Verbose mode",
     )
 
-    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     changelog_parser = subparsers.add_parser(
         "changelog",


### PR DESCRIPTION
This PR changes the release script to better reflect my current workflow. It is more opinionated and also will try to prevent as many mistakes as possible.

I changed the interface to be more user friendly. It makes use of subcommands:
* `release-rez.py changelog` generates the changelog based on upstream commits. It gets the commits between the previous release and HEAD and for each commits gets the corresponding PR. The output is the same as before.
* `release-rez.py tag` same as before.
* `release-rez.py release` creates the release. It now properly formats the release notes to be compatible with what GH expects. It also now prints a preview of the release and asks you if you want to actually create the release. This gives us an opportunity to catch any mistakes before it's too late.

The `push` step is gone. It was not useful IMO.

In terms of robustness, the checks for remotes was augmented to do this:
* If there is more than one remote, print an error and exit.
* If there is only one remote but its name is not origin, print an error and exit.

This removes a few footguns with the previous version of the script.

Lastly, I updated the release instructions to match the new script.

I believe that with these changes in place, the release process has been simplified and most importantly, the footguns have been removed. This will hopefully lead to streamlined releases without the additional stress caused by the previous script.

I used some help from an LLM to create this PR. Mostly for the regexes and the GH API calls. Corresponding threads:
* https://ampcode.com/threads/T-019e800c-848c-71be-b822-39e3095945d9
* https://ampcode.com/threads/T-019e803f-4399-76fc-85bf-3400699ccdf0