### PR TITLE
Don't assume package repositories are on the filesystem

### DIFF
--- a/src/rez/build_process.py
+++ b/src/rez/build_process.py
@@ -299,12 +299,19 @@ class BuildProcessHelper(BuildProcess):
         return context, rxt_filepath
 
     def pre_release(self) -> None:
+        from rez.package_repository import package_repository_manager
+
         release_settings = self.package.config.plugins.release_vcs
 
-        # test that the release path exists
         release_path = self.package.config.release_packages_path
-        if not os.path.exists(release_path):
-            raise ReleaseError("Release path does not exist: %r" % release_path)
+        try:
+            # make sure the release path exists for filesystem repos
+            repository = package_repository_manager.get_repository(release_path)
+            if repository.name() == "filesystem" and not os.path.exists(release_path):
+                raise ReleaseError(f"Release path does not exist: {release_path!r}")
+
+        except Exception as e:
+            raise ReleaseError(f"Could not access release package repository {release_path!r}: {e}")
 
         # test that the repo is in a state to release
         if self.vcs:

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -33,7 +33,10 @@ from rez.packages import get_variant, Variant
 from rez.system import system
 from rez.utils.filesystem import rename
 
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, cast, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rez.package_resources import VariantResource
 
 
 class PackageCache(object):
@@ -263,7 +266,10 @@ class PackageCache(object):
                 % variant.uri
             )
 
-        if not os.path.isdir(variant_root):
+        # Non fs repos may not fetch the variant from disk
+        if package.repository.name() == "filesystem" and not os.path.isdir(
+            variant_root
+        ):
             raise PackageCacheError(
                 "Not cached - variant %s root does not appear on disk: %s"
                 % (variant.uri, variant_root)
@@ -410,7 +416,7 @@ class PackageCache(object):
         th.start()
 
         try:
-            shutil.copytree(variant_root, rootpath)
+            cast("VariantResource", variant.resource).install(rootpath)
         finally:
             still_copying = False
 

--- a/src/rez/package_resources.py
+++ b/src/rez/package_resources.py
@@ -19,6 +19,7 @@ from rez.vendor.schema.schema import Schema, SchemaError, Optional, Or, And, Use
 
 from textwrap import dedent
 import os.path
+import shutil
 from abc import abstractmethod
 from hashlib import sha1
 from typing import Any, Iterable, Iterator, TYPE_CHECKING
@@ -367,6 +368,13 @@ class VariantResource(PackageResource):
     def root(self) -> str:
         """Return the 'root' path of the variant."""
         return self._root()
+
+    def install(self, location: str) -> None:
+        """Install this variant's payload to `location`
+
+        Override for repos which don't live on the fs
+        """
+        shutil.copytree(self.root, location)
 
     @cached_property
     def subpath(self) -> str:

--- a/src/rez/tests/test_package_cache.py
+++ b/src/rez/tests/test_package_cache.py
@@ -11,7 +11,7 @@ import os.path
 import time
 import subprocess
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from rez.tests.util import TestBase, TempdirMixin, restore_os_environ, \
     install_dependent
@@ -340,3 +340,45 @@ class TestPackageCache(TestBase, TempdirMixin):
              patch.object(pkgcache, 'variant_meets_space_requirements', return_value=False):
             _, status = pkgcache.add_variant(variant)
             self.assertEqual(status, PackageCache.VARIANT_SKIPPED)
+
+    def test_cache_fail_missing_root_filesystem_repo(self) -> None:
+        """Filesystem repo variant with nonexistent root raises PackageCacheError."""
+        pkgcache = self._pkgcache()
+
+        package = get_package("versioned", "3.0")
+        variant = next(package.iter_variants())
+
+        with patch.object(type(variant), "root", new="/no/such/path"):
+            with self.assertRaises(PackageCacheError):
+                pkgcache.add_variant(variant)
+
+    def test_cache_skips_root_check_for_non_filesystem_repo(self) -> None:
+        """Non-filesystem repo variant does not fail on missing root dir."""
+        pkgcache = self._pkgcache()
+
+        package = get_package("versioned", "3.0")
+        variant = next(package.iter_variants())
+
+        mock_repo = MagicMock()
+        mock_repo.name.return_value = "custom"
+
+        with patch.object(type(variant.parent), "repository", new=mock_repo), \
+             patch.object(type(variant), "root", new="/no/such/path"):
+            _, status = pkgcache.add_variant(variant)
+            self.assertEqual(status, PackageCache.VARIANT_CREATED)
+
+        pkgcache.remove_variant(variant)
+
+    def test_cache_variant_calls_resource_install(self) -> None:
+        """add_variant delegates to variant.resource.install."""
+        pkgcache = self._pkgcache()
+
+        package = get_package("versioned", "3.0")
+        variant = next(package.iter_variants())
+
+        with patch.object(pkgcache, "_get_cached_root", return_value=(PackageCache.VARIANT_NOT_FOUND, "")), \
+             patch.object(variant.resource, "install") as mock_install:
+            rootpath, status = pkgcache.add_variant(variant)
+
+            self.assertEqual(status, PackageCache.VARIANT_CREATED)
+            mock_install.assert_called_once_with(rootpath)


### PR DESCRIPTION
Hey!

We found during our tests that some rez internals assume that the package repository lives on the filesystem. 
There are very likely more of these assumptions scattered around, but the fixes in this PR are the ones we found blocking from doing any package_cache/rez release + remote repo work (without larger rez internal restructuring). The introduced `VariantResource.install` should likely make future fixes easier, too

I also added tests covering some cases around this topic for the package cache

Cheers!