### PR TITLE
Add tests for package_search  (#2092)

### DIFF
--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -8,7 +8,7 @@ test package_search module
 import unittest
 
 from rez.package_search import get_reverse_dependency_tree, get_plugins, \
-    ResourceSearcher
+    ResourceSearcher, ResourceSearchResultFormatter, ResourceSearchResult
 from rez.tests.util import TestBase, TempdirMixin
 from rez.version import Version
 
@@ -59,6 +59,28 @@ class TestPackageSearch(TestBase, TempdirMixin):
         self.assertEqual(resource_type, "package")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].resource.version, Version("3"))
+    def test_formatter_default_output(self) -> None:
+        """test ResourceSearchResultFormatter with default (no output_format) settings"""
+        searcher = ResourceSearcher(package_paths=[self.solver_packages_path], latest=True)
+        resource_type, results = searcher.search("pydad")
+
+        formatter = ResourceSearchResultFormatter()
+        formatted_lines = formatter.format_search_results(results)
+
+        # default output just shows the qualified name
+        self.assertEqual(len(formatted_lines), 1)
+        text, color = formatted_lines[0]
+        self.assertEqual(text, "pydad-3")
+    def test_resource_search_result(self) -> None:
+        """test ResourceSearchResult stores its attributes correctly"""
+        result = ResourceSearchResult("fake_resource", "package")
+
+        self.assertEqual(result.resource, "fake_resource")
+        self.assertEqual(result.resource_type, "package")
+        self.assertIsNone(result.validation_error)
+
+        result_with_error = ResourceSearchResult("fake_resource", "package", "some error")
+        self.assertEqual(result_with_error.validation_error, "some error")
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -7,8 +7,12 @@ test package_search module
 """
 import unittest
 
-from rez.package_search import get_reverse_dependency_tree, get_plugins, \
-    ResourceSearcher, ResourceSearchResultFormatter, ResourceSearchResult
+from rez.package_search import (
+    get_reverse_dependency_tree,
+    ResourceSearcher,
+    ResourceSearchResultFormatter,
+    ResourceSearchResult
+)
 from rez.tests.util import TestBase, TempdirMixin
 from rez.version import Version
 

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+test package_search module
+"""
+import unittest
+
+from rez.package_search import get_reverse_dependency_tree, get_plugins, \
+    ResourceSearcher
+from rez.tests.util import TestBase, TempdirMixin
+
+
+class TestPackageSearch(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls) -> None:
+        TempdirMixin.setUpClass()
+
+        cls.solver_packages_path = cls.data_path("solver", "packages")
+
+        cls.settings = dict(
+            packages_path=[cls.solver_packages_path],
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        TempdirMixin.tearDownClass()
+
+    def test_reverse_dependency_tree(self) -> None:
+        """test get_reverse_dependency_tree finds direct and indirect parents"""
+        pkgs_list, g = get_reverse_dependency_tree("pymum")
+
+        self.assertEqual(pkgs_list[0], ["pymum"])
+        self.assertEqual(pkgs_list[1], ["pydad", "pyson"])
+
+    def test_reverse_dependency_tree_depth_limit(self) -> None:
+        """test get_reverse_dependency_tree respects depth limit"""
+        pkgs_list, g = get_reverse_dependency_tree("pymum", depth=0)
+
+        # depth=0 means only the root package itself, no parents
+        self.assertEqual(len(pkgs_list), 1)
+        self.assertEqual(pkgs_list[0], ["pymum"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -10,7 +10,7 @@ import unittest
 from rez.package_search import get_reverse_dependency_tree, get_plugins, \
     ResourceSearcher
 from rez.tests.util import TestBase, TempdirMixin
-
+from rez.version import Version
 
 class TestPackageSearch(TestBase, TempdirMixin):
     @classmethod
@@ -41,6 +41,24 @@ class TestPackageSearch(TestBase, TempdirMixin):
         # depth=0 means only the root package itself, no parents
         self.assertEqual(len(pkgs_list), 1)
         self.assertEqual(pkgs_list[0], ["pymum"])
+
+    def test_resource_searcher_family(self) -> None:
+        """test ResourceSearcher finds a package family by name"""
+        searcher = ResourceSearcher(package_paths=[self.solver_packages_path])
+        resource_type, results = searcher.search("pydad")
+
+        self.assertEqual(resource_type, "package")
+        # pydad has 3 versions, all should be found
+        self.assertEqual(len(results), 3)
+
+    def test_resource_searcher_latest_only(self) -> None:
+        """test ResourceSearcher with latest=True returns only newest version"""
+        searcher = ResourceSearcher(package_paths=[self.solver_packages_path], latest=True)
+        resource_type, results = searcher.search("pydad")
+
+        self.assertEqual(resource_type, "package")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].resource.version, Version("3"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -16,6 +16,7 @@ from rez.package_search import (
 from rez.tests.util import TestBase, TempdirMixin
 from rez.version import Version
 
+
 class TestPackageSearch(TestBase, TempdirMixin):
     @classmethod
     def setUpClass(cls) -> None:
@@ -91,6 +92,7 @@ class TestPackageSearch(TestBase, TempdirMixin):
 
         result_with_error = ResourceSearchResult("fake_resource", "package", "some error")
         self.assertEqual(result_with_error.validation_error, "some error")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -38,6 +38,10 @@ class TestPackageSearch(TestBase, TempdirMixin):
         self.assertEqual(pkgs_list[0], ["pymum"])
         self.assertEqual(pkgs_list[1], ["pydad", "pyson"])
 
+        # verify the graph itself: nodes and edges
+        self.assertEqual(set(g.nodes()), {"pymum", "pydad", "pyson"})
+        self.assertEqual(set(g.edges()), {("pydad", "pymum"), ("pyson", "pymum")})
+
     def test_reverse_dependency_tree_depth_limit(self) -> None:
         """test get_reverse_dependency_tree respects depth limit"""
         pkgs_list, g = get_reverse_dependency_tree("pymum", depth=0)

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -63,6 +63,7 @@ class TestPackageSearch(TestBase, TempdirMixin):
         self.assertEqual(resource_type, "package")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].resource.version, Version("3"))
+
     def test_formatter_default_output(self) -> None:
         """test ResourceSearchResultFormatter with default (no output_format) settings"""
         searcher = ResourceSearcher(package_paths=[self.solver_packages_path], latest=True)
@@ -75,6 +76,7 @@ class TestPackageSearch(TestBase, TempdirMixin):
         self.assertEqual(len(formatted_lines), 1)
         text, color = formatted_lines[0]
         self.assertEqual(text, "pydad-3")
+
     def test_resource_search_result(self) -> None:
         """test ResourceSearchResult stores its attributes correctly"""
         result = ResourceSearchResult("fake_resource", "package")

--- a/src/rez/tests/test_package_search.py
+++ b/src/rez/tests/test_package_search.py
@@ -36,7 +36,7 @@ class TestPackageSearch(TestBase, TempdirMixin):
         pkgs_list, g = get_reverse_dependency_tree("pymum")
 
         self.assertEqual(pkgs_list[0], ["pymum"])
-        self.assertEqual(pkgs_list[1], ["pydad", "pyson"])
+        self.assertEqual(set(pkgs_list[1]), {"pydad", "pyson"})
 
         # verify the graph itself: nodes and edges
         self.assertEqual(set(g.nodes()), {"pymum", "pydad", "pyson"})


### PR DESCRIPTION
## Description

This PR adds unit tests for `src/rez/package_search.py`, which currently has no test coverage (as noted in #2092).

Addresses part of #2092.

## What's tested

 `get_reverse_dependency_tree()`
  Correctly builds a reverse dependency tree for a package with known direct dependents
   Respects the `depth` argument (e.g. `depth=0` returns only the root package)
 `ResourceSearcher.search()`
   Finds all versions of a package family
   Returns only the latest version when `latest=True`
 `ResourceSearchResultFormatter`
   Default (no `output_format`) output correctly shows a package's qualified name
 `ResourceSearchResult`
   Correctly stores `resource`, `resource_type`, and `validation_error` (including default `None`)


## Notes

Tests reuse the existing `solver/packages` test data already used by `test_packages.py`, so no new test fixtures were added.
`get_plugins()` is not yet covered, no existing test data currently includes packages with `plugin_for` set. Open to guidance on whether to add new fixture packages for this, or if there's a preferred approach.