### PR TITLE
refactor(ruff): remove ruff per file exemptions (#2120)

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -13,6 +13,7 @@ on:
       - '!src/rez/utils/_version.py'
       - '!src/rez/vendor/**'
       - '!src/rez/data/**'
+      - '!src/support/**'
   push:
     paths:
       - '.github/workflows/ruff.yaml'
@@ -26,6 +27,7 @@ on:
       - '!src/rez/utils/_version.py'
       - '!src/rez/vendor/**'
       - '!src/rez/data/**'
+      - '!src/support/**'
 
 permissions:
   contents: read

--- a/install.py
+++ b/install.py
@@ -18,7 +18,6 @@ try:
     import venv
 except ImportError:
     USE_VIRTUALENV = True
-    import virtualenv
 
 
 source_path = os.path.dirname(os.path.realpath(__file__))
@@ -29,7 +28,7 @@ sys.path.insert(0, src_path)
 # though rez is not yet built.
 #
 from rez.utils._version import _rez_version  # noqa: E402
-from rez.utils.filesystem import safe_rmtree
+from rez.utils.filesystem import safe_rmtree  # noqa: E402
 from rez.utils.which import which  # noqa: E402
 from rez.cli._entry_points import get_specifications  # noqa: E402
 from rez.vendor.distlib.scripts import ScriptMaker  # noqa: E402

--- a/release-rez.py
+++ b/release-rez.py
@@ -24,7 +24,7 @@ source_path = os.path.dirname(os.path.realpath(__file__))
 src_path = os.path.join(source_path, "src")
 sys.path.insert(0, src_path)
 
-from rez.utils._version import _rez_version
+from rez.utils._version import _rez_version  # noqa: E402
 
 
 def get_github_repo_owner():
@@ -212,7 +212,7 @@ def generate_changelog_entry(issue_nums):
             )
 
     # print title section
-    today = date.today()
+    today = date.today()  # noqa: DTZ011
     print(
         "## v%s (%d-%02d-%02d)" %
         (_rez_version, today.year, today.month, today.day)

--- a/ruff.toml
+++ b/ruff.toml
@@ -108,9 +108,6 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"src/rez/tests/*.py" = [
-    "F821"    # Undefined name
-]
 "src/rez/bind/_pymodule.py" = [
     "F821"    # Undefined name
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -123,9 +123,6 @@ ignore = [
 "src/rez/resolver.py" = [
     "F821"    # Undefined name
 ]
-"src/rez/cli/_main.py" = [
-    "ISC002"  # Implicitly concatenated string literals over multiple lines
-]
 "src/rez/cli/release.py" = [
     "F821"    # Undefined name
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -114,9 +114,6 @@ ignore = [
 "src/rez/cli/release.py" = [
     "F821"    # Undefined name
 ]
-"src/rez/tests/test_formatter.py" = [
-    "E742"    # Ambiguous class name: `I`
-]
 "src/rezplugins/release_vcs/git.py" = [
     "F821"    # Undefined name
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -126,15 +126,6 @@ ignore = [
 "src/rez/tests/test_formatter.py" = [
     "E742"    # Ambiguous class name: `I`
 ]
-"src/rezgui/objects/Config.py" = [
-    "E721"    # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
-]
-"src/rezgui/widgets/ContextToolsWidget.py" = [
-    "F401"    # "rezgui.objects.App.app" imported but unused
-]
-"src/rezgui/widgets/TimestampWidget.py" = [
-    "E731"    # Do not assign a `lambda` expression, use a `def`
-]
 "src/rezplugins/release_vcs/git.py" = [
     "F821"    # Undefined name
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,6 +21,7 @@ include = [
 extend-exclude = [
     "src/rez/vendor",
     "src/rez/data",
+    "src/support"
 ]
 
 # Match flake8 linter defaults
@@ -108,17 +109,10 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"src/rez/utils/filesystem.py" = [
-    "F821"    # Undefined name
-]
-"src/rez/cli/release.py" = [
-    "F821"    # Undefined name
-]
+# Bug in the following.  Uses the git python package, which is not installed, in the
+# export # class method.  rez-diff calls the method.
 "src/rezplugins/release_vcs/git.py" = [
     "F821"    # Undefined name
-]
-"src/support/package_utils/set_authors.py" = [
-    "INP001"  # part of an implicit namespace package
 ]
 
 [lint.flake8-annotations]

--- a/ruff.toml
+++ b/ruff.toml
@@ -145,9 +145,6 @@ ignore = [
     "E402",   # Module level import not at top of file
     "F401"    # "virtualenv" imported but unused
 ]
-"./setup.py" = [
-    "E402"    # Module level import not at top of file
-]
 
 [lint.flake8-annotations]
 # Allow "Any" for dynamically typed *args and **kwargs arguments

--- a/ruff.toml
+++ b/ruff.toml
@@ -126,9 +126,6 @@ ignore = [
 "src/rez/cli/release.py" = [
     "F821"    # Undefined name
 ]
-"src/rez/package_order.py" = [
-    "E721"    # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
-]
 "src/rez/tests/test_formatter.py" = [
     "E742"    # Ambiguous class name: `I`
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -108,13 +108,7 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"src/rez/bind/_pymodule.py" = [
-    "F821"    # Undefined name
-]
 "src/rez/utils/filesystem.py" = [
-    "F821"    # Undefined name
-]
-"src/rez/resolver.py" = [
     "F821"    # Undefined name
 ]
 "src/rez/cli/release.py" = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -108,9 +108,6 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"__init__.py" = [
-    "D104"    # undocumented-public-package
-]
 "src/rez/tests/*.py" = [
     "F821"    # Undefined name
 ]
@@ -143,10 +140,6 @@ ignore = [
 ]
 "src/support/package_utils/set_authors.py" = [
     "INP001"  # part of an implicit namespace package
-]
-"./release-rez.py" = [
-    "E402",   # Module level import not at top of file
-    "DTZ011"  # `datetime.date.today()` used
 ]
 "./install.py" = [
     "E402",   # Module level import not at top of file

--- a/ruff.toml
+++ b/ruff.toml
@@ -141,10 +141,6 @@ ignore = [
 "src/support/package_utils/set_authors.py" = [
     "INP001"  # part of an implicit namespace package
 ]
-"./install.py" = [
-    "E402",   # Module level import not at top of file
-    "F401"    # "virtualenv" imported but unused
-]
 
 [lint.flake8-annotations]
 # Allow "Any" for dynamically typed *args and **kwargs arguments

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ source_path = os.path.dirname(os.path.realpath(__file__))
 src_path = os.path.join(source_path, "src")
 sys.path.insert(0, src_path)
 
-from rez.utils._version import _rez_version
-from rez.cli._entry_points import get_specifications
+from rez.utils._version import _rez_version  # noqa: E402
+from rez.cli._entry_points import get_specifications  # noqa: E402
 
 
 def find_files(pattern, path=None, root="rez"):

--- a/src/rez/bind/_pymodule.py
+++ b/src/rez/bind/_pymodule.py
@@ -21,12 +21,12 @@ import os.path
 
 
 def commands() -> None:
-    env.PYTHONPATH.append('{this.root}/python')
+    env.PYTHONPATH.append('{this.root}/python')  # noqa: F821
 
 
 def commands_with_bin() -> None:
-    env.PYTHONPATH.append('{this.root}/python')
-    env.PATH.append('{this.root}/bin')
+    env.PYTHONPATH.append('{this.root}/python')  # noqa: F821
+    env.PATH.append('{this.root}/bin')  # noqa: F821
 
 
 def copy_module(name, destpath):

--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -35,14 +35,11 @@ class SetupRezSubParser(object):
 
         error_msg = None
         if not mod.__doc__:
-            error_msg = "command module %s must have a module-level " \
-                "docstring (used as the command help)" % self.module_name
+            error_msg = f"command module {self.module_name} must have a module-level docstring (used as the command help)"
         if not hasattr(mod, 'command'):
-            error_msg = "command module %s must provide a command() " \
-                "function" % self.module_name
+            error_msg = f"command module {self.module_name} must provide a command() function"
         if not hasattr(mod, 'setup_parser'):
-            error_msg = "command module %s  must provide a setup_parser() " \
-                "function" % self.module_name
+            error_msg = f"command module {self.module_name} must provide a setup_parser() function"
         if error_msg:
             print(error_msg, file=sys.stderr)
             return SUPPRESS

--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -35,7 +35,10 @@ class SetupRezSubParser(object):
 
         error_msg = None
         if not mod.__doc__:
-            error_msg = f"command module {self.module_name} must have a module-level docstring (used as the command help)"
+            error_msg = (
+                f"command module {self.module_name} must have a module-level docstring "
+                "(used as the command help)"
+            )
         if not hasattr(mod, 'command'):
             error_msg = f"command module {self.module_name} must provide a command() function"
         if not hasattr(mod, 'setup_parser'):

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -659,7 +659,7 @@ class Config(object, metaclass=LazyAttributeMeta):
         Returns:
             List of str: The sourced files.
         """
-        _ = self._data  # noqa; force a config load
+        _ = self._data  # force a config load # noqa
         return self._sourced_filepaths or []
 
     @cached_property

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -193,7 +193,9 @@ class PackageOrder(object):
         raise NotImplementedError
 
     def __eq__(self, other):
-        return type(self) == type(other) and str(self) == str(other)  # noqa: E721
+        if isinstance(other, type(self)):
+            return str(self) == str(other)
+        return NotImplemented
 
     def __ne__(self, other) -> bool:
         return not self == other
@@ -220,7 +222,7 @@ class NullPackageOrder(PackageOrder):
         return "{}"
 
     def __eq__(self, other):
-        return type(self) == type(other)  # noqa: E721
+        return type(self) is type(other)
 
     def to_pod(self) -> dict[str, Any]:
         """
@@ -266,10 +268,7 @@ class SortedOrder(PackageOrder):
         return str(self.descending)
 
     def __eq__(self, other):
-        return (  # noqa: E721
-            type(self) == type(other)
-            and self.descending == other.descending
-        )
+        return type(self) is type(other) and self.descending == other.descending
 
     def to_pod(self) -> dict[str, Any]:
         """
@@ -345,8 +344,8 @@ class PerFamilyOrder(PackageOrder):
         return str((items, str(self.default_order)))
 
     def __eq__(self, other):
-        return (  # noqa: E721
-            type(other) == type(self)
+        return (
+            type(other) is type(self)
             and self.order_dict == other.order_dict
             and self.default_order == other.default_order
         )
@@ -437,10 +436,7 @@ class VersionSplitPackageOrder(PackageOrder):
         return str(self.first_version)
 
     def __eq__(self, other):
-        return (  # noqa: E721
-            type(other) == type(self)
-            and self.first_version == other.first_version
-        )
+        return type(other) is type(self) and self.first_version == other.first_version
 
     def to_pod(self) -> dict[str, Any]:
         """
@@ -601,7 +597,7 @@ class TimestampPackageOrder(PackageOrder):
 
     def __eq__(self, other):
         return (  # noqa: E721
-            type(other) == type(self)
+            type(other) is type(self)
             and self.timestamp == other.timestamp
             and self.rank == other.rank
         )

--- a/src/rez/resolver.py
+++ b/src/rez/resolver.py
@@ -20,7 +20,9 @@ from typing import Any, Callable, Iterator, TypedDict, TYPE_CHECKING
 if TYPE_CHECKING:
     from rez.package_order import PackageOrderList
     from rez.resolved_context import ResolvedContext
+    from rez.utils.resources import ResourceHandle
     from rez.utils.typing import SupportsWrite
+    from rez.vendor.pygraph.classes.digraph import digraph
 
 
 class SolverDict(TypedDict):

--- a/src/rez/tests/ruff.toml
+++ b/src/rez/tests/ruff.toml
@@ -1,0 +1,20 @@
+extend = "../../../ruff.toml"
+
+# Treat rex as builtin 
+builtins = [
+   "alias",
+   "appendenv",
+   "command",
+   "comment",
+   "defined",
+   "env",
+   "error",
+   "getenv",
+   "info",
+   "prependenv",
+   "setenv",
+   "shebang",
+   "source",
+   "undefined",
+   "unsetenv",
+]

--- a/src/rez/tests/test_formatter.py
+++ b/src/rez/tests/test_formatter.py
@@ -100,7 +100,7 @@ class TestFormatter(TestBase):
             def __format__(self, format_spec) -> str:
                 return 1.0
 
-        class I(datetime.date):
+        class I(datetime.date):  # noqa: E742
             def __format__(self, format_spec) -> str:
                 return self.strftime(format_spec)
 

--- a/src/rezgui/objects/Config.py
+++ b/src/rezgui/objects/Config.py
@@ -26,7 +26,7 @@ class Config(QtCore.QSettings):
         if type_ is None:
             default = self._default_value(key)
             val = self._value(key, default)
-            if type(val) == type(default):
+            if type(val) is type(default):
                 return val
             else:
                 return self._convert_value(val, type(default))

--- a/src/rezgui/widgets/ContextToolsWidget.py
+++ b/src/rezgui/widgets/ContextToolsWidget.py
@@ -7,7 +7,6 @@ from rezgui.widgets.ToolWidget import ToolWidget
 from rezgui.models.ContextModel import ContextModel
 from rezgui.mixins.ContextViewMixin import ContextViewMixin
 from rezgui.util import get_icon
-from rezgui.objects.App import app
 
 
 class _TreeNode(QtWidgets.QLabel):

--- a/src/rezgui/widgets/TimestampWidget.py
+++ b/src/rezgui/widgets/TimestampWidget.py
@@ -63,10 +63,9 @@ class TimestampWidget(QtWidgets.QFrame):
         self.refresh()
 
     def _selectPackage(self) -> None:
-        fn = lambda x: bool(x.timestamp)
         dlg = BrowsePackageDialog(context_model=self.context_model,
                                   parent=self.parentWidget(),
-                                  package_selectable_callback=fn)
+                                  package_selectable_callback=lambda x: bool(x.timestamp))
         dlg.exec_()
         if dlg.package:
             self.set_time(dlg.package.timestamp)

--- a/src/rezplugins/release_vcs/git.py
+++ b/src/rezplugins/release_vcs/git.py
@@ -6,6 +6,7 @@
 Git version control
 """
 from rez.release_vcs import ReleaseVCS
+from rez.utils.filesystem import retain_cwd
 from rez.utils.logging_ import print_error, print_debug
 from rez.exceptions import ReleaseVCSError
 from shutil import rmtree


### PR DESCRIPTION
## Branch summary: `refactor/2120-remove-ruff-per-file-exemptions`

**13 commits** ahead of `main` (issue #2120). **16 files changed**, +55 / −84 lines.

### Goal

Remove most Ruff **per-file-ignores** and fix the underlying lint issues in code instead of suppressing them globally per file.

### Config & CI

- **`ruff.toml`**: Dropped ~20 per-file ignore entries (tests, bind, resolver, CLI, rezgui, install/setup scripts, etc.). Only one remains:
  - `src/rezplugins/release_vcs/git.py` — **F821** (undefined `git` in `export()`; uses the `git` Python package, which isn’t installed — noted as a known bug used by `rez-diff` / `diff_packages.py`)
- **`ruff.toml` + `.github/workflows/ruff.yaml`**: Exclude **`src/support/`** from Ruff entirely.
- **`src/rez/tests/ruff.toml`** (new): Extends root config and treats **rex builtins** (`env`, `command`, etc.) as known names in tests.

### Code fixes (replacing suppressions)

| Area | Change |
|------|--------|
| **Type comparisons (E721)** | `package_order.py`, `rezgui/objects/Config.py` — use `type(x) is type(y)` |
| **String concatenation (ISC002)** | `cli/_main.py` — f-strings instead of implicit concatenation |
| **Unused import (F401)** | `ContextToolsWidget.py` — removed unused `app` import; `install.py` — removed unused `virtualenv` import |
| **Lambda assignment (E731)** | `TimestampWidget.py` — inline lambda |
| **Undefined names (F821)** | `resolver.py` — TYPE_CHECKING imports; `bind/_pymodule.py` — inline `# noqa: F821` on `env` |
| **Ambiguous class (E742)** | `test_formatter.py` — inline `# noqa: E742` on class `I` |
| **Import order (E402)** | `install.py`, `setup.py`, `release-rez.py` — inline `# noqa: E402` |
| **Datetime (DTZ011)** | `release-rez.py` — inline `# noqa: DTZ011` on `date.today()` |
| **Git VCS** | `git.py` — added missing `retain_cwd` import (used by `export()`, which `diff_packages.py` calls) |

### Not in committed changes

**`diff_packages.py`** is unchanged on this branch; it’s relevant context because it calls `GitReleaseVCS.export()`, which is why the `git.py` F821 exemption remains.

I used some help from an LLM to create the summary for this PR