### PR TITLE
Check production install only if async is needed

### DIFF
--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -506,7 +506,7 @@ class PackageCache(object):
         # a prod install. On non-windows we could fork instead, but there would
         # remain no good solution on windows.
         #
-        if not system.is_production_rez_install:
+        if package_cache_async and not system.is_production_rez_install:
             raise PackageCacheError(
                 "PackageCache.add_variants is only supported in a "
                 "production rez installation."


### PR DESCRIPTION
Hello, 

This is spawn from https://github.com/AcademySoftwareFoundation/rez/issues/1500.

In the `PackageCache.add_variants` method there's a check for verify that rez is installed as a "production install". 
I reckon this check only needs to happen if we want to cache the packages in async mode, and it should not matter if we are caching them in the same thread.

Thank you!