### PR TITLE
refactor(ruff): enable sim rule (#2120)

### DIFF
--- a/install.py
+++ b/install.py
@@ -7,6 +7,7 @@ This script uses venv/virtualenv to create a standalone, production-ready Rez
 installation in the specified directory.
 """
 import argparse
+import contextlib
 import os
 import platform
 import sys
@@ -91,7 +92,7 @@ def patch_rez_binaries(dest_dir):
     specs = get_specifications()
 
     # delete rez bin files written into virtualenv
-    for name in specs.keys():
+    for name in specs:
         basepath = os.path.join(virtualenv_bin_path, name)
         filepaths = [
             basepath,
@@ -263,10 +264,8 @@ def install_as_rez_package(repo_path):
 
     finally:
         # cleanup temp install
-        try:
+        with contextlib.suppress(BaseException):
             safe_rmtree(tmpdir)
-        except:
-            pass
 
 
 if __name__ == "__main__":
@@ -311,12 +310,9 @@ if __name__ == "__main__":
     else:
         path = "/opt/rez"
 
-    if opts.as_rez_package:
-        dest_dir = path
-    else:
-        dest_dir = path.format(version=_rez_version)
-
+    dest_dir = path if opts.as_rez_package else path.format(version=_rez_version)
     dest_dir = os.path.expanduser(dest_dir)
+
     if not opts.keep_symlinks:
         dest_dir = os.path.realpath(dest_dir)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -147,15 +147,11 @@ ignore = [
 "src/rezplugins/release_vcs/git.py" = [
     "F821"    # Undefined name
 ]
-"src/support/package_utils/set_authors.py" = [
-    "INP001"  # part of an implicit namespace package
-]
 "./release-rez.py" = [
     "E402",   # Module level import not at top of file
     "DTZ011"  # `datetime.date.today()` used
 ]
 "./install.py" = [
-    "E402",   # Module level import not at top of file
     "F401"    # "virtualenv" imported but unused
 ]
 "./setup.py" = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -72,7 +72,7 @@ select = [
     "RSE",     # flake8-raise
 #   "RET",     # flake8-return
 #   "SLF",     # flake8-self
-#   "SIM",     # flake8-simplify
+    "SIM",     # flake8-simplify
     "SLOT",    # flake8-slots
     "TID",     # flake8-tidy-imports
 #   "TD",      # flake8-todos

--- a/ruff.toml
+++ b/ruff.toml
@@ -155,6 +155,7 @@ ignore = [
     "DTZ011"  # `datetime.date.today()` used
 ]
 "./install.py" = [
+    "E402",   # Module level import not at top of file
     "F401"    # "virtualenv" imported but unused
 ]
 "./setup.py" = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -147,6 +147,9 @@ ignore = [
 "src/rezplugins/release_vcs/git.py" = [
     "F821"    # Undefined name
 ]
+"src/support/package_utils/set_authors.py" = [
+    "INP001"  # part of an implicit namespace package
+]
 "./release-rez.py" = [
     "E402",   # Module level import not at top of file
     "DTZ011"  # `datetime.date.today()` used

--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -398,10 +398,7 @@ class BuildProcessHelper(BuildProcess):
 
     def get_changelog(self) -> str | None:
         previous_package = self.get_previous_release()
-        if previous_package:
-            previous_revision = previous_package.revision
-        else:
-            previous_revision = None
+        previous_revision = previous_package.revision if previous_package else None
 
         changelog = None
         with self.repo_operation():

--- a/src/rez/build_system.py
+++ b/src/rez/build_system.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os.path
 from typing import Sequence, TypedDict, TYPE_CHECKING
 
@@ -52,11 +53,8 @@ def get_valid_build_systems(working_dir: str,
     from rez.plugin_managers import plugin_manager
     from rez.exceptions import PackageMetadataError
 
-    try:
+    with contextlib.suppress(PackageMetadataError):  # no package, or bad package
         package = package or get_developer_package(working_dir)
-    except PackageMetadataError:
-        # no package, or bad package
-        pass
 
     if package:
         if getattr(package, "build_command", None) is not None:
@@ -249,10 +247,7 @@ class BuildSystem(object):
         package = variant.parent
         variant_requires = map(str, variant.variant_requires)
 
-        if variant.index is None:
-            variant_subpath = ''
-        else:
-            variant_subpath = variant._non_shortlinked_subpath
+        variant_subpath = "" if variant.index is None else variant._non_shortlinked_subpath
 
         # Security warning!
         # Be very careful with values in this dict. Escape (using literal)

--- a/src/rez/cli/_main.py
+++ b/src/rez/cli/_main.py
@@ -140,10 +140,7 @@ def run(command=None):
         args = sys.argv[1:]
 
     # parse args depending on subcommand behaviour
-    if command:
-        arg_mode = subcommands[command].get("arg_mode")
-    else:
-        arg_mode = None
+    arg_mode = subcommands[command].get("arg_mode") if command else None
 
     parser = setup_parser()
     if arg_mode == "grouped":

--- a/src/rez/cli/complete.py
+++ b/src/rez/cli/complete.py
@@ -31,10 +31,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
         comp_point = len(comp_line)
 
     last_word = comp_line.split()[-1]
-    if comp_line.endswith(last_word):
-        prefix = last_word
-    else:
-        prefix = None
+    prefix = last_word if comp_line.endswith(last_word) else None
 
     def _pop_arg(l, p):
         words = l.split()
@@ -52,9 +49,8 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     comp_line, comp_point, cmd = _pop_arg(comp_line, comp_point)
     if cmd in ("rez", "rezolve"):
         comp_line, comp_point, arg = _pop_arg(comp_line, comp_point)
-        if arg:
-            if prefix != arg:
-                subcommand = arg
+        if arg and prefix != arg:
+            subcommand = arg
     else:
         subcommand = cmd.split("-", 1)[-1]
 

--- a/src/rez/cli/config.py
+++ b/src/rez/cli/config.py
@@ -57,11 +57,7 @@ def command(opts, parser, extra_arg_groups=None):
                 raise ValueError("no such setting: %r" % opts.FIELD)
 
     if isinstance(data, (dict, list)):
-        if opts.json:
-            txt = json.dumps(convert_json_safe(data))
-        else:
-            txt = dump_yaml(data)
-
+        txt = json.dumps(convert_json_safe(data)) if opts.json else dump_yaml(data)
         print(txt.strip())
     else:
         print(data)

--- a/src/rez/cli/context.py
+++ b/src/rez/cli/context.py
@@ -122,10 +122,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
         print("not in a resolved environment context.", file=sys.stderr)
         sys.exit(1)
 
-    if rxt_file == '-':  # read from stdin
-        rc = ResolvedContext.read_from_buffer(sys.stdin, 'STDIN')
-    else:
-        rc = ResolvedContext.load(rxt_file)
+    rc = ResolvedContext.read_from_buffer(sys.stdin, 'STDIN') if rxt_file == '-' else ResolvedContext.load(rxt_file)
 
     def _graph():
         if rc.has_graph:

--- a/src/rez/cli/cp.py
+++ b/src/rez/cli/cp.py
@@ -207,11 +207,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
             for src_variant, dest_variant in copied:
                 # None possible if dry_run
-                if dest_variant is None:
-                    dest_uri = dry_run_uri
-                else:
-                    dest_uri = dest_variant.uri
-
+                dest_uri = dry_run_uri if dest_variant is None else dest_variant.uri
                 print("  %s -> %s" % (src_variant.uri, dest_uri))
 
         if skipped:

--- a/src/rez/cli/depends.py
+++ b/src/rez/cli/depends.py
@@ -77,10 +77,7 @@ def command(opts, parser, extra_arg_groups=None) -> int | None:
         return 0
 
     for i, pkgs in enumerate(pkgs_list):
-        if opts.quiet:
-            toks = pkgs
-        else:
-            toks = ["#%d:" % i] + pkgs
+        toks = pkgs if opts.quiet else ["#%d:" % i] + pkgs
         print(' '.join(toks))
 
     return None

--- a/src/rez/cli/diff.py
+++ b/src/rez/cli/diff.py
@@ -28,9 +28,6 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     from rez.utils.diff_packages import diff_packages
 
     pkg1 = get_package_from_string(opts.PKG1)
-    if opts.PKG2:
-        pkg2 = get_package_from_string(opts.PKG2)
-    else:
-        pkg2 = None
+    pkg2 = get_package_from_string(opts.PKG2) if opts.PKG2 else None
 
     diff_packages(pkg1, pkg2)

--- a/src/rez/cli/env.py
+++ b/src/rez/cli/env.py
@@ -194,10 +194,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     if context is None:
         # create package filters
-        if opts.no_filters:
-            package_filter = PackageFilterList()
-        else:
-            package_filter = PackageFilterList.singleton.copy()
+        package_filter = PackageFilterList() if opts.no_filters else PackageFilterList.singleton.copy()
 
         for rule_str in (opts.exclude or []):
             rule = Rule.parse_rule(rule_str)

--- a/src/rez/cli/interpret.py
+++ b/src/rez/cli/interpret.py
@@ -66,10 +66,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     parent_env = {} if opts.no_env else None
 
-    if opts.parent_vars == "all":
-        parent_vars = True
-    else:
-        parent_vars = opts.parent_vars
+    parent_vars = True if opts.parent_vars == "all" else opts.parent_vars
 
     ex = RexExecutor(interpreter=interp,
                      parent_environ=parent_env,

--- a/src/rez/cli/python.py
+++ b/src/rez/cli/python.py
@@ -28,11 +28,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     # We need to skip first arg if 'rez-python' form was used, but we need to
     # skip the first TWO args if 'rez python' form was used.
-    #
-    if is_hyphened_command():
-        args = sys.argv[1:]
-    else:
-        args = sys.argv[2:]
+    args = sys.argv[1:] if is_hyphened_command() else sys.argv[2:]
 
     cmd = [sys.executable, "-E"] + args
 

--- a/src/rez/cli/release.py
+++ b/src/rez/cli/release.py
@@ -7,6 +7,7 @@ Build a package from source and deploy it.
 '''
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 from subprocess import call
@@ -144,7 +145,5 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     # remove the release message file
     if filepath:
-        try:
+        with contextlib.suppress(BaseException):
             os.remove(filepath)
-        except:
-            pass

--- a/src/rez/cli/rm.py
+++ b/src/rez/cli/rm.py
@@ -87,10 +87,7 @@ def remove_package_family(opts, parser, force: bool = False) -> None:
 def remove_ignored_since(opts, parser) -> None:
     from rez.package_remove import remove_packages_ignored_since
 
-    if opts.PATH:
-        paths = [opts.PATH]
-    else:
-        paths = None
+    paths = [opts.PATH] if opts.PATH else None
 
     num_removed = remove_packages_ignored_since(
         days=opts.ignored_since,

--- a/src/rez/cli/search.py
+++ b/src/rez/cli/search.py
@@ -86,10 +86,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     else:
         paths = None
 
-    if opts.type == "auto":
-        type_ = None
-    else:
-        type_ = opts.type
+    type_ = None if opts.type == "auto" else opts.type
 
     searcher = ResourceSearcher(
         package_paths=paths,

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -87,10 +87,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     if opts.keep_tmpdirs:
         os.environ["REZ_KEEP_TMPDIRS"] = "1"
 
-    if not opts.module_tests and not opts.tests:
-        module_tests = all_module_tests
-    else:
-        module_tests = opts.module_tests
+    module_tests = all_module_tests if not opts.module_tests and not opts.tests else opts.module_tests
 
     repo = os.path.join(os.getcwd(), "__tests_pkg_repo")
     os.makedirs(repo, exist_ok=True)

--- a/src/rez/cli/status.py
+++ b/src/rez/cli/status.py
@@ -27,9 +27,6 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     from rez.status import status
     import sys
 
-    if opts.tools:
-        b = status.print_tools(opts.OBJECT)
-    else:
-        b = status.print_info(opts.OBJECT)
+    b = status.print_tools(opts.OBJECT) if opts.tools else status.print_info(opts.OBJECT)
 
     sys.exit(0 if b else 1)

--- a/src/rez/cli/view.py
+++ b/src/rez/cli/view.py
@@ -70,8 +70,5 @@ def command(opts, parser, extra_arg_groups=None) -> None:
         print()
         print("CONTENTS:")
 
-    if opts.format == "py":
-        format_ = FileFormat.py
-    else:
-        format_ = FileFormat.yaml
+    format_ = FileFormat.py if opts.format == "py" else FileFormat.yaml
     package.print_info(format_=format_, include_release=opts.all)

--- a/src/rez/cli/yaml2py.py
+++ b/src/rez/cli/yaml2py.py
@@ -23,10 +23,7 @@ def command(opts, parser, extra_arg_groups=None) -> None:
     import os
     import sys
 
-    if opts.PATH:
-        path = os.path.expanduser(opts.PATH)
-    else:
-        path = os.getcwd()
+    path = os.path.expanduser(opts.PATH) if opts.PATH else os.getcwd()
 
     try:
         package = get_developer_package(path, format=FileFormat.yaml)

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 from rez import __version__
 from rez.utils.data_utils import AttrDictWrapper, RO_AttrDictWrapper, \
     convert_dicts, cached_property, cached_class_property, LazyAttributeMeta, \
@@ -283,10 +285,8 @@ class Dict(Setting):
             try:
                 v = int(v)
             except ValueError:
-                try:
+                with contextlib.suppress(ValueError):
                     v = float(v)
-                except ValueError:
-                    pass
 
             result[k] = v
 
@@ -680,10 +680,8 @@ class Config(object, metaclass=LazyAttributeMeta):
             if key == "plugins":
                 d[key] = self.plugins.data()
             else:
-                try:
+                with contextlib.suppress(AttributeError):  # unknown key, just leave it unchanged
                     d[key] = getattr(self, key)
-                except AttributeError:
-                    pass  # unknown key, just leave it unchanged
         return d
 
     @property

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -659,7 +659,7 @@ class Config(object, metaclass=LazyAttributeMeta):
         Returns:
             List of str: The sourced files.
         """
-        _ = self._data  # noqa; force a config load
+        _ = self._data  # force a config load
         return self._sourced_filepaths or []
 
     @cached_property

--- a/src/rez/developer_package.py
+++ b/src/rez/developer_package.py
@@ -63,10 +63,7 @@ class DeveloperPackage(Package):
         name = None
         data = None
 
-        if format is None:
-            formats = [FileFormat.py, FileFormat.yaml]
-        else:
-            formats = [format]
+        formats = [FileFormat.py, FileFormat.yaml] if format is None else [format]
 
         try:
             mode = os.stat(path).st_mode
@@ -84,9 +81,8 @@ class DeveloperPackage(Package):
                 else:
                     # if format was not specified, verify that it has the
                     # right extension before trying to load
-                    if format is None:
-                        if os.path.splitext(path)[1] != format_.extension:
-                            continue
+                    if format is None and os.path.splitext(path)[1] != format_.extension:
+                        continue
                     filepath = path
                     exists = True
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -3,6 +3,7 @@
 
 
 from __future__ import annotations
+import contextlib
 
 import json
 import os
@@ -371,10 +372,7 @@ class PackageCache(object):
             names = os.listdir(path)
             names = [x for x in names if x.endswith(".json")]
 
-            if names:
-                prev = os.path.splitext(max(names))[0]
-            else:
-                prev = None
+            prev = os.path.splitext(max(names))[0] if names else None
 
             incname = get_next_base26(prev)
 
@@ -399,10 +397,8 @@ class PackageCache(object):
         def _while_copying() -> None:
             while still_copying:
                 time.sleep(self._COPYING_TIME_INC)
-                try:
+                with contextlib.suppress(BaseException):
                     os.utime(copying_filepath, None)
-                except:
-                    pass
 
         rootpath = os.path.join(path, incname)
         th = threading.Thread(target=_while_copying)
@@ -608,10 +604,7 @@ class PackageCache(object):
             with open(os.devnull, 'w') as devnull:
 
                 # don't suppress output if selftest running, easier to debug
-                if system.selftest_is_running:
-                    out_target = None
-                else:
-                    out_target = devnull
+                out_target = None if system.selftest_is_running else devnull
 
                 return subprocess.Popen(
                     args,
@@ -846,10 +839,8 @@ class PackageCache(object):
             lock.acquire(timeout=self._FILELOCK_TIMEOUT)
             yield
         finally:
-            try:
+            with contextlib.suppress(NotLocked):
                 lock.release()
-            except NotLocked:
-                pass
 
     def _run_caching_step(self, state, wait_for_copying: bool = False) -> bool:
         logger = state["logger"]

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -300,20 +300,14 @@ def _copy_variant_payload(src_variant: Variant,
     copy_func = partial(replacing_copy,
                         follow_symlinks=follow_symlinks)
 
-    if shallow:
-        maybe_symlink = replacing_symlink
-    else:
-        maybe_symlink = copy_func
+    maybe_symlink = replacing_symlink if shallow else copy_func
 
     # possibly make install path temporarily writable
     last_dir = get_existing_path(
         variant_install_path,
         topmost_path=os.path.dirname(dest_pkg_payload_path))
 
-    if last_dir and config.make_package_temporarily_writable:
-        ctxt = make_path_writable(last_dir)
-    else:
-        ctxt = with_noop()
+    ctxt = make_path_writable(last_dir) if last_dir and config.make_package_temporarily_writable else with_noop()
 
     # copy the variant payload
     with ctxt:
@@ -450,10 +444,7 @@ def _copy_package_include_modules(src_package: Package, dest_pkg_repo: PackageRe
     last_dir = get_existing_path(dest_include_modules_path,
                                  topmost_path=os.path.dirname(pkg_install_path))
 
-    if last_dir:
-        ctxt = make_path_writable(last_dir)
-    else:
-        ctxt = with_noop()
+    ctxt = make_path_writable(last_dir) if last_dir else with_noop()
 
     with ctxt:
         os.makedirs(dest_include_modules_path, exist_ok=True)

--- a/src/rez/package_filter.py
+++ b/src/rez/package_filter.py
@@ -382,10 +382,7 @@ class Rule(object):
         # parse form 'x(y)' into x, y
         label, txt = Rule._parse_label(txt)
         if label is None:
-            if '*' in txt:
-                label = "glob"
-            else:
-                label = "range"
+            label = "glob" if '*' in txt else "range"
         elif label not in types:
             raise ConfigurationError(
                 "'%s' is not a valid package filter type" % label)

--- a/src/rez/package_serialise.py
+++ b/src/rez/package_serialise.py
@@ -213,12 +213,9 @@ def _dump_package_data_py(items: list[tuple[str, Any]], buf: SupportsWrite) -> N
             lines.append("]")
             txt = '\n'.join(lines)
         else:
-            # default serialisation
+            # default serialization
             value_txt = pformat(value)
-            if '\n' in value_txt:
-                txt = "%s = \\\n%s" % (key, indent(value_txt))
-            else:
-                txt = "%s = %s" % (key, value_txt)
+            txt = "%s = \\\n%s" % (key, indent(value_txt)) if '\n' in value_txt else "%s = %s" % (key, value_txt)
 
         print(txt, file=buf)
         if i < len(items) - 1:

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -156,10 +156,7 @@ class PackageTestRunner(object):
 
         if run_on:
             def _select(value):
-                if isinstance(value, dict):
-                    value = value.get("run_on")
-                else:
-                    value = None
+                value = value.get("run_on") if isinstance(value, dict) else None
 
                 if value is None:
                     return ("default" in run_on)
@@ -175,10 +172,7 @@ class PackageTestRunner(object):
 
         if ran_once:
             def _select_kv(key, value) -> bool:
-                if isinstance(value, dict):
-                    value = value.get("on_variants")
-                else:
-                    value = None
+                value = value.get("on_variants") if isinstance(value, dict) else None
 
                 if value in (None, False):
                     return (key not in ran_once)
@@ -410,12 +404,9 @@ class PackageTestRunner(object):
                 continue
 
             # expand refs like {root} in commands
-            if isinstance(command, str):
-                command = variant.format(command)
-            else:
-                # Note that we convert the iterator to a list to
-                # make sure that we can consume the variable more than once.
-                command = [x for x in map(variant.format, command)]
+            # Note that we convert the iterator to a list to
+            # make sure that we can consume the variable more than once.
+            command = variant.format(command) if isinstance(command, str) else [x for x in map(variant.format, command)]
 
             if extra_test_args:
                 if isinstance(command, str):
@@ -429,10 +420,7 @@ class PackageTestRunner(object):
                     context.print_info(self.stdout)
                     print('')
 
-                if isinstance(command, str):
-                    cmd_str = command
-                else:
-                    cmd_str = ' '.join(map(quote, command))
+                cmd_str = command if isinstance(command, str) else ' '.join(map(quote, command))
 
                 self._print_header("Running test command: %s", cmd_str)
 

--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -144,10 +144,7 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
         # 'data' dict property, since it forwards data from its parent package.
         data.pop("config", None)
         if self.config:
-            if isinstance(self, Package):
-                config_dict = self.data.get("config")
-            else:
-                config_dict = self.parent.data.get("config")
+            config_dict = self.data.get("config") if isinstance(self, Package) else self.parent.data.get("config")
             data["config"] = config_dict
 
         if not include_release:
@@ -608,10 +605,7 @@ def get_package(name: str, version: Version | str, paths: list[str] | None = Non
     Returns:
         `Package` object, or None if the package was not found.
     """
-    if isinstance(version, str):
-        range_ = VersionRange("==%s" % version)
-    else:
-        range_ = VersionRange.from_version(version, "==")
+    range_ = VersionRange("==%s" % version) if isinstance(version, str) else VersionRange.from_version(version, "==")
 
     it = iter_packages(name, range_, paths)
     try:
@@ -902,12 +896,11 @@ def get_completions(prefix: str, paths: list[str] | None = None, family_only: bo
         Set of strings, may be empty.
     """
     op = None
-    if prefix:
-        if prefix[0] in ('!', '~'):
-            if family_only:
-                return set()
-            op = prefix[0]
-            prefix = prefix[1:]
+    if prefix and prefix[0] in ('!', '~'):
+        if family_only:
+            return set()
+        op = prefix[0]
+        prefix = prefix[1:]
 
     fam = None
     for ch in ('-', '@', '#'):

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -589,10 +589,7 @@ def _cmd(context, command):
     cmd_str = ' '.join(quote(x) for x in command)
     _log("running: %s" % cmd_str)
 
-    if context is None:
-        p = Popen(command)
-    else:
-        p = context.execute_shell(command=command, block=False)
+    p = Popen(command) if context is None else context.execute_shell(command=command, block=False)
 
     with p:
         p.wait()

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -233,13 +233,12 @@ class RezPluginType(object):
 
     def register_plugin_module(self, plugin_name, plugin_module, plugin_path):
         module_name = plugin_module.__name__
-        if os.path.dirname(plugin_module.__file__) != plugin_path:
-            if config.debug("plugins"):
-                # this should not happen but if it does, tell why.
-                print_warning(
-                    "plugin module %s is not loaded from current "
-                    "load path but reused from previous imported "
-                    "path: %s" % (module_name, plugin_module.__file__))
+        if os.path.dirname(plugin_module.__file__) != plugin_path and config.debug("plugins"):
+            # this should not happen but if it does, tell why.
+            print_warning(
+                "plugin module %s is not loaded from current "
+                "load path but reused from previous imported "
+                "path: %s" % (module_name, plugin_module.__file__))
 
         if (hasattr(plugin_module, "register_plugin")
                 and callable(plugin_module.register_plugin)):

--- a/src/rez/release_vcs.py
+++ b/src/rez/release_vcs.py
@@ -130,10 +130,7 @@ class ReleaseVCS(object):
         to find it, where 0 means it was found in the indicated path, 1 means it
         was found in that path's parent, etc. If not sucessful, returns None
         """
-        if cls.search_parents_for_root():
-            valid_dirs = walk_up_dirs(path)
-        else:
-            valid_dirs = [path]
+        valid_dirs = walk_up_dirs(path) if cls.search_parents_for_root() else [path]
         for i, current_path in enumerate(valid_dirs):
             if cls.is_valid_root(current_path):
                 return current_path, i

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 from rez import __version__, module_root_path
 from rez.package_repository import package_repository_manager
 from rez.solver import SolverCallbackReturn
@@ -290,10 +292,7 @@ class ResolvedContext(object):
         self.append_sys_path = True
 
         if package_caching is None:
-            if building:
-                package_caching = config.package_cache_during_build
-            else:
-                package_caching = True
+            package_caching = config.package_cache_during_build if building else True
         self.package_caching = package_caching
 
         if package_cache_async is None:
@@ -655,12 +654,11 @@ class ResolvedContext(object):
             overrides = set(x.name for x in package_requests if not x.conflict)
             rank_limiters = []
             for variant in self.resolved_packages:
-                if variant.name not in overrides:
-                    if len(variant.version) >= rank:
-                        version = variant.version.trim(rank - 1)
-                        version = next(version)
-                        req = "~%s<%s" % (variant.name, str(version))
-                        rank_limiters.append(req)
+                if variant.name not in overrides and len(variant.version) >= rank:
+                    version = variant.version.trim(rank - 1)
+                    version = next(version)
+                    req = "~%s<%s" % (variant.name, str(version))
+                    rank_limiters.append(req)
             request += rank_limiters
 
         return request
@@ -706,9 +704,8 @@ class ResolvedContext(object):
 
     def save(self, path: str) -> None:
         """Save the resolved context to file."""
-        with self._detect_bundle(path):
-            with open(path, 'w') as f:
-                self.write_to_buffer(f)
+        with self._detect_bundle(path), open(path, 'w') as f:
+            self.write_to_buffer(f)
 
     def write_to_buffer(self, buf: SupportsWrite) -> None:
         """Save the context to a buffer."""
@@ -748,9 +745,8 @@ class ResolvedContext(object):
     @classmethod
     def load(cls, path: str) -> ResolvedContext:
         """Load a resolved context from file."""
-        with cls._detect_bundle(path):
-            with open(path) as f:
-                context = cls.read_from_buffer(f, path)
+        with cls._detect_bundle(path), open(path) as f:
+            context = cls.read_from_buffer(f, path)
 
         context.set_load_path(path)
         return context
@@ -1366,10 +1362,7 @@ class ResolvedContext(object):
         Note:
             This does not alter the current python session.
         """
-        if parent_environ is None or parent_environ is os.environ:
-            target_environ = {}
-        else:
-            target_environ = parent_environ.copy()
+        target_environ = {} if parent_environ is None or parent_environ is os.environ else parent_environ.copy()
 
         interpreter = Python(target_environ=target_environ)
 
@@ -1863,10 +1856,8 @@ class ResolvedContext(object):
 
             yield
         finally:
-            try:
+            with contextlib.suppress(AttributeError):
                 delattr(cls.local, "bundle_path")
-            except AttributeError:
-                pass
 
     @classmethod
     def _get_bundle_path(cls) -> str | None:
@@ -2012,10 +2003,7 @@ class ResolvedContext(object):
     def _read_from_buffer(cls, buf: SupportsRead, identifier_str: str | None = None) -> ResolvedContext:
         content = buf.read()
 
-        if content.startswith('{'):  # assume json content
-            doc = json.loads(content)
-        else:
-            doc = yaml.load(content, Loader=yaml.FullLoader)
+        doc = json.loads(content) if content.startswith('{') else yaml.load(content, Loader=yaml.FullLoader)
 
         context = cls.from_dict(doc, identifier_str)
         return context
@@ -2119,10 +2107,7 @@ class ResolvedContext(object):
             pkgcache = None
 
         for pkg in resolved_pkgs:
-            if pkgcache:
-                cached_root = pkgcache.get_cached_root(pkg)
-            else:
-                cached_root = None
+            cached_root = pkgcache.get_cached_root(pkg) if pkgcache else None
 
             variant_binding = VariantBinding(
                 pkg, cached_root=cached_root, interpreter=executor.interpreter
@@ -2200,10 +2185,7 @@ class ResolvedContext(object):
 
                 if exc:
                     header = "Error in %s in package %r:\n" % (attr, pkg.uri)
-                    if self.verbosity >= 2:
-                        msg = header + str(exc)
-                    else:
-                        msg = header + exc.short_msg
+                    msg = header + str(exc) if self.verbosity >= 2 else header + exc.short_msg
 
                     raise PackageCommandError(msg)
 

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -322,10 +322,7 @@ class ActionManager(object):
 
         if expanded_key in self.environ:
             del self.environ[expanded_key]
-        if self.interpreter.expand_env_vars:
-            key = expanded_key
-        else:
-            key = unexpanded_key
+        key = expanded_key if self.interpreter.expand_env_vars else unexpanded_key
         self.interpreter.unsetenv(key)
 
     def resetenv(self, key, value, friends=None) -> None:
@@ -350,10 +347,7 @@ class ActionManager(object):
         if (expanded_key not in self.environ) and \
                 ((self.parent_variables is True) or (expanded_key in self.parent_variables)):
             self.environ[expanded_key] = self.parent_environ.get(expanded_key, '')
-            if self.interpreter.expand_env_vars:
-                key_ = expanded_key
-            else:
-                key_ = unexpanded_key
+            key_ = expanded_key if self.interpreter.expand_env_vars else unexpanded_key
             self.interpreter._saferefenv(key_)
 
         # *pend or setenv depending on whether this is first reference to the var
@@ -665,10 +659,9 @@ class Python(ActionInterpreter):
         return self.manager.environ
 
     def setenv(self, key, value: str | EscapedString) -> None:
-        if self.update_session:
-            if key == 'PYTHONPATH':
-                value = self.escape_string(value)
-                sys.path = value.split(self.pathsep)
+        if self.update_session and key == 'PYTHONPATH':
+            value = self.escape_string(value)
+            sys.path = value.split(self.pathsep)
 
     def unsetenv(self, key) -> None:
         pass
@@ -677,16 +670,14 @@ class Python(ActionInterpreter):
         pass
 
     def prependenv(self, key, value: str | EscapedString) -> None:
-        if self.update_session:
-            if key == 'PYTHONPATH':
-                value = self.escape_string(value)
-                sys.path.insert(0, value)
+        if self.update_session and key == 'PYTHONPATH':
+            value = self.escape_string(value)
+            sys.path.insert(0, value)
 
     def appendenv(self, key, value: str | EscapedString) -> None:
-        if self.update_session:
-            if key == 'PYTHONPATH':
-                value = self.escape_string(value)
-                sys.path.append(value)
+        if self.update_session and key == 'PYTHONPATH':
+            value = self.escape_string(value)
+            sys.path.append(value)
 
     def info(self, value) -> None:
         if not self.passive:
@@ -944,10 +935,7 @@ class EscapedString(object):
                 out = EscapedString(value, is_literal)
                 push = False
 
-            if current is None:
-                current = out
-            else:
-                current = current + out
+            current = out if current is None else current + out
             if push:
                 result.append(current)
                 current = None
@@ -1112,7 +1100,7 @@ class EnvironmentDict(MutableMapping):
         """
         self.manager = manager
         self._var_cache = dict((k, EnvironmentVariable(k, self))
-                               for k in manager.parent_environ.keys())
+                               for k in manager.parent_environ)
 
     def keys(self):
         return self._var_cache.keys()
@@ -1135,7 +1123,7 @@ class EnvironmentDict(MutableMapping):
         del self._var_cache[key]
 
     def __iter__(self):
-        for key in self._var_cache.keys():
+        for key in self._var_cache:
             yield key
 
     def __len__(self) -> int:
@@ -1332,10 +1320,7 @@ class RexExecutor(object):
         """Append system paths to $PATH."""
         from rez.shells import Shell, create_shell
 
-        if isinstance(self.interpreter, Shell):
-            sh = self.interpreter
-        else:
-            sh = create_shell()
+        sh = self.interpreter if isinstance(self.interpreter, Shell) else create_shell()
 
         for path in sh.get_syspaths():
             self.env.PATH.append(path)
@@ -1375,17 +1360,11 @@ class RexExecutor(object):
             Compiled code object.
         """
         if filename is None:
-            if isinstance(code, SourceCode):
-                filename = code.sourcename
-            else:
-                filename = "<string>"
+            filename = code.sourcename if isinstance(code, SourceCode) else "<string>"
 
         # compile
         try:
-            if isinstance(code, SourceCode):
-                pyc = code.compiled
-            else:
-                pyc = compile(code, filename, 'exec')
+            pyc = code.compiled if isinstance(code, SourceCode) else compile(code, filename, "exec")
         except SourceCodeError as e:
             reraise(e, RexError)
         except:

--- a/src/rez/serialise.py
+++ b/src/rez/serialise.py
@@ -145,10 +145,7 @@ def load_from_file(filepath: str, format_=FileFormat.py, update_data_callback=No
 
 def _load_from_file__key(filepath, format_, update_data_callback):
     st = os.stat(filepath)
-    if update_data_callback is None:
-        callback_key = 'None'
-    else:
-        callback_key = getattr(update_data_callback, "__name__", "None")
+    callback_key = "None" if update_data_callback is None else getattr(update_data_callback, "__name__", "None")
 
     return str(("package_file", filepath, str(format_), callback_key,
                 int(st.st_ino), st.st_mtime))
@@ -340,13 +337,9 @@ def process_python_objects(data: dict, filepath: str | None = None) -> dict:
                 if len(args) not in (0, 1):
                     raise ResourceError("@early decorated function must "
                                         "take zero or one args only")
-                if args:
-                    # this 'data' arg support isn't needed anymore, but I'm
-                    # supporting it til I know nobody is using it...
-                    #
-                    value_ = fn(data)
-                else:
-                    value_ = fn()
+                # this 'data' arg support isn't needed anymore, but I'm
+                # supporting it til I know nobody is using it...
+                value_ = fn(data) if args else fn()
 
                 # process again in case this is a function returning a function
                 return _process(value_)

--- a/src/rez/shells.py
+++ b/src/rez/shells.py
@@ -540,10 +540,7 @@ class UnixShell(Shell):
 
         cmd = []
         if pre_command:
-            if isinstance(pre_command, str):
-                cmd = pre_command.strip().split()
-            else:
-                cmd = pre_command
+            cmd = pre_command.strip().split() if isinstance(pre_command, str) else pre_command
         cmd.extend([self.executable, target_file])
 
         if config.debug("shell_startup"):

--- a/src/rez/solver.py
+++ b/src/rez/solver.py
@@ -641,9 +641,8 @@ class _PackageVariantSlice(_Common):
         if range_.is_any():
             return self
 
-        if self.solver.optimised:
-            if range_ in self.been_intersected_with:
-                return self
+        if self.solver.optimised and range_ in self.been_intersected_with:
+            return self
 
         if self.pr:
             self.pr.passive("intersecting %s wrt range '%s'...", self, range_)
@@ -676,9 +675,8 @@ class _PackageVariantSlice(_Common):
             reqstr = _short_req_str(package_request)
             self.pr.passive("reducing %s wrt %s...", self, reqstr)
 
-        if self.solver.optimised:
-            if package_request in self.been_reduced_by:
-                return (self, [])
+        if self.solver.optimised and package_request in self.been_reduced_by:
+            return (self, [])
 
         if (package_request.range is None) or \
                 (package_request.name not in self.fam_requires):
@@ -804,10 +802,7 @@ class _PackageVariantSlice(_Common):
 
             if self.pr:
                 if common_fams:
-                    if len(common_fams) == 1:
-                        reason_str = next(iter(common_fams))
-                    else:
-                        reason_str = ", ".join(common_fams)
+                    reason_str = next(iter(common_fams)) if len(common_fams) == 1 else ", ".join(common_fams)
                 else:
                     reason_str = "first variant"
                 self.pr("split (reason: %s) %s into %s and %s",
@@ -816,10 +811,7 @@ class _PackageVariantSlice(_Common):
             return slice_, next_slice
 
         # determine if we need to find first variant without common dependency
-        if len(self) > 2:
-            fams = self.first_variant.request_fams - self.extracted_fams
-        else:
-            fams = None
+        fams = self.first_variant.request_fams - self.extracted_fams if len(self) > 2 else None
 
         if not fams:
             # trivial case, split on first variant
@@ -1663,10 +1655,7 @@ class _ResolvePhase(_Common):
                 return id_
 
             label = str(request)
-            if initial_request:
-                color = request_color
-            else:
-                color = node_color
+            color = request_color if initial_request else node_color
 
             id_ = _add_node(label, color, "filled,dashed")
             request_nodes[request] = id_
@@ -1744,7 +1733,7 @@ class _ResolvePhase(_Common):
                 _add_edge(id1, id2)
 
         # add extraction intersections
-        extracted_fams = set(x[1] for x in self.extractions.keys())
+        extracted_fams = set(x[1] for x in self.extractions)
         for fam in extracted_fams:
             requests = [v for k, v in self.extractions.items() if k[1] == fam]
             if len(requests) > 1:
@@ -1868,10 +1857,7 @@ class _ResolvePhase(_Common):
         return g
 
     def _is_solved(self) -> bool:
-        for scope in self.scopes:
-            if not scope._is_solved():
-                return False
-        return True
+        return all(scope._is_solved() for scope in self.scopes)
 
     def _get_solved_variants(self) -> list[PackageVariant]:
         variants = []

--- a/src/rez/status.py
+++ b/src/rez/status.py
@@ -273,10 +273,7 @@ class Status(object):
             return False
 
         def _print_package(package) -> None:
-            if isinstance(package, Package):
-                name = package.qualified_name
-            else:
-                name = package.qualified_package_name  # Variant
+            name = package.qualified_name if isinstance(package, Package) else package.qualified_package_name
             _pr("Package:  %s" % name)
             path_str = "URI:      %s" % package.uri
             if package.is_local:
@@ -352,10 +349,7 @@ class Status(object):
     def _print_info(self, buf=sys.stdout) -> None:
         lines = ["Using Rez v%s" % __version__]
         if self.context:
-            if self.context.load_path:
-                line = "\nActive Context: %s" % self.context.load_path
-            else:
-                line = "\nIn Active Context."
+            line = "\nActive Context: %s" % self.context.load_path if self.context.load_path else "\nIn Active Context."
             lines.append(line)
         else:
             lines.append("\nNo active context.")

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -516,7 +516,9 @@ class Suite(object):
     @classmethod
     def load(cls, path: str) -> Suite:
         if not os.path.exists(path):
-            open(path)  # raise IOError
+            # Using open for the side effect of raising FileNotFoundError
+            with open(path):
+                pass
         filepath = os.path.join(path, "suite.yaml")
         if not os.path.isfile(filepath):
             raise SuiteError("Not a suite: %r" % path)

--- a/src/rez/system.py
+++ b/src/rez/system.py
@@ -132,26 +132,18 @@ class System(object):
                 shell = next(iter(shells))  # give up - just choose a shell
 
             # sh has to be handled as a special case
-            if shell == "sh":
-                if os.path.islink("/bin/sh"):
-                    path = os.readlink("/bin/sh")
-                    shell2 = os.path.split(path)[-1]
+            if shell == "sh" and os.path.islink("/bin/sh"):
+                path = os.readlink("/bin/sh")
+                shell2 = os.path.split(path)[-1]
 
-                    if shell2 == "bash":
-                        # bash switches to sh-like shell when invoked as sh,
-                        # so we want to use the sh shell plugin
-                        pass
-                    elif shell2 == "dash":
-                        # dash doesn't have an sh emulation mode, so we have
-                        # to use the dash shell plugin
-                        if "dash" in shells:
-                            shell = "dash"
-                        else:
-                            # this isn't good!
-                            if "bash" in shells:
-                                shell = "bash"  # fall back on bash
-                            else:
-                                shell = next(iter(shells))  # give up - just choose a shell
+                if shell2 == "bash":
+                    # bash switches to sh-like shell when invoked as sh,
+                    # so we want to use the sh shell plugin
+                    pass
+                elif shell2 == "dash":
+                    # dash doesn't have an sh emulation mode, so we have
+                    # to use the dash shell plugin
+                    shell = "dash" if "dash" in shells else "bash" if "bash" in shells else next(iter(shells))
 
             # TODO: remove this when/if dash support added
             if shell == "dash":
@@ -233,10 +225,7 @@ class System(object):
         i = len(parts) - 1 - i  # unreverse the index
 
         # find rez bin path and look for the production install marker file
-        if platform.system() == "Windows":
-            bin_dirname = "Scripts"
-        else:
-            bin_dirname = "bin"
+        bin_dirname = "Scripts" if platform.system() == "Windows" else "bin"
 
         binpath = os.path.sep.join(parts[:i] + [bin_dirname, "rez"])
 

--- a/src/rez/tests/test_amqp.py
+++ b/src/rez/tests/test_amqp.py
@@ -256,12 +256,9 @@ class TestInitLogging(TestBase):
     )
 
     def _write_logging_conf(self) -> str:
-        f = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".ini", delete=False
-        )
-        f.write(self._LOGGING_INI)
-        f.close()
-        return f.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+            f.write(self._LOGGING_INI)
+            return f.name
 
     @patch("logging.config.fileConfig")
     def test_logging_conf_does_not_suppress_pika(self, mock_file_config) -> None:

--- a/src/rez/tests/test_cli.py
+++ b/src/rez/tests/test_cli.py
@@ -54,7 +54,7 @@ class TestImports(TestBase):
         if not system.rez_bin_path:
             self.skipTest("Not a production install")
 
-        for toolname in get_specifications().keys():
+        for toolname in get_specifications():
             if toolname.startswith('_'):
                 continue
 
@@ -95,9 +95,8 @@ class TestComplete(TestBase):
 
         parser = setup_parser()
         with TemporaryFile(mode="w+") as t:
-            with _disable_fd_9():
-                with self.assertRaises(SystemExit) as cm:
-                    autocomplete(parser, output_stream=t, exit_method=sys.exit)
+            with _disable_fd_9(), self.assertRaises(SystemExit) as cm:
+                autocomplete(parser, output_stream=t, exit_method=sys.exit)
             self.assertEqual(cm.exception.code, 0)
             t.seek(0)
             return set(t.read().split(self.IFS))

--- a/src/rez/tests/test_commands.py
+++ b/src/rez/tests/test_commands.py
@@ -61,9 +61,7 @@ class TestCommands(TestBase):
                            "PATH"])
 
         for cmd in commands:
-            if isinstance(cmd, (Comment, Shebang)):
-                continue
-            elif isinstance(cmd, EnvAction) and cmd.key in ignore_keys:
+            if isinstance(cmd, (Comment, Shebang)) or (isinstance(cmd, EnvAction) and cmd.key in ignore_keys):
                 continue
             else:
                 commands_.append(cmd)

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -320,27 +320,23 @@ class TestDeprecations(TestBase, TempdirMixin):
             "packages_path": _Deprecation("0.0.0"),
         }
 
-        with unittest.mock.patch(
-            "rez.config._deprecated_settings",
-            fake_deprecated_settings
-        ):
-            with restore_os_environ():
-                os.environ["HOME"] = user_home
-                # On Windows, os.path.expanduser will read HOME and then USERPROFILE with Python 3.7.
-                # https://docs.python.org/3.7/library/os.path.html#os.path.expanduser
-                # Also on Windows but for Python 3.8+, it will look for USERPROFILE and then HOME.
-                # https://docs.python.org/3.8/library/os.path.html#os.path.expanduser
-                os.environ["USERPROFILE"] = user_home
-                config = Config._create_main_config()
-                with self.assertWarns(RezDeprecationWarning) as warning:
-                    _ = config.data
-                    # Assert just to ensure the test was set up properly.
-                    self.assertEqual(config.data["packages_path"], ["/tmp/asd"])
+        with unittest.mock.patch("rez.config._deprecated_settings", fake_deprecated_settings), restore_os_environ():
+            os.environ["HOME"] = user_home
+            # On Windows, os.path.expanduser will read HOME and then USERPROFILE with Python 3.7.
+            # https://docs.python.org/3.7/library/os.path.html#os.path.expanduser
+            # Also on Windows but for Python 3.8+, it will look for USERPROFILE and then HOME.
+            # https://docs.python.org/3.8/library/os.path.html#os.path.expanduser
+            os.environ["USERPROFILE"] = user_home
+            config = Config._create_main_config()
+            with self.assertWarns(RezDeprecationWarning) as warning:
+                _ = config.data
+                # Assert just to ensure the test was set up properly.
+                self.assertEqual(config.data["packages_path"], ["/tmp/asd"])
 
-                self.assertEqual(
-                    str(warning.warning),
-                    "config setting named 'packages_path' is deprecated and will be removed in 0.0.0.",
-                )
+            self.assertEqual(
+                str(warning.warning),
+                "config setting named 'packages_path' is deprecated and will be removed in 0.0.0.",
+            )
 
     def test_deprecation_from_env_var(self) -> None:
         fake_deprecated_settings = {

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -5,6 +5,7 @@
 """
 Test cases for package_order.py (package ordering)
 """
+import contextlib
 import json
 
 from rez.config import config
@@ -312,10 +313,8 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         }))
 
         # Clear @classproperty cache
-        try:
+        with contextlib.suppress(AttributeError):
             delattr(PackageOrderList, '_class_property_singleton')
-        except AttributeError:
-            pass
         self.assertEqual(expected, PackageOrderList.singleton)
 
     def test_singleton_novalue(self) -> None:
@@ -323,10 +322,8 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         config.override("package_orderers", None)
 
         # Clear @classproperty cache
-        try:
+        with contextlib.suppress(AttributeError):
             delattr(PackageOrderList, '_class_property_singleton')
-        except AttributeError:
-            pass
 
         self.assertEqual(PackageOrderList(), PackageOrderList.singleton)
 

--- a/src/rez/tests/test_rex.py
+++ b/src/rez/tests/test_rex.py
@@ -373,8 +373,8 @@ class TestRex(TestBase):
 
         def _rex_1():
             return {
-                "A": "A" in env.keys(),
-                "B": "B" in env.keys(),
+                "A": "A" in env.keys(),  # noqa: SIM118
+                "B": "B" in env.keys(),  # noqa: SIM118
             }
 
         def _rex_2():

--- a/src/rez/tests/test_utils_filesystem.py
+++ b/src/rez/tests/test_utils_filesystem.py
@@ -103,14 +103,13 @@ class TestFileSystem(TestBase, TempdirMixin):
         self.assertFalse(os.path.exists(src))
 
     def test_safe_rmtree_with_file_not_found(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error):
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error):  # noqa: SIM117
             with self.assertRaises(FileNotFoundError):
                 filesystem.safe_rmtree("path")
 
     def test_safe_rmtree_with_other_error(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
-            with self.assertRaises(PermissionError):
-                filesystem.safe_rmtree("path")
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error), self.assertRaises(PermissionError):
+            filesystem.safe_rmtree("path")
 
     def test_safe_rmtree_with_file_not_found_and_apple_double(self) -> None:
         with unittest.mock.patch("shutil.rmtree", wraps=rmtree_file_not_found_error) as mock_rmtree:
@@ -122,6 +121,5 @@ class TestFileSystem(TestBase, TempdirMixin):
                     filesystem.safe_rmtree("._path")
 
     def test_safe_rmtree_with_other_error_and_apple_double(self) -> None:
-        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error):
-            with self.assertRaises(PermissionError):
-                filesystem.safe_rmtree("._path")
+        with unittest.mock.patch("shutil.rmtree", wraps=rmtree_permission_error), self.assertRaises(PermissionError):
+            filesystem.safe_rmtree("._path")

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -2,6 +2,7 @@
 # Copyright Contributors to the Rez Project
 
 
+import contextlib
 import unittest
 from rez import module_root_path
 from rez.config import config, _create_locked_config
@@ -262,10 +263,8 @@ def per_available_shell(exclude=None):
                 # Remove __wrapped__ because py.test will try to look at __wrapped__
                 # to determine which parameters should be used with this test case,
                 # and obviously we don't need it to do any parameterization.
-                try:
+                with contextlib.suppress(AttributeError):
                     del standalone_func.__wrapped__
-                except AttributeError:
-                    pass
                 return standalone_func
 
         return rez_parametrized.expand(shells)

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -34,7 +34,7 @@ class ProgressBar(Bar):
         from rez.config import config
 
         if config.quiet or not config.show_progress:
-            self.file = open(os.devnull, 'w')
+            self.file = open(os.devnull, 'w')  # noqa: SIM115
             self.close_file = True
             self.hide_cursor = False
         else:
@@ -80,10 +80,7 @@ def shlex_join(value: Iterable[str], unsafe_regex=None,
             return s
 
         for from_, to_ in (replacements or []):
-            if isinstance(from_, str):
-                s = s.replace(from_, to_)
-            else:
-                s = from_.sub(to_, s)  # assume from_ is re.compile
+            s = s.replace(from_, to_) if isinstance(from_, str) else from_.sub(to_, s)
 
         return enclose_with + s + enclose_with
 

--- a/src/rez/utils/backcompat.py
+++ b/src/rez/utils/backcompat.py
@@ -32,10 +32,7 @@ def convert_old_variant_handle(handle_dict):
 
     path = handle_dict["path"]
     filename = os.path.basename(path)
-    if os.path.splitext(filename)[0] == "package":
-        key = "filesystem.variant"
-    else:
-        key = "filesystem.variant.combined"
+    key = "filesystem.variant" if os.path.splitext(filename)[0] == "package" else "filesystem.variant.combined"
 
     return dict(key=key, variables=variables)
 

--- a/src/rez/utils/base26.py
+++ b/src/rez/utils/base26.py
@@ -59,10 +59,7 @@ def create_unique_base26_symlink(path: str, source: str) -> str:
             if os.path.islink(os.path.join(path, x))
         ]
 
-        if names:
-            prev = max(names)
-        else:
-            prev = None
+        prev = max(names) if names else None
 
         linkname = get_next_base26(prev)
         linkpath = os.path.join(path, linkname)

--- a/src/rez/utils/data_utils.py
+++ b/src/rez/utils/data_utils.py
@@ -189,7 +189,7 @@ def get_dict_diff(d1, d2):
                     else:
                         changed.append(namespace + [k1])
 
-        for k2 in d2_.keys():
+        for k2 in d2_:
             if k2 not in d1_:
                 added.append(namespace + [k2])
 
@@ -342,10 +342,7 @@ class AttrDictWrapper(MutableMapping[str, Any]):
         return self.__dict__['_data']
 
     def __getattr__(self, attr: str) -> Any:
-        if attr.startswith('__') and attr.endswith('__'):
-            d = self.__dict__
-        else:
-            d = self._data
+        d = self.__dict__ if attr.startswith('__') and attr.endswith('__') else self._data
         try:
             return d[attr]
         except KeyError:

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -434,10 +434,7 @@ def copytree(src: str, dst: str, symlinks: bool = False, ignore=None, hardlinks:
     '''copytree that supports hard-linking
     '''
     names = os.listdir(src)
-    if ignore is not None:
-        ignored_names = ignore(src, names)
-    else:
-        ignored_names = set()
+    ignored_names = ignore(src, names) if ignore is not None else set()
 
     if hardlinks:
         def copy(srcname, dstname) -> None:

--- a/src/rez/utils/memcached.py
+++ b/src/rez/utils/memcached.py
@@ -358,10 +358,7 @@ def memcached(servers, key=None, from_cache=None, to_cache=None, time: int = 0,
         if servers:
             def wrapper(*nargs, **kwargs):
                 with memcached_client(servers, debug=debug) as client:
-                    if key:
-                        cache_key = key(*nargs, **kwargs)
-                    else:
-                        cache_key = default_key(func, *nargs, **kwargs)
+                    cache_key = key(*nargs, **kwargs) if key else default_key(func, *nargs, **kwargs)
 
                     # get
                     result = client.get(cache_key)

--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -199,10 +199,7 @@ def pip_specifier_to_rez_requirement(specifier):
     # 1 --> 2; 1.2 --> 1.3; 1.a2 -> 1.0
     def next_ver(rez_ver):
         parts = rez_ver.split('.')
-        if is_release(rez_ver):
-            parts = parts[:-1] + [str(int(parts[-1]) + 1)]
-        else:
-            parts = parts[:-1] + ["0"]
+        parts = parts[:-1] + [str(int(parts[-1]) + 1)] if is_release(rez_ver) else parts[:-1] + ["0"]
         return '.'.join(parts)
 
     # 1 --> 1.1; 1.2 --> 1.2.1; 1.a2 --> 1.0
@@ -698,10 +695,7 @@ def normalize_requirement(requirement):
         marker_str = requirement.get("environment")
 
         # conditional extra, equivalent to: 'foo ; extra = "doc"'
-        if extra:
-            conditional_extras = set([extra])
-        else:
-            conditional_extras = None
+        conditional_extras = set([extra]) if extra else None
 
         for req_str in requires:
             req = packaging_Requirement(req_str)

--- a/src/rez/utils/platform_.py
+++ b/src/rez/utils/platform_.py
@@ -543,7 +543,7 @@ class WindowsPlatform(Platform):
         import subprocess
         try:
             p = Popen(
-                'wmic cpu get NumberOfCores /value'.split(),
+                ("wmic",  "cpu", "get", "NumberOfCores", "/value"),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True
             )

--- a/src/rez/utils/schema.py
+++ b/src/rez/utils/schema.py
@@ -41,7 +41,7 @@ def schema_keys(schema) -> set[str]:
     dict_ = schema._schema
     assert isinstance(dict_, dict)
 
-    for key in dict_.keys():
+    for key in dict_:
         key_ = _get_leaf(key)
         if isinstance(key_, str):
             keys.add(key_)

--- a/src/rez/utils/scope.py
+++ b/src/rez/utils/scope.py
@@ -234,7 +234,7 @@ class ScopeContext(object):
         return self.scope_stack[-1].to_dict()
 
     def __str__(self) -> str:
-        names = ('.'.join(y for y in x) for x in self.scopes.keys())
+        names = ('.'.join(y for y in x) for x in self.scopes)
         return "%r" % (tuple(names),)
 
 

--- a/src/rez/utils/sourcecode.py
+++ b/src/rez/utils/sourcecode.py
@@ -191,10 +191,7 @@ class SourceCode(Generic[T]):
 
     @property
     def sourcename(self) -> str:
-        if self.filepath:
-            filename = self.filepath
-        else:
-            filename = "string"
+        filename = self.filepath or "string"
 
         if self.funcname:
             filename += ":%s" % self.funcname
@@ -239,10 +236,7 @@ class SourceCode(Generic[T]):
 
     def to_text(self, funcname: str) -> str:
         # don't indent code if already indented
-        if self.source[0] in (' ', '\t'):
-            source = self.source
-        else:
-            source = indent(self.source)
+        source = self.source if self.source[0] in (' ', '\t') else indent(self.source)
 
         txt = "def %s():\n%s" % (funcname, source)
 

--- a/src/rez/utils/which.py
+++ b/src/rez/utils/which.py
@@ -76,10 +76,7 @@ def which(cmd: str, mode=os.F_OK | os.X_OK, path: str | None = None, env=None) -
             # target's extension matches any of the expected path extensions.
             #
             realfile = os.path.realpath(os.path.join(normdir, cmd)).lower()
-            if any(realfile.endswith(x) for x in pathext):
-                files = [cmd]
-            else:
-                files = [(cmd + ext) for ext in pathext]
+            files = [cmd] if any(realfile.endswith(x) for x in pathext) else [cmd + ext for ext in pathext]
         else:
             files = [cmd]
 

--- a/src/rez/wrapper.py
+++ b/src/rez/wrapper.py
@@ -75,10 +75,7 @@ class Wrapper(object):
         Returns:
             Return code of the command, or 0 if the command is not run.
         """
-        if self.prefix_char is None:
-            prefix_char = config.suite_alias_prefix_char
-        else:
-            prefix_char = self.prefix_char
+        prefix_char = config.suite_alias_prefix_char if self.prefix_char is None else self.prefix_char
 
         if prefix_char == '':
             # empty prefix char means we don't support the '+' args

--- a/src/rezgui/app.py
+++ b/src/rezgui/app.py
@@ -18,7 +18,8 @@ def get_context_files(filepaths):
             else:
                 raise IOError("Not a file: %s" % path)
         else:
-            open(path)  # raise IOError
+            # Use side effect to raise FileNotFoundError
+            open(path)  # noqa: SIM115
 
     return context_files
 

--- a/src/rezgui/dialogs/WriteGraphDialog.py
+++ b/src/rezgui/dialogs/WriteGraphDialog.py
@@ -26,10 +26,7 @@ class Writer(QtCore.QObject):
             self.process.terminate()
 
     def write_graph(self) -> None:
-        if self.prune_to:
-            graph_str = prune_graph(self.graph_str, self.prune_to)
-        else:
-            graph_str = self.graph_str
+        graph_str = prune_graph(self.graph_str, self.prune_to) if self.prune_to else self.graph_str
 
         error_msg = ''
         try:

--- a/src/rezgui/widgets/ContextResolveTimeLabel.py
+++ b/src/rezgui/widgets/ContextResolveTimeLabel.py
@@ -28,10 +28,7 @@ class ContextResolveTimeLabel(QtWidgets.QLabel, ContextViewMixin):
 
         minutes = (int(time.time()) - context.created) / 60
 
-        if minutes:
-            time_txt = readable_time_duration(minutes * 60)
-        else:
-            time_txt = "moments"
+        time_txt = readable_time_duration(minutes * 60) if minutes else "moments"
         self.setText("resolved %s ago" % time_txt)
         self.timer.start()
 

--- a/src/rezgui/widgets/ContextTableWidget.py
+++ b/src/rezgui/widgets/ContextTableWidget.py
@@ -673,9 +673,8 @@ class ContextTableWidget(QtWidgets.QTableWidget, ContextViewMixin):
         self.setItem(row, column, item)
 
     def _packageTextChanged(self, row, column, txt) -> None:
-        if txt:
-            if self._set_package_cell(row + 1, column):
-                self._update_request_column(column, self.context_model)
+        if txt and self._set_package_cell(row + 1, column):
+            self._update_request_column(column, self.context_model)
 
     def _packageFocusOutViaKeyPress(self, row, column, txt) -> None:
         if txt:

--- a/src/rezgui/widgets/SearchableTextEdit.py
+++ b/src/rezgui/widgets/SearchableTextEdit.py
@@ -22,10 +22,7 @@ class SearchableTextEdit(QtWidgets.QTextEdit):
             return
 
         txt = str(self.textCursor().selectedText()).strip()
-        if len(txt) < 32 and len(txt.split()) == 1:
-            initial_word = txt
-        else:
-            initial_word = None
+        initial_word = txt if len(txt) < 32 and len(txt.split()) == 1 else None
 
         self.popup = FindPopup(self, "bottomLeft", initial_word=initial_word,
                                close_on_find=False, parent=self)

--- a/src/rezgui/widgets/ToolWidget.py
+++ b/src/rezgui/widgets/ToolWidget.py
@@ -107,8 +107,5 @@ class ToolWidget(QtWidgets.QWidget):
         QtWidgets.QMessageBox.information(self, "Processes", txt)
 
     def set_instance_count(self, nprocs) -> None:
-        if nprocs:
-            txt = "%d instances running..." % nprocs
-        else:
-            txt = ""
+        txt = "%d instances running..." % nprocs if nprocs else ""
         self.instances_label.setText(txt)

--- a/src/rezgui/widgets/VariantCellWidget.py
+++ b/src/rezgui/widgets/VariantCellWidget.py
@@ -93,10 +93,7 @@ class VariantCellWidget(QtWidgets.QWidget, ContextViewMixin):
         self.depends_icon.setVisible(bool(access))
         if access:
             enable = (access == 2)
-            if access == 1:
-                desc = "%s indirectly requires %s"
-            else:
-                desc = "%s requires %s"
+            desc = "%s indirectly requires %s" if access == 1 else "%s requires %s"
             self.depends_icon.setToolTip(desc % (self.variant.name, variant.name))
             self.depends_icon.setEnabled(enable)
 
@@ -173,11 +170,9 @@ class VariantCellWidget(QtWidgets.QWidget, ContextViewMixin):
                     # test if variant is latest within package filter
                     if (not ticked
                             and packages2
-                            and package_filter):
-                        if all(package_filter.excludes(x) for x in packages2):
-                            new_icons.append(("yellow_tick",
-                                              "package is latest possible"))
-                            ticked = True
+                            and package_filter) and all(package_filter.excludes(x) for x in packages2):
+                        new_icons.append(("yellow_tick", "package is latest possible"))
+                        ticked = True
 
                     # test if variant was latest package at time of resolve
                     if not ticked and self.variant.timestamp:

--- a/src/rezgui/widgets/VariantSummaryWidget.py
+++ b/src/rezgui/widgets/VariantSummaryWidget.py
@@ -78,14 +78,12 @@ class VariantSummaryWidget(QtWidgets.QWidget):
                 rows.append(("authors: ", txt))
             if variant.requires:
                 var_strs = [str(x) for x in variant.requires]
-                if isinstance(variant, Variant):
-                    # put variant-specific requires in square brackets
-                    if variant.requires:
-                        index = find_last_sublist(variant.requires, variant.requires)
-                        if index is not None:
-                            var_strs[index] = "[%s" % var_strs[index]
-                            index2 = index + len(variant.requires) - 1
-                            var_strs[index2] = "%s]" % var_strs[index2]
+                if isinstance(variant, Variant) and variant.requires:
+                    index = find_last_sublist(variant.requires, variant.requires)
+                    if index is not None:
+                        var_strs[index] = "[%s" % var_strs[index]
+                        index2 = index + len(variant.requires) - 1
+                        var_strs[index2] = "%s]" % var_strs[index2]
                 txt = "; ".join(var_strs)
                 rows.append(("requires: ", txt))
 

--- a/src/rezgui/widgets/VariantVersionsWidget.py
+++ b/src/rezgui/widgets/VariantVersionsWidget.py
@@ -113,10 +113,7 @@ class VariantVersionsWidget(PackageLoadingWidget, ContextViewMixin):
         if diff_num is None:
             # normal mode
             if self.table.version_index == 0:
-                if self.table.num_versions == 1:
-                    txt = "the only package"
-                else:
-                    txt = "the latest package"
+                txt = "the only package" if self.table.num_versions == 1 else "the latest package"
             else:
                 nth = positional_number_string(self.table.version_index + 1)
                 txt = "the %s latest package" % nth

--- a/src/rezgui/windows/MainWindow.py
+++ b/src/rezgui/windows/MainWindow.py
@@ -131,10 +131,9 @@ class MainWindow(QtWidgets.QMainWindow):
         context_save_as = False
 
         subwindow = self.mdi.activeSubWindow()
-        if subwindow:
-            if isinstance(subwindow, ContextSubWindow):
-                context_save = subwindow.is_saveable()
-                context_save_as = subwindow.is_save_as_able()
+        if subwindow and isinstance(subwindow, ContextSubWindow):
+            context_save = subwindow.is_saveable()
+            context_save_as = subwindow.is_save_as_able()
 
         self.save_context_action.setEnabled(context_save)
         self.save_context_as_action.setEnabled(context_save_as)
@@ -154,10 +153,9 @@ class MainWindow(QtWidgets.QMainWindow):
         copy_resolve = False
 
         subwindow = self.mdi.activeSubWindow()
-        if subwindow:
-            if isinstance(subwindow, ContextSubWindow):
-                copy_request = True
-                copy_resolve = bool(subwindow.context())
+        if subwindow and isinstance(subwindow, ContextSubWindow):
+            copy_request = True
+            copy_resolve = bool(subwindow.context())
 
         self.copy_request_action.setEnabled(copy_request)
         self.copy_resolve_action.setEnabled(copy_resolve)

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -177,10 +177,7 @@ class LocalBuildProcess(BuildProcessHelper):
         last_dir = get_existing_path(variant_install_path,
                                      topmost_path=install_path)
 
-        if last_dir and config.make_package_temporarily_writable:
-            ctxt = make_path_writable(last_dir)
-        else:
-            ctxt = with_noop()
+        ctxt = make_path_writable(last_dir) if last_dir and config.make_package_temporarily_writable else with_noop()
 
         with ctxt:
             if install:

--- a/src/rezplugins/build_system/cmake.py
+++ b/src/rezplugins/build_system/cmake.py
@@ -120,10 +120,7 @@ class CMakeBuildSystem(BuildSystem):
                 print(s)
 
         # find cmake binary
-        if self.settings.cmake_binary:
-            exe = self.settings.cmake_binary
-        else:
-            exe = context.which("cmake", fallback=True)
+        exe = self.settings.cmake_binary or context.which("cmake", fallback=True)
         if not exe:
             raise RezCMakeError("could not find cmake binary")
         found_exe = which(exe)
@@ -220,10 +217,9 @@ class CMakeBuildSystem(BuildSystem):
         cmd = [make_binary] + (self.child_build_args or [])
 
         # nmake has no -j
-        if make_binary != "nmake":
-            if not any(x.startswith("-j") for x in (self.child_build_args or [])):
-                n = variant.config.build_thread_count
-                cmd.append("-j%d" % n)
+        if make_binary != "nmake" and not any(x.startswith("-j") for x in (self.child_build_args or [])):
+            n = variant.config.build_thread_count
+            cmd.append("-j%d" % n)
 
         # execute make within the build env
         _pr("\nExecuting: %s" % ' '.join(cmd))

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -7,6 +7,7 @@ Filesystem-based package repository
 """
 from __future__ import annotations
 
+import contextlib
 from contextlib import contextmanager
 from functools import lru_cache
 import os.path
@@ -233,10 +234,8 @@ class FileSystemPackageResource(PackageResourceHelper):
                 filepath = os.path.join(path_, "release_time.txt")
                 if os.path.isfile(filepath):
                     value = load_from_file(filepath, FileFormat.txt)
-                    try:
+                    with contextlib.suppress(BaseException):
                         data["timestamp"] = int(value.strip())
-                    except:
-                        pass
         return data
 
     @staticmethod
@@ -613,12 +612,8 @@ class FileSystemPackageRepository(PackageRepository):
         pkg_name = parts[0]
 
         if len(parts) == 2:
-            if '<' in part:
-                # "combined" package type, like 'mypkg/package.py<1.0.0>'
-                pkg_ver_str = parts[1][1:-1]
-            else:
-                # 'mypkg/package.py' (unversioned)
-                pkg_ver_str = ''
+            # "combined" package type, like 'mypkg/package.py<1.0.0>' or 'mypkg/package.py' (unversioned)
+            pkg_ver_str = parts[1][1:-1] if "<" in part else ""
         elif len(parts) == 3:
             # typical case: 'mypkg/1.0.0/package.py'
             pkg_ver_str = parts[1]
@@ -1003,10 +998,8 @@ class FileSystemPackageRepository(PackageRepository):
             yield
 
         finally:
-            try:
+            with contextlib.suppress(NotLocked):
                 lock.release()
-            except NotLocked:
-                pass
 
     def clear_caches(self) -> None:
         super(FileSystemPackageRepository, self).clear_caches()
@@ -1184,10 +1177,7 @@ class FileSystemPackageRepository(PackageRepository):
         return [x for x in package_resource.iter_variants()]
 
     def _get_file(self, path: str, package_filename=None) -> tuple[str, FileFormat] | tuple[None, None]:
-        if package_filename:
-            package_filenames = [package_filename]
-        else:
-            package_filenames = _settings.package_filenames
+        package_filenames = [package_filename] if package_filename else _settings.package_filenames
 
         for name in package_filenames:
             # TODO: Deprecate YAML
@@ -1273,10 +1263,7 @@ class FileSystemPackageRepository(PackageRepository):
         #
         def _get_package_data(pkg: PackageRepositoryResourceWrapper):
             data = pkg.validated_data()
-            if hasattr(pkg, "_data"):
-                raw_data = pkg._data
-            else:
-                raw_data = pkg.resource._data
+            raw_data = pkg._data if hasattr(pkg, "_data") else pkg.resource._data
 
             raw_config_data = raw_data.get('config')
             data.pop("config", None)
@@ -1405,10 +1392,7 @@ class FileSystemPackageRepository(PackageRepository):
 
         # create version dir if it doesn't already exist
         family_path = os.path.join(self.location, variant_name)
-        if variant_version:
-            pkg_base_path = os.path.join(family_path, str(variant_version))
-        else:
-            pkg_base_path = family_path
+        pkg_base_path = os.path.join(family_path, str(variant_version)) if variant_version else family_path
         os.makedirs(pkg_base_path, exist_ok=True)
 
         # Apply overrides.
@@ -1446,26 +1430,21 @@ class FileSystemPackageRepository(PackageRepository):
         package_file = ".".join([package_filename, package_extension])
         filepath = os.path.join(pkg_base_path, package_file)
 
-        with make_path_writable(pkg_base_path):
-            with open_file_for_write(filepath, mode=self.package_file_mode) as f:
-                dump_package_data(package_data, buf=f, format_=package_format)
+        with make_path_writable(pkg_base_path), open_file_for_write(filepath, mode=self.package_file_mode) as f:
+            dump_package_data(package_data, buf=f, format_=package_format)
 
         # delete the tmp 'building' file.
         if variant_version:
             filename = self.building_prefix + str(variant_version)
             filepath = os.path.join(family_path, filename)
             if os.path.exists(filepath):
-                try:
+                with contextlib.suppress(BaseException):
                     os.remove(filepath)
-                except:
-                    pass
 
         # delete other stale building files; previous failed releases may have
         # left some around
-        try:
+        with contextlib.suppress(BaseException):
             self._delete_stale_build_tagfiles(family_path)
-        except:
-            pass
 
         self._on_changed(variant_name)
 

--- a/src/rezplugins/package_repository/memory.py
+++ b/src/rezplugins/package_repository/memory.py
@@ -50,7 +50,7 @@ class MemoryPackageFamilyResource(PackageFamilyResource):
             return
 
         # versioned packages
-        for version_str in data.keys():
+        for version_str in data:
             package = self._repository.get_resource(
                 MemoryPackageResource.key,
                 location=self.location,
@@ -186,7 +186,7 @@ class MemoryPackageRepository(PackageRepository):
         return None
 
     def iter_package_families(self) -> Iterator[MemoryPackageFamilyResource | None]:
-        for name in self.data.keys():
+        for name in self.data:
             family = self.get_package_family(name)
             yield family
 

--- a/src/rezplugins/release_hook/amqp.py
+++ b/src/rezplugins/release_hook/amqp.py
@@ -52,10 +52,7 @@ class AmqpReleaseHook(ReleaseHook):
         super(AmqpReleaseHook, self).__init__(source_path)
 
     def post_release(self, user, install_path, variants, **kwargs) -> None:
-        if variants:
-            package = variants[0].parent
-        else:
-            package = self.package
+        package = variants[0].parent if variants else self.package
 
         # build the message dict
         data: dict[str, Any] = {}

--- a/src/rezplugins/release_hook/command.py
+++ b/src/rezplugins/release_hook/command.py
@@ -77,10 +77,7 @@ class CommandReleaseHook(ReleaseHook):
                 print(stdout.strip())
             return True
 
-        if not os.path.isfile(cmd_name):
-            cmd_full_path = which(cmd_name)
-        else:
-            cmd_full_path = cmd_name
+        cmd_full_path = which(cmd_name) if not os.path.isfile(cmd_name) else cmd_name
         if not cmd_full_path:
             msg = "%s: command not found" % cmd_name
             _err(msg)
@@ -126,10 +123,7 @@ class CommandReleaseHook(ReleaseHook):
         # developer package (self.package). Otherwise, attributes such as 'root'
         # will be None
         errors = []
-        if variants:
-            package = variants[0].parent
-        else:
-            package = self.package
+        package = variants[0].parent if variants else self.package
 
         self._execute_commands(self.settings.post_release_commands,
                                install_path=install_path,
@@ -201,9 +195,8 @@ class CommandReleaseHook(ReleaseHook):
                                         cmd_arguments=args,
                                         user=conf.get("user"),
                                         errors=errors,
-                                        env=env_):
-                if self.settings.stop_on_error:
-                    return
+                                        env=env_) and self.settings.stop_on_error:
+                return
 
 
 def register_plugin():

--- a/src/rezplugins/release_vcs/hg.py
+++ b/src/rezplugins/release_vcs/hg.py
@@ -160,7 +160,7 @@ class HgReleaseVCS(ReleaseVCS):
 
     def tag_exists(self, tag_name) -> bool:
         tags = self.get_tags()
-        return (tag_name in tags.keys())
+        return tag_name in tags
 
     def is_ancestor(self, commit1, commit2, patch: bool = False) -> bool:
         """Returns True if commit1 is a direct ancestor of commit2, or False

--- a/src/rezplugins/shell/cmd.py
+++ b/src/rezplugins/shell/cmd.py
@@ -184,18 +184,12 @@ class CMD(Shell):
 
         cmd = []
         if pre_command:
-            if isinstance(pre_command, str):
-                cmd = pre_command.strip().split()
-            else:
-                cmd = pre_command
+            cmd = pre_command.strip().split() if isinstance(pre_command, str) else pre_command
 
         # Test for None specifically because resolved_context.execute_rex_code
         # passes '' and we do NOT want to keep a shell open during a rex code
         # exec operation.
-        if shell_command is None:
-            cmd_flags = ['/Q', '/K']
-        else:
-            cmd_flags = ['/Q', '/C']
+        cmd_flags = ["/Q", "/K"] if shell_command is None else ["/Q", "/C"]
 
         cmd += [self.executable]
         cmd += cmd_flags

--- a/src/rezplugins/shell/csh.py
+++ b/src/rezplugins/shell/csh.py
@@ -145,7 +145,7 @@ class CSH(UnixShell):
         if config.set_prompt and self.settings.prompt:
             # TODO: Do more like in sh.py, much less error prone
             stored_prompt = os.getenv("REZ_STORED_PROMPT_CSH")
-            curr_prompt = stored_prompt or os.getenv("prompt", "[%m %c]%# ")
+            curr_prompt = stored_prompt or os.getenv("prompt", "[%m %c]%# ")  # noqa: SIM112
             if not stored_prompt:
                 self.setenv("REZ_STORED_PROMPT_CSH", '"%s"' % curr_prompt)
 


### PR DESCRIPTION
Checking the current branch state for an updated summary.


## Branch summary: `refactor/2120-enable-sim-rule`

**5 commits** ahead of `main` (issue #2120). **80 files changed**, +240 / −559 lines (net simplification).

### Goal

Enable Ruff’s **flake8-simplify (`SIM`)** ruleset and update the codebase to comply, as part of the broader flake8 → Ruff migration.

### Config changes (`ruff.toml`)

- **Enable `SIM`** (flake8-simplify) in the selected rule set.

### Code changes (SIM-driven refactors)

Applied broadly across core rez, CLI, tests, rezgui, and plugins:

| Pattern | Example |
|--------|---------|
| **`contextlib.suppress`** | Replace `try/except: pass` with `with contextlib.suppress(...)` |
| **Ternary expressions** | `x if cond else y` instead of multi-line if/else |
| **Combined `if` conditions** | Nested `if`s merged with `and` |
| **Combined `with` statements** | Multiple context managers in one `with` |
| **Simpler iteration** | `for name in specs` instead of `specs.keys()` |
| **Cleanup** | Remove unneeded `# noqa` comments |

Largest touch points: `resolved_context.py`, `rex.py`, `solver.py`, `system.py`, `package_repository/filesystem.py`, plus many CLI modules.

I used some help from an LLM to create the summary for this PR