### PR TITLE
Draft: feat: package orderers as configurable plugins with config-arg-passing

### DIFF
--- a/docs/source/package_orderers.rst
+++ b/docs/source/package_orderers.rst
@@ -14,6 +14,35 @@ Configuration
 
 Package orderers can be configured in the ``rezconfig.py`` via the :data:`package_orderers` setting.
 
+Environment Variable Configuration
+==================================
+
+Package orderers can also be configured at runtime using the
+``REZ_PACKAGE_ORDERERS_JSON`` environment variable. The value must be a
+JSON-encoded list of orderer definitions, using the same structure as the
+:data:`package_orderers` setting:
+
+.. code-block:: bash
+
+   export REZ_PACKAGE_ORDERERS_JSON='[{"type": "per_family", "orderers": [{"packages": ["python"], "type": "version_split", "first_version": "2.7.16"}]}]'
+
+This is useful for configuring orderers with constructor arguments (such as
+prerelease risk tolerance or custom version priority ranges) without modifying
+``rezconfig.py``.
+
+.. note::
+
+   The environment variable is read on first access to the configuration.
+   If you need to change it at runtime via the API, clear both caches:
+
+   .. code-block:: python
+
+      from rez.config import config
+      from rez.package_order import PackageOrderList
+
+      config._uncache("package_orderers")
+      PackageOrderList.clear_singleton_cache()
+
 Types
 =====
 
@@ -188,9 +217,20 @@ package. You would use a :class:`rez.package_order.NullPackageOrder` in a :class
 Custom orderers
 ===============
 
-It is possible to create custom orderers using the API. This can be achieved
-by subclassing :class:`rez.package_order.PackageOrder` and implementing some mandatory
-methods. Once that's done, you need to register the orderer using :func:`rez.package_order.register_orderer`.
+It is possible to create custom orderers using the API. The preferred approach
+is to create a plugin in ``rezplugins/package_order/``. Alternatively, you can
+subclass :class:`rez.package_order.PackageOrder` and register the orderer using
+:func:`rez.package_order.register_orderer` (API-based registration).
+
+.. note::
+
+   The plugin system is preferred for persistent, facility-wide orderers.
+   Use ``register_orderer()`` for dynamic or programmatic registration.
+
+.. seealso::
+
+   For plugin-based orderer examples, see the built-in orderers in
+   ``src/rezplugins/package_order/``.
 
 .. note::
 

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -9,10 +9,11 @@ from hashlib import sha1
 from typing import Any, Callable, Iterable, List, TYPE_CHECKING
 
 from rez.config import config
+from rez.exceptions import RezPluginError
 from rez.utils.data_utils import cached_class_property
 from rez.version import Version, VersionRange
-from rez.version._version import _Comparable, _ReversedComparable, _LowerBound, _UpperBound, _Bound
-from rez.packages import iter_packages, Package
+from rez.version._version import _Comparable, _LowerBound, _UpperBound, _Bound
+from rez.packages import Package
 from rez.utils.typing import SupportsLessThan
 
 if TYPE_CHECKING:
@@ -193,7 +194,7 @@ class PackageOrder(object):
         raise NotImplementedError
 
     def __eq__(self, other):
-        return type(self) == type(other) and str(self) == str(other)  # noqa: E721
+        return type(self) is type(other) and str(self) == str(other)
 
     def __ne__(self, other) -> bool:
         return not self == other
@@ -202,434 +203,51 @@ class PackageOrder(object):
         return "%s(%s)" % (self.__class__.__name__, str(self))
 
 
-class NullPackageOrder(PackageOrder):
-    """An orderer that does not change the order - a no op.
+# Legacy orderer registry. Used as fallback by _find_orderer when an orderer
+# is not found in the plugin system.
+_orderers = {}
 
-    This orderer is useful in cases where you want to apply some default orderer
-    to a set of packages, but may want to explicitly NOT reorder a particular
-    package. You would use a :class:`NullPackageOrder` in a :class:`PerFamilyOrder` to do this.
+
+def _find_orderer(name):
+    """Find an orderer class by name.
+
+    Checks the plugin system first, then falls back to the legacy _orderers
+    registry for backward compatibility with register_orderer().
     """
-    name = "no_order"
+    from rez.plugin_managers import plugin_manager
 
-    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
-        # python's sort will preserve the order of items that compare equal, so
-        # to not change anything, we just return the same object for all...
-        return 0
-
-    def __str__(self) -> str:
-        return "{}"
-
-    def __eq__(self, other):
-        return type(self) == type(other)  # noqa: E721
-
-    def to_pod(self) -> dict[str, Any]:
-        """
-        Example (in yaml):
-
-        .. code-block:: yaml
-
-           type: no_order
-           packages: ["foo"]
-        """
-        return {
-            "packages": self.packages,
-        }
-
-    @classmethod
-    def from_pod(cls, data: dict[str, Any]) -> Self:
-        return cls(packages=data.get("packages"))
+    try:
+        return plugin_manager.get_plugin_class('package_order', name)
+    except RezPluginError:
+        # Fallback to legacy "register_orderer" method
+        if name not in _orderers:
+            raise
+        return _orderers[name]
 
 
-class SortedOrder(PackageOrder):
-    """An orderer that sorts based on :attr:`Package.version <rez.packages.Package.version>`.
+# Backward-compat aliases. These are resolved lazily via __getattr__ below to
+# avoid a circular import: the plugin modules in rezplugins/package_order/
+# import from this module, so we cannot call _find_orderer (which loads the
+# plugin system) at module load time.
+#
+# New code should import from the plugin system directly.
+_LEGACY_ORDERER_NAMES = {
+    "NullPackageOrder": "no_order",
+    "PerFamilyOrder": "per_family",
+    "SortedOrder": "sorted",
+    "TimestampPackageOrder": "soft_timestamp",
+    "VersionSplitPackageOrder": "version_split",
+}
+
+
+def __getattr__(name):
+    """Provide backward-compat class aliases for orderers now in the plugin system.
+
+    Resolved lazily to avoid circular imports at module load time.
     """
-    name = "sorted"
-
-    def __init__(self, descending: bool, packages: list[str] | None = None) -> None:
-        super().__init__(packages)
-        self.descending = descending
-
-    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
-        # Note that the name "descending" can be slightly confusing - it
-        # indicates that the final ordering this Order gives should be
-        # version descending (ie, the default) - however, the sort_key itself
-        # returns its results in "normal" ascending order (because it needs to
-        # be used "alongside" normally-sorted objects like versions).
-        # when the key is passed to sort(), though, it is always invoked with
-        # reverse=True...
-        if self.descending:
-            return version
-        else:
-            return _ReversedComparable(version)
-
-    def __str__(self) -> str:
-        return str(self.descending)
-
-    def __eq__(self, other):
-        return (  # noqa: E721
-            type(self) == type(other)
-            and self.descending == other.descending
-        )
-
-    def to_pod(self) -> dict[str, Any]:
-        """
-        Example (in yaml):
-
-        .. code-block:: yaml
-
-           type: sorted
-           descending: true
-           packages: ["foo"]
-        """
-        return {
-            "descending": self.descending,
-            "packages": self.packages,
-        }
-
-    @classmethod
-    def from_pod(cls, data: dict[str, Any]) -> Self:
-        return cls(
-            data["descending"],
-            packages=data.get("packages"),
-        )
-
-
-class PerFamilyOrder(PackageOrder):
-    """An orderer that applies different orderers to different package families.
-    """
-    name = "per_family"
-
-    def __init__(self, order_dict: dict[str, PackageOrder],
-                 default_order: PackageOrder | None = None) -> None:
-        """Create a reorderer.
-
-        Args:
-            order_dict (dict[str, PackageOrder]): Orderers to apply to
-                each package family.
-            default_order (PackageOrder): Orderer to apply to any packages
-                not specified in ``order_dict``.
-        """
-        super().__init__(list(order_dict))
-        self.order_dict = order_dict.copy()
-        self.default_order = default_order
-
-    def reorder(self, iterable: Iterable[Package],
-                key: Callable[[Any], Package] | None = None) -> list[Package] | None:
-        package_name = self._get_package_name_from_iterable(iterable, key)
-        if package_name is None:
-            return None
-
-        orderer = self.order_dict.get(package_name)
-        if orderer is None:
-            orderer = self.default_order
-        if orderer is None:
-            return None
-
-        return orderer.reorder(iterable, key)
-
-    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
-        orderer = self.order_dict.get(package_name)
-        if orderer is None:
-            if self.default_order is None:
-                # shouldn't get here, because applies_to should protect us...
-                raise RuntimeError(
-                    "package family orderer %r does not apply to package family %r",
-                    (self, package_name))
-
-            orderer = self.default_order
-
-        return orderer.sort_key_implementation(package_name, version)
-
-    def __str__(self) -> str:
-        items = sorted((x[0], str(x[1])) for x in self.order_dict.items())
-        return str((items, str(self.default_order)))
-
-    def __eq__(self, other):
-        return (  # noqa: E721
-            type(other) == type(self)
-            and self.order_dict == other.order_dict
-            and self.default_order == other.default_order
-        )
-
-    def to_pod(self) -> dict[str, Any]:
-        """
-        Example (in yaml):
-
-        .. code-block:: yaml
-
-           type: per_family
-           orderers:
-           - packages: ['foo', 'bah']
-             type: version_split
-             first_version: '4.0.5'
-           - packages: ['python']
-             type: sorted
-             descending: false
-           default_order:
-             type: sorted
-             descending: true
-        """
-        orderers = {}
-        packages = {}
-
-        # group package fams by orderer they use
-        for fam, orderer in self.order_dict.items():
-            k = id(orderer)
-            orderers[k] = orderer
-            packages.setdefault(k, set()).add(fam)
-
-        orderlist = []
-        for k, fams in packages.items():
-            orderer = orderers[k]
-            data = to_pod(orderer)
-            data["packages"] = sorted(fams)
-            orderlist.append(data)
-
-        result: dict[str, Any] = {"orderers": orderlist}
-
-        if self.default_order is not None:
-            result["default_order"] = to_pod(self.default_order)
-
-        return result
-
-    @classmethod
-    def from_pod(cls, data: dict[str, Any]) -> Self:
-        order_dict = {}
-        default_order = None
-
-        for d in data["orderers"]:
-            d = d.copy()
-            fams = d.pop("packages")
-            orderer = from_pod(d)
-
-            for fam in fams:
-                order_dict[fam] = orderer
-
-        d = data.get("default_order")
-        if d:
-            default_order = from_pod(d)
-
-        return cls(order_dict, default_order)
-
-
-class VersionSplitPackageOrder(PackageOrder):
-    """Orders package versions <= a given version first.
-
-    For example, given the versions [5, 4, 3, 2, 1], an orderer initialized
-    with ``version=3`` would give the order [3, 2, 1, 5, 4].
-    """
-    name = "version_split"
-
-    def __init__(self, first_version: Version, packages: list[str] | None = None) -> None:
-        """Create a reorderer.
-
-        Args:
-            first_version (Version): Start with versions <= this value.
-        """
-        super().__init__(packages)
-        self.first_version = first_version
-
-    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
-        priority_key = 1 if version <= self.first_version else 0
-        return priority_key, version
-
-    def __str__(self) -> str:
-        return str(self.first_version)
-
-    def __eq__(self, other):
-        return (  # noqa: E721
-            type(other) == type(self)
-            and self.first_version == other.first_version
-        )
-
-    def to_pod(self) -> dict[str, Any]:
-        """
-        Example (in yaml):
-
-        .. code-block:: yaml
-
-           type: version_split
-           first_version: "3.0.0"
-           packages: ["foo"]
-        """
-        return dict(
-            first_version=str(self.first_version),
-            packages=self.packages,
-        )
-
-    @classmethod
-    def from_pod(cls, data: dict[str, Any]) -> Self:
-        return cls(
-            Version(data["first_version"]),
-            packages=data.get("packages"),
-        )
-
-
-class TimestampPackageOrder(PackageOrder):
-    """A timestamp order function.
-
-    Given a time ``T``, this orderer returns packages released before ``T``, in descending
-    order, followed by those released after. If ``rank`` is non-zero, version
-    changes at that rank and above are allowed over the timestamp.
-
-    For example, consider the common case where we want to prioritize packages
-    released before ``T``, except for newer patches. Consider the following package
-    versions, and time ``T``:
-
-    .. code-block:: text
-
-       2.2.1
-       2.2.0
-       2.1.1
-       2.1.0
-       2.0.6
-       2.0.5
-             <-- T
-       2.0.0
-       1.9.0
-
-    A timestamp orderer set to ``rank=3`` (patch versions) will attempt to consume
-    the packages in the following order:
-
-    .. code-block:: text
-
-       2.0.6
-       2.0.5
-       2.0.0
-       1.9.0
-       2.1.1
-       2.1.0
-       2.2.1
-       2.2.0
-
-    Notice that packages before ``T`` are preferred, followed by newer versions.
-    Newer versions are consumed in ascending order, except within rank (this is
-    why 2.1.1 is consumed before 2.1.0).
-    """
-    name = "soft_timestamp"
-
-    def __init__(self, timestamp: int, rank: int = 0, packages: list[str] | None = None) -> None:
-        """Create a reorderer.
-
-        Args:
-            timestamp (int): Epoch time of timestamp. Packages before this time
-                are preferred.
-            rank (int): If non-zero, allow version changes at this rank or above
-                past the timestamp.
-        """
-        super().__init__(packages)
-        self.timestamp = timestamp
-        self.rank = rank
-
-        # dictionary mapping from package family to the first-version-after
-        # the given timestamp
-        self._cached_first_after = {}
-        self._cached_sort_key = {}
-
-    def _get_first_after(self, package_family: str) -> Version | None:
-        """Get the first package version that is after the timestamp"""
-        try:
-            first_after = self._cached_first_after[package_family]
-        except KeyError:
-            first_after = self._calc_first_after(package_family)
-            self._cached_first_after[package_family] = first_after
-        return first_after
-
-    def _calc_first_after(self, package_family: str) -> Version | None:
-        descending = sorted(iter_packages(package_family),
-                            key=lambda p: p.version,
-                            reverse=True)
-        first_after = None
-        for i, package in enumerate(descending):
-            if not package.timestamp:
-                continue
-            if package.timestamp > self.timestamp:
-                first_after = package.version
-            else:
-                break
-
-        if not self.rank:
-            return first_after
-
-        # if we have rank, then we need to then go back UP the
-        # versions, until we find one whose trimmed version doesn't
-        # match.
-        # Note that we COULD do this by simply iterating through
-        # an ascending sequence, in which case we wouldn't have to
-        # "switch direction" after finding the first result after
-        # by timestamp... but we're making the assumption that the
-        # timestamp break will be closer to the higher end of the
-        # version, and that we'll therefore have to check fewer
-        # timestamps this way...
-        trimmed_version = package.version.trim(self.rank - 1)
-        first_after = None
-        for after_package in reversed(descending[:i]):
-            if after_package.version.trim(self.rank - 1) != trimmed_version:
-                return after_package.version
-
-        return first_after
-
-    def _calc_sort_key(self, package_name: str, version: Version) -> SupportsLessThan:
-        first_after = self._get_first_after(package_name)
-        if first_after is None:
-            # all packages are before T
-            is_before: bool | int = True
-        else:
-            is_before = int(version < first_after)
-
-        if is_before:
-            return is_before, version
-
-        if self.rank:
-            return (is_before,
-                    _ReversedComparable(version.trim(self.rank - 1)),
-                    version.tokens[self.rank - 1:])
-
-        return is_before, _ReversedComparable(version)
-
-    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
-        cache_key = (package_name, str(version))
-        result = self._cached_sort_key.get(cache_key)
-        if result is None:
-            result = self._calc_sort_key(package_name, version)
-            self._cached_sort_key[cache_key] = result
-
-        return result
-
-    def __str__(self) -> str:
-        return str((self.timestamp, self.rank))
-
-    def __eq__(self, other):
-        return (  # noqa: E721
-            type(other) == type(self)
-            and self.timestamp == other.timestamp
-            and self.rank == other.rank
-        )
-
-    def to_pod(self) -> dict[str, Any]:
-        """
-        Example (in yaml):
-
-        .. code-block:: yaml
-
-           type: soft_timestamp
-           timestamp: 1234567
-           rank: 3
-           packages: ["foo"]
-        """
-        return dict(
-            timestamp=self.timestamp,
-            rank=self.rank,
-            packages=self.packages,
-        )
-
-    @classmethod
-    def from_pod(cls, data: dict[str, Any]) -> Self:
-        return cls(
-            data["timestamp"],
-            rank=data.get("rank", 0),
-            packages=data.get("packages"),
-        )
+    if name in _LEGACY_ORDERER_NAMES:
+        return _find_orderer(_LEGACY_ORDERER_NAMES[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class PackageOrderList(List[PackageOrder]):
@@ -656,6 +274,19 @@ class PackageOrderList(List[PackageOrder]):
     def singleton(cls) -> PackageOrderList:
         """Filter list as configured by rezconfig.package_filter."""
         return cls.from_pod(config.package_orderers)
+
+    @classmethod
+    def clear_singleton_cache(cls) -> None:
+        """Clear the cached singleton so the next access re-reads config.
+
+        Use this when runtime configuration (e.g. REZ_PACKAGE_ORDERERS_JSON)
+        has changed and you want the new config to take effect. Note that
+        the config-level cache must also be cleared via
+        ``config._uncache("package_orderers")``.
+        """
+        name = "_class_property_singleton"
+        if hasattr(cls, name):
+            delattr(cls, name)
 
     @staticmethod
     def _to_orderer(orderer: dict | PackageOrder) -> PackageOrder:
@@ -727,12 +358,12 @@ def from_pod(data: dict[str, Any]) -> PackageOrder:
         data = data.copy()
         data.pop("type")
 
-        cls = _orderers[cls_name]
+        cls = _find_orderer(cls_name)
         return cls.from_pod(data)
     else:
         # old-style, kept for backwards compatibility
         cls_name, data_ = data
-        cls = _orderers[cls_name]
+        cls = _find_orderer(cls_name)
         return cls.from_pod(data_)
 
 
@@ -744,15 +375,26 @@ def get_orderer(package_name: str, orderers: PackageOrderList | dict[str, Packag
         orderer = orderers.get(ALL_PACKAGES)
     if orderer is None:
         # default ordering is version descending
-        orderer = SortedOrder(descending=True)
+        sorted_order = _find_orderer("sorted")
+        orderer = sorted_order(descending=True)
     return orderer
 
 
+# Legacy orderer registry. Used as fallback by _find_orderer when an orderer
+# is not found in the plugin system.
+_orderers = {}
+
+
+# Legacy orderer registration. New orderers should be implemented as plugins
+# in rezplugins/package_order/. This function is kept for backward
+# compatibility with custom orderers registered via rezconfig.py.
 def register_orderer(cls: type[PackageOrder]) -> bool:
-    """Register an orderer
+    """Register an orderer.
+
+    Kept for backwards compatibility. New orderers should be a plugin.
 
     Args:
-        cls (type[PackageOrder]): Package orderer class to register.
+        cls (type[PackageOrder]): Package order class to register.
 
     returns:
         bool: True if successfully registered, else False.
@@ -763,9 +405,3 @@ def register_orderer(cls: type[PackageOrder]) -> bool:
         return True
     else:
         return False
-
-
-# registration of builtin orderers
-_orderers = {}
-for o in list(globals().values()):
-    register_orderer(o)

--- a/src/rez/package_order.py
+++ b/src/rez/package_order.py
@@ -16,11 +16,6 @@ from rez.version._version import _Comparable, _LowerBound, _UpperBound, _Bound
 from rez.packages import Package
 from rez.utils.typing import SupportsLessThan
 
-if TYPE_CHECKING:
-    # this is not available in typing until 3.11, but due to __future__.annotations
-    # we can use it without really importing it
-    from typing import Self
-
 ALL_PACKAGES = "*"
 
 
@@ -29,9 +24,7 @@ class FallbackComparable(_Comparable):
     fails, compares using the fallback_comparable object.
     """
 
-    def __init__(self,
-                 main_comparable: SupportsLessThan,
-                 fallback_comparable: SupportsLessThan) -> None:
+    def __init__(self, main_comparable: SupportsLessThan, fallback_comparable: SupportsLessThan) -> None:
         self.main_comparable = main_comparable
         self.fallback_comparable = fallback_comparable
 
@@ -48,7 +41,7 @@ class FallbackComparable(_Comparable):
             return self.fallback_comparable < other.fallback_comparable
 
     def __repr__(self) -> str:
-        return '%s(%r, %r)' % (type(self).__name__, self.main_comparable, self.fallback_comparable)
+        return "%s(%r, %r)" % (type(self).__name__, self.main_comparable, self.fallback_comparable)
 
 
 class PackageOrder(object):
@@ -85,8 +78,7 @@ class PackageOrder(object):
         else:
             self._packages = sorted(packages)
 
-    def reorder(self, iterable: Iterable[Package],
-                key: Callable[[Any], Package] | None = None) -> list[Package] | None:
+    def reorder(self, iterable: Iterable[Package], key: Callable[[Any], Package] | None = None) -> list[Package] | None:
         """Put packages into some order for consumption.
 
         You can safely assume that the packages referred to by `iterable` are
@@ -109,14 +101,12 @@ class PackageOrder(object):
         """
         key = key or (lambda x: x)
         package_name = self._get_package_name_from_iterable(iterable, key=key)
-        return sorted(iterable,
-                      key=lambda x: self.sort_key(package_name, key(x).version),
-                      reverse=True)
+        return sorted(iterable, key=lambda x: self.sort_key(package_name, key(x).version), reverse=True)
 
     @staticmethod
-    def _get_package_name_from_iterable(iterable: Iterable[Package],
-                                        key: Callable[[Any], Package] | None = None
-                                        ) -> str | None:
+    def _get_package_name_from_iterable(
+        iterable: Iterable[Package], key: Callable[[Any], Package] | None = None
+    ) -> str | None:
         """Utility method for getting a package from an iterable"""
         try:
             item = next(iter(iterable))
@@ -126,9 +116,9 @@ class PackageOrder(object):
         key = key or (lambda x: x)
         return key(item).name
 
-    def sort_key(self, package_name: str,
-                 version_like: Version | _LowerBound | _UpperBound | _Bound | VersionRange | None
-                 ) -> SupportsLessThan:
+    def sort_key(
+        self, package_name: str, version_like: Version | _LowerBound | _UpperBound | _Bound | VersionRange | None
+    ) -> SupportsLessThan:
         """Returns a sort key usable for sorting packages within the same family
 
         Args:
@@ -145,8 +135,7 @@ class PackageOrder(object):
         if isinstance(version_like, VersionRange):
             return tuple(self.sort_key(package_name, bound) for bound in version_like.bounds)
         if isinstance(version_like, _Bound):
-            return (self.sort_key(package_name, version_like.lower),
-                    self.sort_key(package_name, version_like.upper))
+            return (self.sort_key(package_name, version_like.lower), self.sort_key(package_name, version_like.upper))
         if isinstance(version_like, _LowerBound):
             inclusion_key = -2 if version_like.inclusive else -1
             return self.sort_key(package_name, version_like.version), inclusion_key
@@ -155,8 +144,7 @@ class PackageOrder(object):
             return self.sort_key(package_name, version_like.version), inclusion_key
         if isinstance(version_like, Version):
             # finally, the bit that we actually use the sort_key_implementation for.
-            return FallbackComparable(
-                self.sort_key_implementation(package_name, version_like), version_like)
+            return FallbackComparable(self.sort_key_implementation(package_name, version_like), version_like)
         if version_like is None:
             # As no version range is provided for this package,
             # Python's sort preserves the order of equal elements.
@@ -188,7 +176,7 @@ class PackageOrder(object):
 
     @property
     def sha1(self) -> str:
-        return sha1(repr(self).encode('utf-8')).hexdigest()
+        return sha1(repr(self).encode("utf-8")).hexdigest()
 
     def __str__(self) -> str:
         raise NotImplementedError
@@ -211,15 +199,15 @@ _orderers = {}
 def _find_orderer(name):
     """Find an orderer class by name.
 
-    Checks the plugin system first, then falls back to the legacy _orderers
-    registry for backward compatibility with register_orderer().
+    Checks the plugin system first, then falls back to the _orderers
+    registry for orderers registered via register_orderer().
     """
     from rez.plugin_managers import plugin_manager
 
     try:
-        return plugin_manager.get_plugin_class('package_order', name)
+        return plugin_manager.get_plugin_class("package_order", name)
     except RezPluginError:
-        # Fallback to legacy "register_orderer" method
+        # Fallback to register_orderer() API-based registration
         if name not in _orderers:
             raise
         return _orderers[name]
@@ -251,8 +239,7 @@ def __getattr__(name):
 
 
 class PackageOrderList(List[PackageOrder]):
-    """A list of package orderer.
-    """
+    """A list of package orderer."""
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -380,18 +367,22 @@ def get_orderer(package_name: str, orderers: PackageOrderList | dict[str, Packag
     return orderer
 
 
-# Legacy orderer registry. Used as fallback by _find_orderer when an orderer
-# is not found in the plugin system.
+# Orderers registered at runtime via register_orderer(). This is the API-based
+# registration pathway, used as fallback by _find_orderer when an orderer is
+# not found in the plugin system.
 _orderers = {}
 
 
-# Legacy orderer registration. New orderers should be implemented as plugins
-# in rezplugins/package_order/. This function is kept for backward
-# compatibility with custom orderers registered via rezconfig.py.
+# Register an orderer for runtime/API-based use. Orderers registered here are
+# found by _find_orderer as a fallback when the plugin system does not have
+# a matching orderer. For filesystem-based, facility-wide orderers, prefer
+# creating a plugin in rezplugins/package_order/ instead.
 def register_orderer(cls: type[PackageOrder]) -> bool:
     """Register an orderer.
 
-    Kept for backwards compatibility. New orderers should be a plugin.
+    This is the API-based registration pathway, useful for dynamic or
+    programmatic orderer registration. For persistent, facility-wide
+    orderers, prefer the plugin system (rezplugins/package_order/).
 
     Args:
         cls (type[PackageOrder]): Package order class to register.
@@ -399,8 +390,7 @@ def register_orderer(cls: type[PackageOrder]) -> bool:
     returns:
         bool: True if successfully registered, else False.
     """
-    if isclass(cls) and issubclass(cls, PackageOrder) and \
-            hasattr(cls, "name") and cls.name:
+    if isclass(cls) and issubclass(cls, PackageOrder) and hasattr(cls, "name") and cls.name:
         _orderers[cls.name] = cls
         return True
     else:

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -537,6 +537,12 @@ class CommandPluginType(RezPluginType):
     type_name = "command"
 
 
+class PackageOrderPluginType(RezPluginType):
+    """Support for different ordering of packages.
+    """
+    type_name = "package_order"
+
+
 plugin_manager = RezPluginManager()
 
 
@@ -547,3 +553,4 @@ plugin_manager.register_plugin_type(BuildSystemPluginType)
 plugin_manager.register_plugin_type(PackageRepositoryPluginType)
 plugin_manager.register_plugin_type(BuildProcessPluginType)
 plugin_manager.register_plugin_type(CommandPluginType)
+plugin_manager.register_plugin_type(PackageOrderPluginType)

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -5,6 +5,7 @@
 """
 Manages loading of all types of Rez plugins.
 """
+
 from __future__ import annotations
 
 from rez.config import config, expand_system_vars, _load_config_from_filepaths
@@ -70,7 +71,7 @@ def extend_path(path, name):
         # frozen package.  Return the path unchanged in that case.
         return path
 
-    pname = os.path.join(*name.split('.'))  # Reconstitute as relative path
+    pname = os.path.join(*name.split("."))  # Reconstitute as relative path
     # Just in case os.extsep != '.'
     init_py = "__init__" + os.extsep + "py"
     path = path[:]
@@ -106,13 +107,13 @@ class RezPluginType(object):
     'type_name' must correspond with one of the source directories found under
     the 'plugins' directory.
     """
+
     type_name: str
 
     def __init__(self) -> None:
         if self.type_name is None:
-            raise TypeError("Subclasses of RezPluginType must provide a "
-                            "'type_name' attribute")
-        self.pretty_type_name = self.type_name.replace('_', ' ')
+            raise TypeError("Subclasses of RezPluginType must provide a 'type_name' attribute")
+        self.pretty_type_name = self.type_name.replace("_", " ")
         self.plugin_classes: dict[str, type] = {}
         self.failed_plugins: dict[str, str] = {}
         self.plugin_modules: dict[str, types.ModuleType] = {}
@@ -120,7 +121,7 @@ class RezPluginType(object):
         self.load_plugins()
 
     def __repr__(self) -> str:
-        return '%s(%s)' % (self.__class__.__name__, self.plugin_classes.keys())
+        return "%s(%s)" % (self.__class__.__name__, self.plugin_classes.keys())
 
     def register_plugin(self, plugin_name: str, plugin_class: type, plugin_module: types.ModuleType) -> None:
         # TODO: check plugin_class to ensure it is a sub-class of expected base-class?
@@ -136,7 +137,8 @@ class RezPluginType(object):
     def load_plugins_from_namespace(self):
         import pkgutil
         from importlib import import_module
-        type_module_name = 'rezplugins.' + self.type_name
+
+        type_module_name = "rezplugins." + self.type_name
         package = import_module(type_module_name)
 
         # on import, the `__path__` variable of the imported package is extended
@@ -144,8 +146,7 @@ class RezPluginType(object):
         # extend_path, above). this means that `walk_packages` will walk over all
         # modules on the search path at the same level (.e.g in a
         # 'rezplugins/type_name' sub-directory).
-        paths = [package.__path__] if isinstance(package.__path__, str) \
-            else package.__path__
+        paths = [package.__path__] if isinstance(package.__path__, str) else package.__path__
 
         # reverse plugin path order, so that custom plugins have a chance to
         # be found before the builtin plugins (from /rezplugins).
@@ -155,14 +156,12 @@ class RezPluginType(object):
             if config.debug("plugins"):
                 print_debug("searching plugin path %s...", path)
 
-            for importer, modname, ispkg in pkgutil.iter_modules(
-                    [path], package.__name__ + '.'):
-
+            for importer, modname, ispkg in pkgutil.iter_modules([path], package.__name__ + "."):
                 if importer is None:
                     continue
 
-                plugin_name = modname.split('.')[-1]
-                if plugin_name.startswith('_') or plugin_name == 'rezconfig':
+                plugin_name = modname.split(".")[-1]
+                if plugin_name.startswith("_") or plugin_name == "rezconfig":
                     continue
 
                 if plugin_name in self.plugin_modules:
@@ -171,13 +170,11 @@ class RezPluginType(object):
                     # `sys.modules` below. skipping the rest of the process
                     # for good.
                     if config.debug("plugins"):
-                        print_warning("skipped same named %s plugin at %s: %s"
-                                      % (self.type_name, path, modname))
+                        print_warning("skipped same named %s plugin at %s: %s" % (self.type_name, path, modname))
                     continue
 
                 if config.debug("plugins"):
-                    print_debug("loading %s plugin at %s: %s..."
-                                % (self.type_name, path, modname))
+                    print_debug("loading %s plugin at %s: %s..." % (self.type_name, path, modname))
 
                 try:
                     plugin_module = sys.modules.get(modname)
@@ -202,8 +199,7 @@ class RezPluginType(object):
 
         for plugin in discovered_plugins:
             if config.debug("plugins"):
-                print_debug("loading %s plugin for %r..."
-                            % (self.type_name, f"{plugin.name} = {plugin.value!r}"))
+                print_debug("loading %s plugin for %r..." % (self.type_name, f"{plugin.name} = {plugin.value!r}"))
             try:
                 plugin_name = plugin.name
                 plugin = plugin.load()
@@ -214,7 +210,7 @@ class RezPluginType(object):
                 self.print_log_plugins_error(plugin.__name__, e)
 
     def print_log_plugins_error(self, module_name, error):
-        nameish = module_name.split('.')[-1]
+        nameish = module_name.split(".")[-1]
         self.failed_plugins[nameish] = str(error)
 
         if not config.debug("plugins"):
@@ -222,6 +218,7 @@ class RezPluginType(object):
 
         import traceback
         from io import StringIO
+
         out = StringIO()
         traceback.print_exc(file=out)
         print_debug(out.getvalue())
@@ -239,55 +236,46 @@ class RezPluginType(object):
                 print_warning(
                     "plugin module %s is not loaded from current "
                     "load path but reused from previous imported "
-                    "path: %s" % (module_name, plugin_module.__file__))
+                    "path: %s" % (module_name, plugin_module.__file__)
+                )
 
-        if (hasattr(plugin_module, "register_plugin")
-                and callable(plugin_module.register_plugin)):
-
+        if hasattr(plugin_module, "register_plugin") and callable(plugin_module.register_plugin):
             plugin_class = plugin_module.register_plugin()
             if plugin_class is not None:
-                self.register_plugin(
-                    plugin_name,
-                    plugin_class,
-                    plugin_module
-                )
+                self.register_plugin(plugin_name, plugin_class, plugin_module)
             else:
                 if config.debug("plugins"):
                     print_warning(
-                        "'register_plugin' function at %s: %s did "
-                        "not return a class." % (plugin_path, module_name))
+                        "'register_plugin' function at %s: %s did not return a class." % (plugin_path, module_name)
+                    )
         else:
             if config.debug("plugins"):
-                print_warning(
-                    "no 'register_plugin' function at %s: %s"
-                    % (plugin_path, module_name))
+                print_warning("no 'register_plugin' function at %s: %s" % (plugin_path, module_name))
 
     def get_plugin_class(self, plugin_name: str) -> type:
         """Returns the class registered under the given plugin name."""
         try:
             return self.plugin_classes[plugin_name]
         except KeyError:
-            raise RezPluginError("Unrecognised %s plugin: '%s'"
-                                 % (self.pretty_type_name, plugin_name))
+            raise RezPluginError("Unrecognised %s plugin: '%s'" % (self.pretty_type_name, plugin_name))
 
     def get_plugin_module(self, plugin_name: str) -> types.ModuleType:
         """Returns the module containing the plugin of the given name."""
         try:
             return self.plugin_modules[plugin_name]
         except KeyError:
-            raise RezPluginError("Unrecognised %s plugin: '%s'"
-                                 % (self.pretty_type_name, plugin_name))
+            raise RezPluginError("Unrecognised %s plugin: '%s'" % (self.pretty_type_name, plugin_name))
 
     @cached_property
     def config_schema(self):
         """Returns the merged configuration data schema for this plugin
         type."""
         from rez.config import _plugin_config_dict
+
         d = _plugin_config_dict.get(self.type_name, {})
 
         for name, plugin_class in self.plugin_classes.items():
-            if hasattr(plugin_class, "schema_dict") \
-                    and plugin_class.schema_dict:
+            if hasattr(plugin_class, "schema_dict") and plugin_class.schema_dict:
                 d_ = {name: plugin_class.schema_dict}
                 deep_update(d, d_)
         return dict_to_schema(d, required=True, modifier=expand_system_vars)
@@ -350,6 +338,7 @@ class RezPluginManager(object):
             This is important  because it ensures that rez's copy of
             'rezplugins' is always found first.
     """
+
     def __init__(self) -> None:
         self._plugin_types: dict[str, LazySingleton[RezPluginType]] = {}
 
@@ -390,15 +379,13 @@ class RezPluginManager(object):
         try:
             return self._plugin_types[plugin_type]()
         except KeyError:
-            raise RezPluginError("Unrecognised plugin type: '%s'"
-                                 % plugin_type)
+            raise RezPluginError("Unrecognised plugin type: '%s'" % plugin_type)
 
     def register_plugin_type(self, type_class: type[RezPluginType]) -> None:
         if not issubclass(type_class, RezPluginType):
             raise TypeError("'type_class' must be a RezPluginType sub class")
         if type_class.type_name is None:
-            raise TypeError("Subclasses of RezPluginType must provide a "
-                            "'type_name' attribute")
+            raise TypeError("Subclasses of RezPluginType must provide a 'type_name' attribute")
         self._plugin_types[type_class.type_name] = LazySingleton(type_class)
 
     def get_plugin_types(self) -> list[str]:
@@ -477,69 +464,69 @@ class RezPluginManager(object):
 
     def get_summary_string(self) -> str:
         """Get a formatted string summarising the plugins that were loaded."""
-        rows = [["PLUGIN TYPE", "NAME", "DESCRIPTION", "STATUS"],
-                ["-----------", "----", "-----------", "------"]]
+        rows = [["PLUGIN TYPE", "NAME", "DESCRIPTION", "STATUS"], ["-----------", "----", "-----------", "------"]]
         for plugin_type in sorted(self.get_plugin_types()):
-            type_name = plugin_type.replace('_', ' ')
+            type_name = plugin_type.replace("_", " ")
             for name in sorted(self.get_plugins(plugin_type)):
                 module = self.get_plugin_module(plugin_type, name)
-                desc = (getattr(module, "__doc__", None) or '').strip()
+                desc = (getattr(module, "__doc__", None) or "").strip()
                 rows.append((type_name, name, desc, "loaded"))
-            for (name, reason) in sorted(self.get_failed_plugins(plugin_type)):
+            for name, reason in sorted(self.get_failed_plugins(plugin_type)):
                 msg = "FAILED: %s" % reason
-                rows.append((type_name, name, '', msg))
-        return '\n'.join(columnise(rows))
+                rows.append((type_name, name, "", msg))
+        return "\n".join(columnise(rows))
 
 
 # ------------------------------------------------------------------------------
 # Plugin Types
 # ------------------------------------------------------------------------------
 
+
 class ShellPluginType(RezPluginType):
-    """Support for different types of target shells, such as bash, tcsh.
-    """
+    """Support for different types of target shells, such as bash, tcsh."""
+
     type_name = "shell"
 
 
 class ReleaseVCSPluginType(RezPluginType):
-    """Support for different version control systems when releasing packages.
-    """
+    """Support for different version control systems when releasing packages."""
+
     type_name = "release_vcs"
 
 
 class ReleaseHookPluginType(RezPluginType):
-    """Support for different version control systems when releasing packages.
-    """
+    """Support for different version control systems when releasing packages."""
+
     type_name = "release_hook"
 
 
 class BuildSystemPluginType(RezPluginType):
-    """Support for different build systems when building packages.
-    """
+    """Support for different build systems when building packages."""
+
     type_name = "build_system"
 
 
 class PackageRepositoryPluginType(RezPluginType):
-    """Support for different package repositories for loading packages.
-    """
+    """Support for different package repositories for loading packages."""
+
     type_name = "package_repository"
 
 
 class BuildProcessPluginType(RezPluginType):
-    """Support for different build and release processes.
-    """
+    """Support for different build and release processes."""
+
     type_name = "build_process"
 
 
 class CommandPluginType(RezPluginType):
-    """Support for different custom Rez applications/subcommands.
-    """
+    """Support for different custom Rez applications/subcommands."""
+
     type_name = "command"
 
 
 class PackageOrderPluginType(RezPluginType):
-    """Support for different ordering of packages.
-    """
+    """Support for different ordering of packages."""
+
     type_name = "package_order"
 
 

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -33,6 +33,7 @@ class TestCompletion(TestBase):
                        "plugin_path"])
         _eq("plugins", ["plugins",
                         "plugins.command",
+                        "plugins.package_order",
                         "plugins.package_repository",
                         "plugins.build_process",
                         "plugins.build_system",

--- a/src/rez/tests/test_completion.py
+++ b/src/rez/tests/test_completion.py
@@ -5,6 +5,7 @@
 """
 test completions
 """
+
 import unittest
 from rez.tests.util import TestBase
 from rez.config import Config, get_module_root_config
@@ -15,53 +16,74 @@ class TestCompletion(TestBase):
     @classmethod
     def setUpClass(cls) -> None:
         packages_path = cls.data_path("solver", "packages")
-        cls.settings = dict(
-            packages_path=[packages_path],
-            package_filter=None)
+        cls.settings = dict(packages_path=[packages_path], package_filter=None)
 
         cls.config = Config([get_module_root_config()], locked=True)
 
     def test_config(self) -> None:
         """Test config completion."""
+
         def _eq(prefix, expected_completions) -> None:
             completions = self.config.get_completions(prefix)
             self.assertEqual(set(completions), set(expected_completions))
 
         _eq("zzz", [])
         _eq("pref", ["prefix_prompt"])
-        _eq("plugin", ["plugins",
-                       "plugin_path"])
-        _eq("plugins", ["plugins",
-                        "plugins.command",
-                        "plugins.package_order",
-                        "plugins.package_repository",
-                        "plugins.build_process",
-                        "plugins.build_system",
-                        "plugins.release_hook",
-                        "plugins.release_vcs",
-                        "plugins.shell"])
-        _eq("plugins.release_vcs.releasable_",
-            ["plugins.release_vcs.releasable_branches"])
+        _eq("plugin", ["plugins", "plugin_path"])
+        _eq(
+            "plugins",
+            [
+                "plugins",
+                "plugins.command",
+                "plugins.package_order",
+                "plugins.package_repository",
+                "plugins.build_process",
+                "plugins.build_system",
+                "plugins.release_hook",
+                "plugins.release_vcs",
+                "plugins.shell",
+            ],
+        )
+        _eq("plugins.release_vcs.releasable_", ["plugins.release_vcs.releasable_branches"])
 
     def test_packages(self) -> None:
         """Test packages completion."""
+
         def _eq(prefix, expected_completions) -> None:
             completions = get_completions(prefix)
             self.assertEqual(set(completions), set(expected_completions))
 
         _eq("zzz", [])
-        _eq("", ["bahish", "nada", "nopy", "pybah", "pydad", "pyfoo", "pymum",
-                 "pyodd", "pyson", "pysplit", "python", "pyvariants",
-                 "test_variant_split_start", "test_variant_split_mid1",
-                 "test_variant_split_mid2", "test_variant_split_end", "missing_variant_requires",
-                 "test_weakly_reference_requires", "test_weakly_reference_variant"])
-        _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson",
-            "pysplit", "python", "pyvariants"])
+        _eq(
+            "",
+            [
+                "bahish",
+                "nada",
+                "nopy",
+                "pybah",
+                "pydad",
+                "pyfoo",
+                "pymum",
+                "pyodd",
+                "pyson",
+                "pysplit",
+                "python",
+                "pyvariants",
+                "test_variant_split_start",
+                "test_variant_split_mid1",
+                "test_variant_split_mid2",
+                "test_variant_split_end",
+                "missing_variant_requires",
+                "test_weakly_reference_requires",
+                "test_weakly_reference_variant",
+            ],
+        )
+        _eq("py", ["pybah", "pydad", "pyfoo", "pymum", "pyodd", "pyson", "pysplit", "python", "pyvariants"])
         _eq("pys", ["pyson", "pysplit"])
         _eq("pyb", ["pybah", "pybah-4", "pybah-5"])
         _eq("pybah-", ["pybah-4", "pybah-5"])
         _eq("pyfoo-3.0", ["pyfoo-3.0.0"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -13,10 +13,16 @@ from rez.package_order import (
     PackageOrder,
     PackageOrderList,
     from_pod,
+    to_pod,
+    get_orderer,
+    register_orderer,
+    _find_orderer,
+    _orderers,
+    FallbackComparable,
 )
 from rez.packages import iter_packages
 from rez.tests.util import TestBase, TempdirMixin
-from rez.version import Version
+from rez.version import Version, VersionRange
 
 
 def _orderer(name):
@@ -179,9 +185,25 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
         self._test_reorder(orderer, "missing_package", [])
 
     def test_reorder_no_default_order(self) -> None:
-        """Test behavior when there's no secondary default_order."""
+        """Validate we correctly handle no default order for a PerFamilyOrder."""
         fam_orderer = self.PerFamilyOrder(order_dict={})
         self._test_reorder(fam_orderer, "pymum", ["3", "2", "1"])
+
+    def test_sort_key_implementation_with_default_order(self) -> None:
+        """sort_key_implementation falls back to default_order for unregistered families."""
+        orderer = self.PerFamilyOrder(
+            order_dict={},
+            default_order=self.SortedOrder(descending=False),
+        )
+        # "unknown" is not in order_dict, so falls back to default_order
+        key = orderer.sort_key_implementation("unknown", Version("1.0"))
+        self.assertIsNotNone(key)
+
+    def test_sort_key_implementation_no_orderer_raises(self) -> None:
+        """sort_key_implementation raises RuntimeError when no orderer applies."""
+        orderer = self.PerFamilyOrder(order_dict={}, default_order=None)
+        with self.assertRaises(RuntimeError):
+            orderer.sort_key_implementation("unknown", Version("1.0"))
 
     def test_comparison(self) -> None:
         """Validate we can compare PerFamilyOrder."""
@@ -585,6 +607,9 @@ class TestPackageOrderPublic(TestBase):
 
     def setUp(self) -> None:
         self.VersionSplitPackageOrder = _orderer("version_split")
+        self.SortedOrder = _orderer("sorted")
+        self.NullPackageOrder = _orderer("no_order")
+        self.PerFamilyOrder = _orderer("per_family")
         super().setUp()
 
     def test_from_pod_old_style(self) -> None:
@@ -593,3 +618,175 @@ class TestPackageOrderPublic(TestBase):
             self.VersionSplitPackageOrder(first_version=Version("1.2.3")),
             from_pod(("version_split", {"first_version": "1.2.3"})),
         )
+
+    def test_find_orderer_unknown_name(self) -> None:
+        """_find_orderer raises RezPluginError for unknown orderer names."""
+        from rez.exceptions import RezPluginError
+
+        with self.assertRaises(RezPluginError):
+            _find_orderer("nonexistent_orderer")
+
+    def test_getattr_unknown_name(self) -> None:
+        """Module-level __getattr__ raises AttributeError for unknown names."""
+        import rez.package_order as po
+
+        with self.assertRaises(AttributeError):
+            po.nonexistent_attribute  # noqa: B018
+
+    def test_register_orderer_invalid(self) -> None:
+        """register_orderer returns False for non-PackageOrder classes."""
+
+        class NotAnOrderer:
+            pass
+
+        self.assertFalse(register_orderer(NotAnOrderer))
+
+    def test_register_orderer_valid(self) -> None:
+        """register_orderer returns True and registers a valid orderer."""
+
+        class TestOrderer(PackageOrder):
+            name = "test_coverage_orderer"
+
+            def sort_key_implementation(self, package_name, version):
+                return 0
+
+            def __str__(self):
+                return "test"
+
+            def to_pod(self):
+                return {}
+
+            @classmethod
+            def from_pod(cls, data):
+                return cls()
+
+        try:
+            self.assertTrue(register_orderer(TestOrderer))
+            self.assertEqual(_find_orderer("test_coverage_orderer"), TestOrderer)
+        finally:
+            _orderers.pop("test_coverage_orderer", None)
+
+    def test_sort_key_with_version_range(self) -> None:
+        """sort_key handles VersionRange, not just Version."""
+        orderer = self.SortedOrder(descending=True)
+        key = orderer.sort_key("foo", VersionRange("1.0+<2.0"))
+        self.assertIsInstance(key, tuple)
+
+    def test_sort_key_with_none(self) -> None:
+        """sort_key returns 0 for None (preserves original order)."""
+        orderer = self.SortedOrder(descending=True)
+        self.assertEqual(orderer.sort_key("foo", None), 0)
+
+    def test_sort_key_invalid_type(self) -> None:
+        """sort_key raises TypeError for unrecognized types."""
+        orderer = self.SortedOrder(descending=True)
+        with self.assertRaises(TypeError):
+            orderer.sort_key("foo", 123)
+
+    def test_fallback_comparable(self) -> None:
+        """FallbackComparable falls back when main comparison fails."""
+
+        class _Raises:
+            """Object that raises on comparison, forcing fallback path."""
+
+            def __eq__(self, other):
+                raise TypeError("nope")
+
+            def __lt__(self, other):
+                raise TypeError("nope")
+
+        fc1 = FallbackComparable(_Raises(), 1)
+        fc2 = FallbackComparable(_Raises(), 1)
+        # main comparison raises, so falls back to 1 == 1
+        self.assertTrue(fc1 == fc2)
+
+        fc3 = FallbackComparable(_Raises(), 2)
+        self.assertFalse(fc1 == fc3)
+        self.assertTrue(fc1 < fc3)
+
+    def test_fallback_comparable_repr(self) -> None:
+        """FallbackComparable has a useful repr."""
+        fc = FallbackComparable(1, 2)
+        self.assertIn("FallbackComparable", repr(fc))
+
+    def test_get_orderer_default(self) -> None:
+        """get_orderer returns descending SortedOrder as default fallback."""
+        orderer = get_orderer("nonexistent_package")
+        self.assertTrue(orderer.descending)
+
+    def test_to_pod_round_trip(self) -> None:
+        """to_pod produces a dict with 'type' that from_pod can consume."""
+        orderer = self.SortedOrder(descending=True)
+        pod = to_pod(orderer)
+        self.assertEqual(pod["type"], "sorted")
+        result = from_pod(pod)
+        self.assertEqual(orderer, result)
+
+
+class TestPackageOrderListCoverage(_BaseTestPackagesOrder):
+    """Coverage for PackageOrderList methods."""
+
+    def test_dirty_flag_on_append(self) -> None:
+        """append sets dirty flag."""
+        ol = PackageOrderList()
+        ol.append(self.SortedOrder(descending=True))
+        self.assertTrue(ol.dirty)
+
+    def test_dirty_flag_on_extend(self) -> None:
+        """extend sets dirty flag."""
+        ol = PackageOrderList()
+        ol.extend([self.SortedOrder(descending=True)])
+        self.assertTrue(ol.dirty)
+
+    def test_dirty_flag_on_pop(self) -> None:
+        """pop sets dirty flag."""
+        ol = PackageOrderList([self.SortedOrder(descending=True)])
+        ol.pop()
+        self.assertTrue(ol.dirty)
+
+    def test_dirty_flag_on_remove(self) -> None:
+        """remove sets dirty flag."""
+        orderer = self.SortedOrder(descending=True)
+        ol = PackageOrderList([orderer])
+        ol.remove(orderer)
+        self.assertTrue(ol.dirty)
+
+    def test_dirty_flag_on_clear(self) -> None:
+        """clear sets dirty flag."""
+        ol = PackageOrderList([self.SortedOrder(descending=True)])
+        ol.clear()
+        self.assertTrue(ol.dirty)
+
+    def test_dirty_flag_on_insert(self) -> None:
+        """insert sets dirty flag."""
+        ol = PackageOrderList()
+        ol.insert(0, self.SortedOrder(descending=True))
+        self.assertTrue(ol.dirty)
+
+    def test_to_orderer_with_dict(self) -> None:
+        """_to_orderer converts a dict to an orderer via from_pod."""
+        ol = PackageOrderList()
+        orderer = ol._to_orderer({"type": "sorted", "descending": True})
+        self.assertTrue(orderer.descending)
+
+    def test_pod_round_trip(self) -> None:
+        """PackageOrderList to_pod/from_pod round-trip."""
+        ol = PackageOrderList([self.SortedOrder(descending=True)])
+        pod = ol.to_pod()
+        result = PackageOrderList.from_pod(pod)
+        self.assertEqual(ol, result)
+
+    def test_get_with_dirty_refresh(self) -> None:
+        """get() triggers refresh when dirty."""
+        orderer = self.SortedOrder(descending=True, packages=["foo"])
+        ol = PackageOrderList([orderer])
+        self.assertTrue(ol.dirty)
+        result = ol.get("foo")
+        self.assertEqual(result, orderer)
+        self.assertFalse(ol.dirty)
+
+    def test_get_missing_package_returns_default(self) -> None:
+        """get() returns default for unknown package."""
+        ol = PackageOrderList()
+        result = ol.get("nonexistent", default=self.NullPackageOrder())
+        self.assertIsInstance(result, self.NullPackageOrder)

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -5,11 +5,20 @@
 """
 Test cases for package_order.py (package ordering)
 """
+
 import json
 
 from rez.config import config
-from rez.package_order import NullPackageOrder, PackageOrder, PerFamilyOrder, VersionSplitPackageOrder, \
-    TimestampPackageOrder, SortedOrder, PackageOrderList, from_pod
+from rez.package_order import (
+    NullPackageOrder,
+    PackageOrder,
+    PerFamilyOrder,
+    VersionSplitPackageOrder,
+    TimestampPackageOrder,
+    SortedOrder,
+    PackageOrderList,
+    from_pod,
+)
 from rez.packages import iter_packages
 from rez.tests.util import TestBase, TempdirMixin
 from rez.version import Version
@@ -17,6 +26,7 @@ from rez.version import Version
 
 class _BaseTestPackagesOrder(TestBase, TempdirMixin):
     """Base class for a package ordering test case"""
+
     @classmethod
     def setUpClass(cls) -> None:
         TempdirMixin.setUpClass()
@@ -24,12 +34,7 @@ class _BaseTestPackagesOrder(TestBase, TempdirMixin):
         cls.py_packages_path = cls.data_path("packages", "py_packages")
         cls.solver_packages_path = cls.data_path("solver", "packages")
 
-        cls.settings = dict(
-            packages_path=[
-                cls.solver_packages_path,
-                cls.py_packages_path
-            ],
-            package_filter=None)
+        cls.settings = dict(packages_path=[cls.solver_packages_path, cls.py_packages_path], package_filter=None)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -89,11 +94,8 @@ class TestNullPackageOrder(_BaseTestPackagesOrder):
         self._test_pod(NullPackageOrder())
 
     def test_sha1(self) -> None:
-        """Validate we can get a sha1 hash.
-        """
-        self.assertEqual(
-            'bf7c2fa4e6bd198c02adeea2c3a382cf57242051', NullPackageOrder().sha1
-        )
+        """Validate we can get a sha1 hash."""
+        self.assertEqual("bf7c2fa4e6bd198c02adeea2c3a382cf57242051", NullPackageOrder().sha1)
 
 
 class TestSortedOrder(_BaseTestPackagesOrder):
@@ -141,9 +143,9 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
             order_dict=dict(
                 pysplit=NullPackageOrder(),
                 python=VersionSplitPackageOrder(Version("2.6.0")),
-                timestamped=TimestampPackageOrder(timestamp=3001, rank=3)
+                timestamped=TimestampPackageOrder(timestamp=3001, rank=3),
             ),
-            default_order=SortedOrder(descending=False)
+            default_order=SortedOrder(descending=False),
         )
 
         self._test_reorder(orderer, "pysplit", expected_null_result)
@@ -163,10 +165,10 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
 
     def test_comparison(self) -> None:
         """Validate we can compare PerFamilyOrder."""
-        inst1 = PerFamilyOrder(order_dict={'foo': NullPackageOrder()}, default_order=NullPackageOrder())
-        inst2 = PerFamilyOrder(order_dict={'foo': NullPackageOrder()}, default_order=NullPackageOrder())
-        inst3 = PerFamilyOrder(order_dict={'bar': NullPackageOrder()}, default_order=NullPackageOrder())
-        inst4 = PerFamilyOrder(order_dict={'foo': NullPackageOrder()}, default_order=None)
+        inst1 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder())
+        inst2 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder())
+        inst3 = PerFamilyOrder(order_dict={"bar": NullPackageOrder()}, default_order=NullPackageOrder())
+        inst4 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=None)
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == inst3)  # __eq__ negative (different order dict)
         self.assertFalse(inst1 == inst4)  # __eq__ negative (different default_order)
@@ -181,14 +183,10 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
 
     def test_pod(self) -> None:
         """Validate we can save and load a PerFamilyOrder to its pod representation."""
-        self._test_pod(
-            PerFamilyOrder(order_dict={'foo': NullPackageOrder()}, default_order=NullPackageOrder())
-        )
+        self._test_pod(PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder()))
 
         # No default_order
-        self._test_pod(
-            PerFamilyOrder(order_dict={'foo': NullPackageOrder()})
-        )
+        self._test_pod(PerFamilyOrder(order_dict={"foo": NullPackageOrder()}))
 
 
 class TestVersionSplitPackageOrder(_BaseTestPackagesOrder):
@@ -228,7 +226,7 @@ class TestTimestampPackageOrder(_BaseTestPackagesOrder):
     def test_reorder_no_rank(self) -> None:
         """Validate reordering with a rank of 0."""
         orderer = TimestampPackageOrder(timestamp=3001)
-        expected = ['1.1.0', '1.0.6', '1.0.5', '1.1.1', '1.2.0', '2.0.0', '2.1.0', '2.1.5']
+        expected = ["1.1.0", "1.0.6", "1.0.5", "1.1.1", "1.2.0", "2.0.0", "2.1.0", "2.1.5"]
         self._test_reorder(orderer, "timestamped", expected)
 
     def test_reorder_rank_3(self) -> None:
@@ -246,7 +244,7 @@ class TestTimestampPackageOrder(_BaseTestPackagesOrder):
     def test_reorder_rank_2(self) -> None:
         """Add coverage for a corner case where there's only one candidate without the rank."""
         orderer = TimestampPackageOrder(timestamp=4001, rank=3)  # 1.1.1
-        expected = ['1.1.1', '1.1.0', '1.0.6', '1.0.5', '1.2.0', '2.0.0', '2.1.5', '2.1.0']
+        expected = ["1.1.1", "1.1.0", "1.0.6", "1.0.5", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
         self._test_reorder(orderer, "timestamped", expected)
 
     def test_reorder_packages_without_timestamps(self) -> None:
@@ -257,13 +255,13 @@ class TestTimestampPackageOrder(_BaseTestPackagesOrder):
     def test_reorder_all_packages_before_timestamp(self) -> None:
         """Test behavior when all packages are before the timestamp."""
         timestamp_orderer = TimestampPackageOrder(timestamp=9999999999, rank=3)
-        expected = ['2.1.5', '2.1.0', '2.0.0', '1.2.0', '1.1.1', '1.1.0', '1.0.6', '1.0.5']
+        expected = ["2.1.5", "2.1.0", "2.0.0", "1.2.0", "1.1.1", "1.1.0", "1.0.6", "1.0.5"]
         self._test_reorder(timestamp_orderer, "timestamped", expected)
 
     def test_reorder_all_packages_after_timestamp(self) -> None:
         """Test behavior when all packages are after the timestamp."""
         timestamp_orderer = TimestampPackageOrder(timestamp=0, rank=3)
-        expected = ['1.0.6', '1.0.5', '1.1.1', '1.1.0', '1.2.0', '2.0.0', '2.1.5', '2.1.0']
+        expected = ["1.0.6", "1.0.5", "1.1.1", "1.1.0", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
         self._test_reorder(timestamp_orderer, "timestamped", expected)
 
     def test_comparison(self) -> None:
@@ -294,26 +292,21 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 
     def test_singleton(self) -> None:
         """Validate we can build a PackageOrderList object from configuration values."""
-        config.override("package_orderers", [
-            {
-                "type": "per_family",
-                "orderers": [
-                    {
-                        "packages": ["python"],
-                        "type": "version_split",
-                        "first_version": "2.9.9"
-                    }
-                ]
-            }
-        ])
+        config.override(
+            "package_orderers",
+            [
+                {
+                    "type": "per_family",
+                    "orderers": [{"packages": ["python"], "type": "version_split", "first_version": "2.9.9"}],
+                }
+            ],
+        )
         expected = PackageOrderList()
-        expected.append(PerFamilyOrder(order_dict={
-            "python": VersionSplitPackageOrder(Version("2.9.9"))
-        }))
+        expected.append(PerFamilyOrder(order_dict={"python": VersionSplitPackageOrder(Version("2.9.9"))}))
 
         # Clear @classproperty cache
         try:
-            delattr(PackageOrderList, '_class_property_singleton')
+            delattr(PackageOrderList, "_class_property_singleton")
         except AttributeError:
             pass
         self.assertEqual(expected, PackageOrderList.singleton)
@@ -324,7 +317,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 
         # Clear @classproperty cache
         try:
-            delattr(PackageOrderList, '_class_property_singleton')
+            delattr(PackageOrderList, "_class_property_singleton")
         except AttributeError:
             pass
 
@@ -332,10 +325,12 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 
     def test_pod(self) -> None:
         """Validate we can save and load a PackageOrdererList to pod representation."""
-        inst = PackageOrderList((
-            VersionSplitPackageOrder(Version("2.6.0")),
-            PerFamilyOrder(order_dict={}, default_order=SortedOrder(descending=False))
-        ))
+        inst = PackageOrderList(
+            (
+                VersionSplitPackageOrder(Version("2.6.0")),
+                PerFamilyOrder(order_dict={}, default_order=SortedOrder(descending=False)),
+            )
+        )
         self._test_pod(inst)
 
     def test_from_pod_module_function_round_trip(self):
@@ -352,35 +347,26 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         self.assertIsInstance(orderer, NullPackageOrder)
 
         # version_split
-        orderer = module_from_pod({
-            "type": "version_split",
-            "first_version": "1.2.3"
-        })
+        orderer = module_from_pod({"type": "version_split", "first_version": "1.2.3"})
         self.assertIsInstance(orderer, VersionSplitPackageOrder)
 
     def test_isinstance_against_imported_classes(self):
         """Verify isinstance works for orderer classes imported from package_order."""
         self.assertIsInstance(SortedOrder(descending=True), SortedOrder)
         self.assertIsInstance(NullPackageOrder(), NullPackageOrder)
-        self.assertIsInstance(
-            VersionSplitPackageOrder(first_version=Version("1.0")),
-            VersionSplitPackageOrder
-        )
-        self.assertIsInstance(
-            TimestampPackageOrder(timestamp=1000),
-            TimestampPackageOrder
-        )
+        self.assertIsInstance(VersionSplitPackageOrder(first_version=Version("1.0")), VersionSplitPackageOrder)
+        self.assertIsInstance(TimestampPackageOrder(timestamp=1000), TimestampPackageOrder)
         # Cross-type checks
         self.assertNotIsInstance(SortedOrder(descending=True), NullPackageOrder)
 
     def test_get_orderer_default_fallback(self):
         """Verify get_orderer falls back to SortedOrder(descending=True)."""
-        from rez.package_order import get_orderer, ALL_PACKAGES
+        from rez.package_order import get_orderer
 
         config.override("package_orderers", None)
         # Clear singleton cache
         try:
-            delattr(PackageOrderList, '_class_property_singleton')
+            delattr(PackageOrderList, "_class_property_singleton")
         except AttributeError:
             pass
 
@@ -401,7 +387,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         }
 
         for plugin_name, class_name in expected.items():
-            cls = plugin_manager.get_plugin_class('package_order', plugin_name)
+            cls = plugin_manager.get_plugin_class("package_order", plugin_name)
             self.assertEqual(cls.__name__, class_name)
 
     def test_pod_round_trip_through_plugin_system(self) -> None:
@@ -413,10 +399,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
             NullPackageOrder(),
             VersionSplitPackageOrder(first_version=Version("1.2.3")),
             TimestampPackageOrder(timestamp=3001, rank=3),
-            PerFamilyOrder(
-                order_dict={"foo": NullPackageOrder()},
-                default_order=NullPackageOrder()
-            ),
+            PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder()),
         ]
 
         for original in orderers:
@@ -427,9 +410,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 
     def test_legacy_register_orderer_fallback(self) -> None:
         """Verify _find_orderer falls back to _orderers for legacy-registered orderers."""
-        from rez.package_order import (
-            PackageOrder, register_orderer, _find_orderer, _orderers
-        )
+        from rez.package_order import PackageOrder, register_orderer, _find_orderer, _orderers
 
         class TestLegacyOrderer(PackageOrder):
             name = "test_legacy_fallback"
@@ -463,18 +444,14 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         """
         import json
 
-        config_json = json.dumps([
-            {
-                "type": "per_family",
-                "orderers": [
-                    {
-                        "packages": ["python"],
-                        "type": "version_split",
-                        "first_version": "2.9.9"
-                    }
-                ]
-            }
-        ])
+        config_json = json.dumps(
+            [
+                {
+                    "type": "per_family",
+                    "orderers": [{"packages": ["python"], "type": "version_split", "first_version": "2.9.9"}],
+                }
+            ]
+        )
 
         old_overrides = config.overrides.get("package_orderers")
         try:
@@ -504,9 +481,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
             self.assertEqual(len(orderers1), 0)
 
             # Second config: one orderer
-            config.override("package_orderers", json.loads(
-                '[{"type": "sorted", "descending": false}]'
-            ))
+            config.override("package_orderers", json.loads('[{"type": "sorted", "descending": false}]'))
             PackageOrderList.clear_singleton_cache()
             orderers2 = PackageOrderList.singleton
             self.assertEqual(len(orderers2), 1)
@@ -530,9 +505,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         we simulate the _JSON path by parsing JSON and using config.override().
         """
         import json
-        from rez.package_order import (
-            PackageOrder, register_orderer, _orderers
-        )
+        from rez.package_order import PackageOrder, register_orderer, _orderers
 
         class TestKwargOrderer(PackageOrder):
             name = "test_kwarg"
@@ -564,9 +537,9 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         try:
             register_orderer(TestKwargOrderer)
 
-            config.override("package_orderers", json.loads(
-                '[{"type": "test_kwarg", "mode": "production", "packages": ["foo"]}]'
-            ))
+            config.override(
+                "package_orderers", json.loads('[{"type": "test_kwarg", "mode": "production", "packages": ["foo"]}]')
+            )
             PackageOrderList.clear_singleton_cache()
 
             orderers = PackageOrderList.singleton
@@ -590,5 +563,5 @@ class TestPackageOrderPublic(TestBase):
         """Validate from_pod is still compatible with the older pod style."""
         self.assertEqual(
             VersionSplitPackageOrder(first_version=Version("1.2.3")),
-            from_pod(("version_split", {"first_version": "1.2.3"}))
+            from_pod(("version_split", {"first_version": "1.2.3"})),
         )

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -85,7 +85,7 @@ class TestNullPackageOrder(_BaseTestPackagesOrder):
         self.assertFalse(inst1 != inst2)  # __ne__ negative
 
     def test_pod(self) -> None:
-        """Validate we can save and load a VersionSplitPackageOrder to it's pod representation."""
+        """Validate we can save and load a VersionSplitPackageOrder to its pod representation."""
         self._test_pod(NullPackageOrder())
 
     def test_sha1(self) -> None:
@@ -124,7 +124,7 @@ class TestSortedOrder(_BaseTestPackagesOrder):
         self.assertEqual("SortedOrder(True)", repr(SortedOrder(descending=True)))
 
     def test_pod(self) -> None:
-        """Validate we can save and load a SortedOrder to it's pod representation."""
+        """Validate we can save and load a SortedOrder to its pod representation."""
         self._test_pod(SortedOrder(descending=True))
 
 
@@ -180,7 +180,7 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
         self.assertEqual("PerFamilyOrder(([('family1', '2.6.0')], 'None'))", repr(inst))
 
     def test_pod(self) -> None:
-        """Validate we can save and load a PerFamilyOrder to it's pod representation."""
+        """Validate we can save and load a PerFamilyOrder to its pod representation."""
         self._test_pod(
             PerFamilyOrder(order_dict={'foo': NullPackageOrder()}, default_order=NullPackageOrder())
         )
@@ -218,7 +218,7 @@ class TestVersionSplitPackageOrder(_BaseTestPackagesOrder):
         self.assertEqual("VersionSplitPackageOrder(1,2,3)", repr(inst))
 
     def test_pod(self) -> None:
-        """Validate we can save and load a VersionSplitPackageOrder to it's pod representation."""
+        """Validate we can save and load a VersionSplitPackageOrder to its pod representation."""
         self._test_pod(VersionSplitPackageOrder(first_version=Version("1.2.3")))
 
 

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -10,12 +10,7 @@ import json
 
 from rez.config import config
 from rez.package_order import (
-    NullPackageOrder,
     PackageOrder,
-    PerFamilyOrder,
-    VersionSplitPackageOrder,
-    TimestampPackageOrder,
-    SortedOrder,
     PackageOrderList,
     from_pod,
 )
@@ -24,8 +19,33 @@ from rez.tests.util import TestBase, TempdirMixin
 from rez.version import Version
 
 
+def _orderer(name):
+    """Resolve an orderer class lazily.
+
+    The plugin manager may be reset by other tests (e.g. test_plugin_manager),
+    which re-imports plugin modules and creates new class objects. Importing
+    orderer classes at module level binds them to stale class objects. This
+    helper resolves them at call time so tests always see the current class.
+    """
+    from rez.package_order import _find_orderer
+
+    return _find_orderer(name)
+
+
 class _BaseTestPackagesOrder(TestBase, TempdirMixin):
     """Base class for a package ordering test case"""
+
+    def setUp(self) -> None:
+        # Re-resolve orderer classes on each test run. The plugin manager
+        # may be reset by other tests (e.g. test_plugin_manager), which
+        # re-imports plugin modules and creates new class objects. Class
+        # references bound at module import time would become stale.
+        self.NullPackageOrder = _orderer("no_order")
+        self.SortedOrder = _orderer("sorted")
+        self.PerFamilyOrder = _orderer("per_family")
+        self.VersionSplitPackageOrder = _orderer("version_split")
+        self.TimestampPackageOrder = _orderer("soft_timestamp")
+        super().setUp()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -78,12 +98,12 @@ class TestNullPackageOrder(_BaseTestPackagesOrder):
 
     def test_repr(self) -> None:
         """Validate we can represent a VersionSplitPackageOrder as a string."""
-        self.assertEqual("NullPackageOrder({})", repr(NullPackageOrder()))
+        self.assertEqual("NullPackageOrder({})", repr(self.NullPackageOrder()))
 
     def test_comparison(self) -> None:
         """Validate we can compare VersionSplitPackageOrder together."""
-        inst1 = NullPackageOrder()
-        inst2 = NullPackageOrder()
+        inst1 = self.NullPackageOrder()
+        inst2 = self.NullPackageOrder()
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == "wrong_type")  # __eq__ negative (wrong type)
         self.assertTrue(inst1 != "wrong_type")  # __ne__ positive (wrong type)
@@ -91,11 +111,11 @@ class TestNullPackageOrder(_BaseTestPackagesOrder):
 
     def test_pod(self) -> None:
         """Validate we can save and load a VersionSplitPackageOrder to its pod representation."""
-        self._test_pod(NullPackageOrder())
+        self._test_pod(self.NullPackageOrder())
 
     def test_sha1(self) -> None:
         """Validate we can get a sha1 hash."""
-        self.assertEqual("bf7c2fa4e6bd198c02adeea2c3a382cf57242051", NullPackageOrder().sha1)
+        self.assertEqual("bf7c2fa4e6bd198c02adeea2c3a382cf57242051", self.NullPackageOrder().sha1)
 
 
 class TestSortedOrder(_BaseTestPackagesOrder):
@@ -103,17 +123,17 @@ class TestSortedOrder(_BaseTestPackagesOrder):
 
     def test_reorder_ascending(self) -> None:
         """Validate we can sort packages in ascending order."""
-        self._test_reorder(SortedOrder(descending=False), "pymum", ["1", "2", "3"])
+        self._test_reorder(self.SortedOrder(descending=False), "pymum", ["1", "2", "3"])
 
     def test_reorder_descending(self) -> None:
         """Validate we can sort packages in descending order."""
-        self._test_reorder(SortedOrder(descending=True), "pymum", ["3", "2", "1"])
+        self._test_reorder(self.SortedOrder(descending=True), "pymum", ["3", "2", "1"])
 
     def test_comparison(self) -> None:
         """Validate we can compare SortedOrder together."""
-        inst1 = SortedOrder(descending=False)
-        inst2 = SortedOrder(descending=False)
-        inst3 = SortedOrder(descending=True)
+        inst1 = self.SortedOrder(descending=False)
+        inst2 = self.SortedOrder(descending=False)
+        inst3 = self.SortedOrder(descending=True)
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == inst3)  # __eq__ negative
         self.assertTrue(inst1 != inst3)  # __ne__ positive
@@ -123,11 +143,11 @@ class TestSortedOrder(_BaseTestPackagesOrder):
 
     def test_repr(self) -> None:
         """Validate we can represent a SortedOrder as a string."""
-        self.assertEqual("SortedOrder(True)", repr(SortedOrder(descending=True)))
+        self.assertEqual("SortedOrder(True)", repr(self.SortedOrder(descending=True)))
 
     def test_pod(self) -> None:
         """Validate we can save and load a SortedOrder to its pod representation."""
-        self._test_pod(SortedOrder(descending=True))
+        self._test_pod(self.SortedOrder(descending=True))
 
 
 class TestPerFamilyOrder(_BaseTestPackagesOrder):
@@ -139,13 +159,13 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
         expected_split_result = ["2.6.0", "2.5.2", "2.7.0", "2.6.8"]
         expected_timestamp_result = ["1.1.1", "1.1.0", "1.0.6", "1.0.5", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
 
-        orderer = PerFamilyOrder(
+        orderer = self.PerFamilyOrder(
             order_dict=dict(
-                pysplit=NullPackageOrder(),
-                python=VersionSplitPackageOrder(Version("2.6.0")),
-                timestamped=TimestampPackageOrder(timestamp=3001, rank=3),
+                pysplit=self.NullPackageOrder(),
+                python=self.VersionSplitPackageOrder(Version("2.6.0")),
+                timestamped=self.TimestampPackageOrder(timestamp=3001, rank=3),
             ),
-            default_order=SortedOrder(descending=False),
+            default_order=self.SortedOrder(descending=False),
         )
 
         self._test_reorder(orderer, "pysplit", expected_null_result)
@@ -155,20 +175,20 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
 
     def test_reorder_no_packages(self) -> None:
         """Validate ordering for a family with no packages."""
-        orderer = PerFamilyOrder(order_dict=dict(missing_package=NullPackageOrder()))
+        orderer = self.PerFamilyOrder(order_dict=dict(missing_package=self.NullPackageOrder()))
         self._test_reorder(orderer, "missing_package", [])
 
     def test_reorder_no_default_order(self) -> None:
         """Test behavior when there's no secondary default_order."""
-        fam_orderer = PerFamilyOrder(order_dict={})
+        fam_orderer = self.PerFamilyOrder(order_dict={})
         self._test_reorder(fam_orderer, "pymum", ["3", "2", "1"])
 
     def test_comparison(self) -> None:
         """Validate we can compare PerFamilyOrder."""
-        inst1 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder())
-        inst2 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder())
-        inst3 = PerFamilyOrder(order_dict={"bar": NullPackageOrder()}, default_order=NullPackageOrder())
-        inst4 = PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=None)
+        inst1 = self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}, default_order=self.NullPackageOrder())
+        inst2 = self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}, default_order=self.NullPackageOrder())
+        inst3 = self.PerFamilyOrder(order_dict={"bar": self.NullPackageOrder()}, default_order=self.NullPackageOrder())
+        inst4 = self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}, default_order=None)
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == inst3)  # __eq__ negative (different order dict)
         self.assertFalse(inst1 == inst4)  # __eq__ negative (different default_order)
@@ -178,15 +198,17 @@ class TestPerFamilyOrder(_BaseTestPackagesOrder):
 
     def test_repr(self) -> None:
         """Validate we can represent a PerFamilyOrder as a string."""
-        inst = PerFamilyOrder(order_dict={"family1": VersionSplitPackageOrder(Version("2.6.0"))})
+        inst = self.PerFamilyOrder(order_dict={"family1": self.VersionSplitPackageOrder(Version("2.6.0"))})
         self.assertEqual("PerFamilyOrder(([('family1', '2.6.0')], 'None'))", repr(inst))
 
     def test_pod(self) -> None:
         """Validate we can save and load a PerFamilyOrder to its pod representation."""
-        self._test_pod(PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder()))
+        self._test_pod(
+            self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}, default_order=self.NullPackageOrder())
+        )
 
         # No default_order
-        self._test_pod(PerFamilyOrder(order_dict={"foo": NullPackageOrder()}))
+        self._test_pod(self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}))
 
 
 class TestVersionSplitPackageOrder(_BaseTestPackagesOrder):
@@ -194,15 +216,15 @@ class TestVersionSplitPackageOrder(_BaseTestPackagesOrder):
 
     def test_reordere(self) -> None:
         """Validate package ordering with a VersionSplitPackageOrder"""
-        orderer = VersionSplitPackageOrder(Version("2.6.0"))
+        orderer = self.VersionSplitPackageOrder(Version("2.6.0"))
         expected = ["2.6.0", "2.5.2", "2.7.0", "2.6.8"]
         self._test_reorder(orderer, "python", expected)
 
     def test_comparison(self) -> None:
         """Validate we can compare VersionSplitPackageOrder together."""
-        inst1 = VersionSplitPackageOrder(first_version=Version("1.2.3"))
-        inst2 = VersionSplitPackageOrder(first_version=Version("1.2.3"))
-        inst3 = VersionSplitPackageOrder(first_version=Version("1.2.4"))
+        inst1 = self.VersionSplitPackageOrder(first_version=Version("1.2.3"))
+        inst2 = self.VersionSplitPackageOrder(first_version=Version("1.2.3"))
+        inst3 = self.VersionSplitPackageOrder(first_version=Version("1.2.4"))
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == inst3)  # __eq__ negative
         self.assertTrue(inst1 != inst3)  # __ne__ positive
@@ -212,12 +234,12 @@ class TestVersionSplitPackageOrder(_BaseTestPackagesOrder):
 
     def test_repr(self) -> None:
         """Validate we can represent a VersionSplitPackageOrder as a string."""
-        inst = VersionSplitPackageOrder(first_version=Version("1,2,3"))
+        inst = self.VersionSplitPackageOrder(first_version=Version("1,2,3"))
         self.assertEqual("VersionSplitPackageOrder(1,2,3)", repr(inst))
 
     def test_pod(self) -> None:
         """Validate we can save and load a VersionSplitPackageOrder to its pod representation."""
-        self._test_pod(VersionSplitPackageOrder(first_version=Version("1.2.3")))
+        self._test_pod(self.VersionSplitPackageOrder(first_version=Version("1.2.3")))
 
 
 class TestTimestampPackageOrder(_BaseTestPackagesOrder):
@@ -225,51 +247,51 @@ class TestTimestampPackageOrder(_BaseTestPackagesOrder):
 
     def test_reorder_no_rank(self) -> None:
         """Validate reordering with a rank of 0."""
-        orderer = TimestampPackageOrder(timestamp=3001)
+        orderer = self.TimestampPackageOrder(timestamp=3001)
         expected = ["1.1.0", "1.0.6", "1.0.5", "1.1.1", "1.2.0", "2.0.0", "2.1.0", "2.1.5"]
         self._test_reorder(orderer, "timestamped", expected)
 
     def test_reorder_rank_3(self) -> None:
         """Validate reordering with a rank of 3."""
         # after v1.1.0 and before v1.1.1
-        orderer1 = TimestampPackageOrder(timestamp=3001, rank=3)
+        orderer1 = self.TimestampPackageOrder(timestamp=3001, rank=3)
         expected1 = ["1.1.1", "1.1.0", "1.0.6", "1.0.5", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
         self._test_reorder(orderer1, "timestamped", expected1)
 
         # after v2.1.0 and before v2.1.5
-        orderer2 = TimestampPackageOrder(timestamp=7001, rank=3)
+        orderer2 = self.TimestampPackageOrder(timestamp=7001, rank=3)
         expected2 = ["2.1.5", "2.1.0", "2.0.0", "1.2.0", "1.1.1", "1.1.0", "1.0.6", "1.0.5"]
         self._test_reorder(orderer2, "timestamped", expected2)
 
     def test_reorder_rank_2(self) -> None:
         """Add coverage for a corner case where there's only one candidate without the rank."""
-        orderer = TimestampPackageOrder(timestamp=4001, rank=3)  # 1.1.1
+        orderer = self.TimestampPackageOrder(timestamp=4001, rank=3)  # 1.1.1
         expected = ["1.1.1", "1.1.0", "1.0.6", "1.0.5", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
         self._test_reorder(orderer, "timestamped", expected)
 
     def test_reorder_packages_without_timestamps(self) -> None:
         """Validate reordering of packages that have no timestamp data."""
-        orderer = TimestampPackageOrder(timestamp=3001)
+        orderer = self.TimestampPackageOrder(timestamp=3001)
         self._test_reorder(orderer, "pymum", ["3", "2", "1"])
 
     def test_reorder_all_packages_before_timestamp(self) -> None:
         """Test behavior when all packages are before the timestamp."""
-        timestamp_orderer = TimestampPackageOrder(timestamp=9999999999, rank=3)
+        timestamp_orderer = self.TimestampPackageOrder(timestamp=9999999999, rank=3)
         expected = ["2.1.5", "2.1.0", "2.0.0", "1.2.0", "1.1.1", "1.1.0", "1.0.6", "1.0.5"]
         self._test_reorder(timestamp_orderer, "timestamped", expected)
 
     def test_reorder_all_packages_after_timestamp(self) -> None:
         """Test behavior when all packages are after the timestamp."""
-        timestamp_orderer = TimestampPackageOrder(timestamp=0, rank=3)
+        timestamp_orderer = self.TimestampPackageOrder(timestamp=0, rank=3)
         expected = ["1.0.6", "1.0.5", "1.1.1", "1.1.0", "1.2.0", "2.0.0", "2.1.5", "2.1.0"]
         self._test_reorder(timestamp_orderer, "timestamped", expected)
 
     def test_comparison(self) -> None:
         """Validate we can compare TimestampPackageOrder."""
-        inst1 = TimestampPackageOrder(timestamp=1, rank=1)
-        inst2 = TimestampPackageOrder(timestamp=1, rank=1)
-        inst3 = TimestampPackageOrder(timestamp=2, rank=1)
-        inst4 = TimestampPackageOrder(timestamp=2, rank=2)
+        inst1 = self.TimestampPackageOrder(timestamp=1, rank=1)
+        inst2 = self.TimestampPackageOrder(timestamp=1, rank=1)
+        inst3 = self.TimestampPackageOrder(timestamp=2, rank=1)
+        inst4 = self.TimestampPackageOrder(timestamp=2, rank=2)
         self.assertTrue(inst1 == inst2)  # __eq__ positive
         self.assertFalse(inst1 == inst3)  # __eq__ negative (different timestamp)
         self.assertFalse(inst1 == inst4)  # __eq__ negative (different rank)
@@ -279,12 +301,12 @@ class TestTimestampPackageOrder(_BaseTestPackagesOrder):
 
     def test_repr(self) -> None:
         """Validate we can represent a TimestampPackageOrder as a string."""
-        inst = TimestampPackageOrder(timestamp=1, rank=2)
+        inst = self.TimestampPackageOrder(timestamp=1, rank=2)
         self.assertEqual(repr(inst), "TimestampPackageOrder((1, 2))")
 
     def test_pod(self) -> None:
         """Validate we can save and load a TimestampPackageOrder to pod representation."""
-        self._test_pod(TimestampPackageOrder(timestamp=3001, rank=3))
+        self._test_pod(self.TimestampPackageOrder(timestamp=3001, rank=3))
 
 
 class TestPackageOrdererList(_BaseTestPackagesOrder):
@@ -302,7 +324,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
             ],
         )
         expected = PackageOrderList()
-        expected.append(PerFamilyOrder(order_dict={"python": VersionSplitPackageOrder(Version("2.9.9"))}))
+        expected.append(self.PerFamilyOrder(order_dict={"python": self.VersionSplitPackageOrder(Version("2.9.9"))}))
 
         # Clear @classproperty cache
         try:
@@ -327,8 +349,8 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         """Validate we can save and load a PackageOrdererList to pod representation."""
         inst = PackageOrderList(
             (
-                VersionSplitPackageOrder(Version("2.6.0")),
-                PerFamilyOrder(order_dict={}, default_order=SortedOrder(descending=False)),
+                self.VersionSplitPackageOrder(Version("2.6.0")),
+                self.PerFamilyOrder(order_dict={}, default_order=self.SortedOrder(descending=False)),
             )
         )
         self._test_pod(inst)
@@ -339,25 +361,27 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 
         # sorted
         orderer = module_from_pod({"type": "sorted", "descending": True})
-        self.assertIsInstance(orderer, SortedOrder)
+        self.assertIsInstance(orderer, self.SortedOrder)
         self.assertTrue(orderer.descending)
 
         # no_order
         orderer = module_from_pod({"type": "no_order"})
-        self.assertIsInstance(orderer, NullPackageOrder)
+        self.assertIsInstance(orderer, self.NullPackageOrder)
 
         # version_split
         orderer = module_from_pod({"type": "version_split", "first_version": "1.2.3"})
-        self.assertIsInstance(orderer, VersionSplitPackageOrder)
+        self.assertIsInstance(orderer, self.VersionSplitPackageOrder)
 
     def test_isinstance_against_imported_classes(self):
         """Verify isinstance works for orderer classes imported from package_order."""
-        self.assertIsInstance(SortedOrder(descending=True), SortedOrder)
-        self.assertIsInstance(NullPackageOrder(), NullPackageOrder)
-        self.assertIsInstance(VersionSplitPackageOrder(first_version=Version("1.0")), VersionSplitPackageOrder)
-        self.assertIsInstance(TimestampPackageOrder(timestamp=1000), TimestampPackageOrder)
+        self.assertIsInstance(self.SortedOrder(descending=True), self.SortedOrder)
+        self.assertIsInstance(self.NullPackageOrder(), self.NullPackageOrder)
+        self.assertIsInstance(
+            self.VersionSplitPackageOrder(first_version=Version("1.0")), self.VersionSplitPackageOrder
+        )
+        self.assertIsInstance(self.TimestampPackageOrder(timestamp=1000), self.TimestampPackageOrder)
         # Cross-type checks
-        self.assertNotIsInstance(SortedOrder(descending=True), NullPackageOrder)
+        self.assertNotIsInstance(self.SortedOrder(descending=True), self.NullPackageOrder)
 
     def test_get_orderer_default_fallback(self):
         """Verify get_orderer falls back to SortedOrder(descending=True)."""
@@ -371,7 +395,7 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
             pass
 
         orderer = get_orderer("nonexistent_package")
-        self.assertIsInstance(orderer, SortedOrder)
+        self.assertIsInstance(orderer, self.SortedOrder)
         self.assertTrue(orderer.descending)
 
     def test_plugin_system_loads_builtin_orderers(self) -> None:
@@ -395,11 +419,11 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         from rez.package_order import to_pod, from_pod
 
         orderers = [
-            SortedOrder(descending=True),
-            NullPackageOrder(),
-            VersionSplitPackageOrder(first_version=Version("1.2.3")),
-            TimestampPackageOrder(timestamp=3001, rank=3),
-            PerFamilyOrder(order_dict={"foo": NullPackageOrder()}, default_order=NullPackageOrder()),
+            self.SortedOrder(descending=True),
+            self.NullPackageOrder(),
+            self.VersionSplitPackageOrder(first_version=Version("1.2.3")),
+            self.TimestampPackageOrder(timestamp=3001, rank=3),
+            self.PerFamilyOrder(order_dict={"foo": self.NullPackageOrder()}, default_order=self.NullPackageOrder()),
         ]
 
         for original in orderers:
@@ -559,9 +583,13 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
 class TestPackageOrderPublic(TestBase):
     """Additional tests for public symbols in package_order.py"""
 
+    def setUp(self) -> None:
+        self.VersionSplitPackageOrder = _orderer("version_split")
+        super().setUp()
+
     def test_from_pod_old_style(self) -> None:
         """Validate from_pod is still compatible with the older pod style."""
         self.assertEqual(
-            VersionSplitPackageOrder(first_version=Version("1.2.3")),
+            self.VersionSplitPackageOrder(first_version=Version("1.2.3")),
             from_pod(("version_split", {"first_version": "1.2.3"})),
         )

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -338,6 +338,56 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         ))
         self._test_pod(inst)
 
+    def test_from_pod_module_function_round_trip(self):
+        """Verify the module-level from_pod function resolves orderer types."""
+        from rez.package_order import from_pod as module_from_pod
+
+        # sorted
+        orderer = module_from_pod({"type": "sorted", "descending": True})
+        self.assertIsInstance(orderer, SortedOrder)
+        self.assertTrue(orderer.descending)
+
+        # no_order
+        orderer = module_from_pod({"type": "no_order"})
+        self.assertIsInstance(orderer, NullPackageOrder)
+
+        # version_split
+        orderer = module_from_pod({
+            "type": "version_split",
+            "first_version": "1.2.3"
+        })
+        self.assertIsInstance(orderer, VersionSplitPackageOrder)
+
+    def test_isinstance_against_imported_classes(self):
+        """Verify isinstance works for orderer classes imported from package_order."""
+        self.assertIsInstance(SortedOrder(descending=True), SortedOrder)
+        self.assertIsInstance(NullPackageOrder(), NullPackageOrder)
+        self.assertIsInstance(
+            VersionSplitPackageOrder(first_version=Version("1.0")),
+            VersionSplitPackageOrder
+        )
+        self.assertIsInstance(
+            TimestampPackageOrder(timestamp=1000),
+            TimestampPackageOrder
+        )
+        # Cross-type checks
+        self.assertNotIsInstance(SortedOrder(descending=True), NullPackageOrder)
+
+    def test_get_orderer_default_fallback(self):
+        """Verify get_orderer falls back to SortedOrder(descending=True)."""
+        from rez.package_order import get_orderer, ALL_PACKAGES
+
+        config.override("package_orderers", None)
+        # Clear singleton cache
+        try:
+            delattr(PackageOrderList, '_class_property_singleton')
+        except AttributeError:
+            pass
+
+        orderer = get_orderer("nonexistent_package")
+        self.assertIsInstance(orderer, SortedOrder)
+        self.assertTrue(orderer.descending)
+
 
 class TestPackageOrderPublic(TestBase):
     """Additional tests for public symbols in package_order.py"""

--- a/src/rez/tests/test_packages_order.py
+++ b/src/rez/tests/test_packages_order.py
@@ -388,6 +388,200 @@ class TestPackageOrdererList(_BaseTestPackagesOrder):
         self.assertIsInstance(orderer, SortedOrder)
         self.assertTrue(orderer.descending)
 
+    def test_plugin_system_loads_builtin_orderers(self) -> None:
+        """Verify all five built-in orderers are loadable via the plugin system."""
+        from rez.plugin_managers import plugin_manager
+
+        expected = {
+            "no_order": "NullPackageOrder",
+            "sorted": "SortedOrder",
+            "per_family": "PerFamilyOrder",
+            "version_split": "VersionSplitPackageOrder",
+            "soft_timestamp": "TimestampPackageOrder",
+        }
+
+        for plugin_name, class_name in expected.items():
+            cls = plugin_manager.get_plugin_class('package_order', plugin_name)
+            self.assertEqual(cls.__name__, class_name)
+
+    def test_pod_round_trip_through_plugin_system(self) -> None:
+        """Verify to_pod/from_pod round-trip works through the plugin system."""
+        from rez.package_order import to_pod, from_pod
+
+        orderers = [
+            SortedOrder(descending=True),
+            NullPackageOrder(),
+            VersionSplitPackageOrder(first_version=Version("1.2.3")),
+            TimestampPackageOrder(timestamp=3001, rank=3),
+            PerFamilyOrder(
+                order_dict={"foo": NullPackageOrder()},
+                default_order=NullPackageOrder()
+            ),
+        ]
+
+        for original in orderers:
+            pod = to_pod(original)
+            restored = from_pod(pod)
+            self.assertEqual(original, restored)
+            self.assertIs(type(original), type(restored))
+
+    def test_legacy_register_orderer_fallback(self) -> None:
+        """Verify _find_orderer falls back to _orderers for legacy-registered orderers."""
+        from rez.package_order import (
+            PackageOrder, register_orderer, _find_orderer, _orderers
+        )
+
+        class TestLegacyOrderer(PackageOrder):
+            name = "test_legacy_fallback"
+
+            def sort_key_implementation(self, package_name, version):
+                return 0
+
+            def __str__(self):
+                return "test"
+
+            def to_pod(self):
+                return {}
+
+            @classmethod
+            def from_pod(cls, data):
+                return cls()
+
+        try:
+            register_orderer(TestLegacyOrderer)
+            found = _find_orderer("test_legacy_fallback")
+            self.assertIs(found, TestLegacyOrderer)
+        finally:
+            _orderers.pop("test_legacy_fallback", None)
+
+    def test_rez_package_orderers_json_env_var(self) -> None:
+        """Verify REZ_PACKAGE_ORDERERS_JSON configures orderers at runtime.
+
+        The test framework uses a locked config that blocks env-var reads, so
+        we simulate the env-var path by parsing the JSON and using
+        config.override() — this is exactly what the _JSON path does.
+        """
+        import json
+
+        config_json = json.dumps([
+            {
+                "type": "per_family",
+                "orderers": [
+                    {
+                        "packages": ["python"],
+                        "type": "version_split",
+                        "first_version": "2.9.9"
+                    }
+                ]
+            }
+        ])
+
+        old_overrides = config.overrides.get("package_orderers")
+        try:
+            config.override("package_orderers", json.loads(config_json))
+            PackageOrderList.clear_singleton_cache()
+
+            orderers = PackageOrderList.singleton
+            self.assertEqual(len(orderers), 1)
+            self.assertEqual(orderers[0].name, "per_family")
+        finally:
+            if old_overrides is not None:
+                config.override("package_orderers", old_overrides)
+            else:
+                config.override("package_orderers", None)
+            PackageOrderList.clear_singleton_cache()
+
+    def test_cache_invalidation_for_env_var_changes(self) -> None:
+        """Verify cache invalidation allows config changes to take effect."""
+        import json
+
+        old_overrides = config.overrides.get("package_orderers")
+        try:
+            # First config: empty orderers
+            config.override("package_orderers", None)
+            PackageOrderList.clear_singleton_cache()
+            orderers1 = PackageOrderList.singleton
+            self.assertEqual(len(orderers1), 0)
+
+            # Second config: one orderer
+            config.override("package_orderers", json.loads(
+                '[{"type": "sorted", "descending": false}]'
+            ))
+            PackageOrderList.clear_singleton_cache()
+            orderers2 = PackageOrderList.singleton
+            self.assertEqual(len(orderers2), 1)
+            self.assertEqual(orderers2[0].name, "sorted")
+            self.assertFalse(orderers2[0].descending)
+        finally:
+            if old_overrides is not None:
+                config.override("package_orderers", old_overrides)
+            else:
+                config.override("package_orderers", None)
+            PackageOrderList.clear_singleton_cache()
+
+    def test_kwarg_orderer_configurable_via_env_var(self) -> None:
+        """Verify an orderer with constructor kwargs can be configured at runtime.
+
+        This validates the pattern used by PRs #1706 (PEP440PackageOrder with
+        'prerelease' kwarg) and #1709 (CustomPackageOrder with 'packages' kwarg)
+        without requiring those PRs to be merged.
+
+        The test framework uses a locked config that blocks env-var reads, so
+        we simulate the _JSON path by parsing JSON and using config.override().
+        """
+        import json
+        from rez.package_order import (
+            PackageOrder, register_orderer, _orderers
+        )
+
+        class TestKwargOrderer(PackageOrder):
+            name = "test_kwarg"
+
+            def __init__(self, mode="default", packages=None):
+                super().__init__(packages)
+                self.mode = mode
+
+            def sort_key_implementation(self, package_name, version):
+                return 0
+
+            def __str__(self):
+                return str(self.mode)
+
+            def __eq__(self, other):
+                return type(self) is type(other) and self.mode == other.mode
+
+            def to_pod(self):
+                return {"mode": self.mode, "packages": self.packages}
+
+            @classmethod
+            def from_pod(cls, data):
+                return cls(
+                    mode=data.get("mode", "default"),
+                    packages=data.get("packages"),
+                )
+
+        old_overrides = config.overrides.get("package_orderers")
+        try:
+            register_orderer(TestKwargOrderer)
+
+            config.override("package_orderers", json.loads(
+                '[{"type": "test_kwarg", "mode": "production", "packages": ["foo"]}]'
+            ))
+            PackageOrderList.clear_singleton_cache()
+
+            orderers = PackageOrderList.singleton
+            self.assertEqual(len(orderers), 1)
+            self.assertEqual(orderers[0].name, "test_kwarg")
+            self.assertEqual(orderers[0].mode, "production")
+            self.assertEqual(orderers[0].packages, ["foo"])
+        finally:
+            _orderers.pop("test_kwarg", None)
+            if old_overrides is not None:
+                config.override("package_orderers", old_overrides)
+            else:
+                config.override("package_orderers", None)
+            PackageOrderList.clear_singleton_cache()
+
 
 class TestPackageOrderPublic(TestBase):
     """Additional tests for public symbols in package_order.py"""

--- a/src/rezplugins/package_order/__init__.py
+++ b/src/rezplugins/package_order/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.plugin_managers import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/src/rezplugins/package_order/__init__.py
+++ b/src/rezplugins/package_order/__init__.py
@@ -3,4 +3,5 @@
 
 
 from rez.plugin_managers import extend_path
+
 __path__ = extend_path(__path__, __name__)

--- a/src/rezplugins/package_order/no_order.py
+++ b/src/rezplugins/package_order/no_order.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.package_order import PackageOrder
+
+
+class NullPackageOrder(PackageOrder):
+    """An orderer that does not change the order - a no op.
+
+    This orderer is useful in cases where you want to apply some default orderer
+    to a set of packages, but may want to explicitly NOT reorder a particular
+    package. You would use a :class:`NullPackageOrder` in a :class:`PerFamilyOrder` to do this.
+    """
+    name = "no_order"
+
+    def sort_key_implementation(self, package_name, version):
+        # python's sort will preserve the order of items that compare equal, so
+        # to not change anything, we just return the same object for all...
+        return 0
+
+    def __str__(self):
+        return "{}"
+
+    def __eq__(self, other):
+        return type(self) is type(other)
+
+    def to_pod(self):
+        """
+        Example (in yaml):
+
+        .. code-block:: yaml
+
+           type: no_order
+           packages: ["foo"]
+        """
+        return {
+            "packages": self.packages,
+        }
+
+    @classmethod
+    def from_pod(cls, data):
+        return cls(packages=data.get("packages"))
+
+
+def register_plugin():
+    return NullPackageOrder

--- a/src/rezplugins/package_order/no_order.py
+++ b/src/rezplugins/package_order/no_order.py
@@ -12,6 +12,7 @@ class NullPackageOrder(PackageOrder):
     to a set of packages, but may want to explicitly NOT reorder a particular
     package. You would use a :class:`NullPackageOrder` in a :class:`PerFamilyOrder` to do this.
     """
+
     name = "no_order"
 
     def sort_key_implementation(self, package_name, version):

--- a/src/rezplugins/package_order/no_order.py
+++ b/src/rezplugins/package_order/no_order.py
@@ -2,7 +2,16 @@
 # Copyright Contributors to the Rez Project
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from rez.package_order import PackageOrder
+from rez.utils.typing import SupportsLessThan
+from rez.version import Version
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class NullPackageOrder(PackageOrder):
@@ -15,18 +24,18 @@ class NullPackageOrder(PackageOrder):
 
     name = "no_order"
 
-    def sort_key_implementation(self, package_name, version):
+    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
         # python's sort will preserve the order of items that compare equal, so
         # to not change anything, we just return the same object for all...
         return 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "{}"
 
     def __eq__(self, other):
         return type(self) is type(other)
 
-    def to_pod(self):
+    def to_pod(self) -> dict[str, object]:
         """
         Example (in yaml):
 
@@ -40,7 +49,7 @@ class NullPackageOrder(PackageOrder):
         }
 
     @classmethod
-    def from_pod(cls, data):
+    def from_pod(cls, data: dict[str, object]) -> Self:
         return cls(packages=data.get("packages"))
 
 

--- a/src/rezplugins/package_order/per_family.py
+++ b/src/rezplugins/package_order/per_family.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.package_order import PackageOrder, to_pod, from_pod
+
+
+class PerFamilyOrder(PackageOrder):
+    """An orderer that applies different orderers to different package families.
+    """
+    name = "per_family"
+
+    def __init__(self, order_dict, default_order=None):
+        """Create a reorderer.
+
+        Args:
+            order_dict (dict[str, PackageOrder]): Orderers to apply to
+                each package family.
+            default_order (PackageOrder): Orderer to apply to any packages
+                not specified in ``order_dict``.
+        """
+        super().__init__(list(order_dict))
+        self.order_dict = order_dict.copy()
+        self.default_order = default_order
+
+    def reorder(self, iterable, key=None):
+        package_name = self._get_package_name_from_iterable(iterable, key)
+        if package_name is None:
+            return None
+
+        orderer = self.order_dict.get(package_name)
+        if orderer is None:
+            orderer = self.default_order
+        if orderer is None:
+            return None
+
+        return orderer.reorder(iterable, key)
+
+    def sort_key_implementation(self, package_name, version):
+        orderer = self.order_dict.get(package_name)
+        if orderer is None:
+            if self.default_order is None:
+                # shouldn't get here, because applies_to should protect us...
+                raise RuntimeError(
+                    "package family orderer %r does not apply to package family %r",
+                    (self, package_name))
+
+            orderer = self.default_order
+
+        return orderer.sort_key_implementation(package_name, version)
+
+    def __str__(self):
+        items = sorted((x[0], str(x[1])) for x in self.order_dict.items())
+        return str((items, str(self.default_order)))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.order_dict == other.order_dict
+            and self.default_order == other.default_order
+        )
+
+    def to_pod(self):
+        """
+        Example (in yaml):
+
+        .. code-block:: yaml
+
+           type: per_family
+           orderers:
+           - packages: ['foo', 'bah']
+             type: version_split
+             first_version: '4.0.5'
+           - packages: ['python']
+             type: sorted
+             descending: false
+           default_order:
+             type: sorted
+             descending: true
+        """
+        orderers = {}
+        packages = {}
+
+        # group package fams by orderer they use
+        for fam, orderer in self.order_dict.items():
+            k = id(orderer)
+            orderers[k] = orderer
+            packages.setdefault(k, set()).add(fam)
+
+        orderlist = []
+        for k, fams in packages.items():
+            orderer = orderers[k]
+            data = to_pod(orderer)
+            data["packages"] = sorted(fams)
+            orderlist.append(data)
+
+        result = {"orderers": orderlist}
+
+        if self.default_order is not None:
+            result["default_order"] = to_pod(self.default_order)
+
+        return result
+
+    @classmethod
+    def from_pod(cls, data):
+        order_dict = {}
+        default_order = None
+
+        for d in data["orderers"]:
+            d = d.copy()
+            fams = d.pop("packages")
+            orderer = from_pod(d)
+
+            for fam in fams:
+                order_dict[fam] = orderer
+
+        d = data.get("default_order")
+        if d:
+            default_order = from_pod(d)
+
+        return cls(order_dict, default_order)
+
+
+def register_plugin():
+    return PerFamilyOrder

--- a/src/rezplugins/package_order/per_family.py
+++ b/src/rezplugins/package_order/per_family.py
@@ -6,8 +6,8 @@ from rez.package_order import PackageOrder, to_pod, from_pod
 
 
 class PerFamilyOrder(PackageOrder):
-    """An orderer that applies different orderers to different package families.
-    """
+    """An orderer that applies different orderers to different package families."""
+
     name = "per_family"
 
     def __init__(self, order_dict, default_order=None):
@@ -42,8 +42,8 @@ class PerFamilyOrder(PackageOrder):
             if self.default_order is None:
                 # shouldn't get here, because applies_to should protect us...
                 raise RuntimeError(
-                    "package family orderer %r does not apply to package family %r",
-                    (self, package_name))
+                    "package family orderer %r does not apply to package family %r", (self, package_name)
+                )
 
             orderer = self.default_order
 

--- a/src/rezplugins/package_order/per_family.py
+++ b/src/rezplugins/package_order/per_family.py
@@ -2,7 +2,17 @@
 # Copyright Contributors to the Rez Project
 
 
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, TYPE_CHECKING
+
 from rez.package_order import PackageOrder, to_pod, from_pod
+from rez.packages import Package
+from rez.utils.typing import SupportsLessThan
+from rez.version import Version
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class PerFamilyOrder(PackageOrder):
@@ -10,7 +20,7 @@ class PerFamilyOrder(PackageOrder):
 
     name = "per_family"
 
-    def __init__(self, order_dict, default_order=None):
+    def __init__(self, order_dict: dict[str, PackageOrder], default_order: PackageOrder | None = None) -> None:
         """Create a reorderer.
 
         Args:
@@ -23,7 +33,7 @@ class PerFamilyOrder(PackageOrder):
         self.order_dict = order_dict.copy()
         self.default_order = default_order
 
-    def reorder(self, iterable, key=None):
+    def reorder(self, iterable: Iterable[Package], key: Callable[[Any], Package] | None = None) -> list[Package] | None:
         package_name = self._get_package_name_from_iterable(iterable, key)
         if package_name is None:
             return None
@@ -36,7 +46,7 @@ class PerFamilyOrder(PackageOrder):
 
         return orderer.reorder(iterable, key)
 
-    def sort_key_implementation(self, package_name, version):
+    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
         orderer = self.order_dict.get(package_name)
         if orderer is None:
             if self.default_order is None:
@@ -49,18 +59,18 @@ class PerFamilyOrder(PackageOrder):
 
         return orderer.sort_key_implementation(package_name, version)
 
-    def __str__(self):
+    def __str__(self) -> str:
         items = sorted((x[0], str(x[1])) for x in self.order_dict.items())
         return str((items, str(self.default_order)))
 
     def __eq__(self, other):
         return (
-            type(self) is type(other)
+            type(other) is type(self)
             and self.order_dict == other.order_dict
             and self.default_order == other.default_order
         )
 
-    def to_pod(self):
+    def to_pod(self) -> dict[str, Any]:
         """
         Example (in yaml):
 
@@ -94,7 +104,7 @@ class PerFamilyOrder(PackageOrder):
             data["packages"] = sorted(fams)
             orderlist.append(data)
 
-        result = {"orderers": orderlist}
+        result: dict[str, Any] = {"orderers": orderlist}
 
         if self.default_order is not None:
             result["default_order"] = to_pod(self.default_order)
@@ -102,7 +112,7 @@ class PerFamilyOrder(PackageOrder):
         return result
 
     @classmethod
-    def from_pod(cls, data):
+    def from_pod(cls, data: dict[str, Any]) -> Self:
         order_dict = {}
         default_order = None
 

--- a/src/rezplugins/package_order/soft_timestamp.py
+++ b/src/rezplugins/package_order/soft_timestamp.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.package_order import PackageOrder
+from rez.packages import iter_packages
+from rez.version._version import _ReversedComparable
+
+
+class TimestampPackageOrder(PackageOrder):
+    """A timestamp order function.
+
+    Given a time ``T``, this orderer returns packages released before ``T``, in descending
+    order, followed by those released after. If ``rank`` is non-zero, version
+    changes at that rank and above are allowed over the timestamp.
+
+    For example, consider the common case where we want to prioritize packages
+    released before ``T``, except for newer patches. Consider the following package
+    versions, and time ``T``:
+
+    .. code-block:: text
+
+       2.2.1
+       2.2.0
+       2.1.1
+       2.1.0
+       2.0.6
+       2.0.5
+             <-- T
+       2.0.0
+       1.9.0
+
+    A timestamp orderer set to ``rank=3`` (patch versions) will attempt to consume
+    the packages in the following order:
+
+    .. code-block:: text
+
+       2.0.6
+       2.0.5
+       2.0.0
+       1.9.0
+       2.1.1
+       2.1.0
+       2.2.1
+       2.2.0
+
+    Notice that packages before ``T`` are preferred, followed by newer versions.
+    Newer versions are consumed in ascending order, except within rank (this is
+    why 2.1.1 is consumed before 2.1.0).
+    """
+    name = "soft_timestamp"
+
+    def __init__(self, timestamp, rank=0, packages=None):
+        """Create a reorderer.
+
+        Args:
+            timestamp (int): Epoch time of timestamp. Packages before this time
+                are preferred.
+            rank (int): If non-zero, allow version changes at this rank or above
+                past the timestamp.
+        """
+        super().__init__(packages)
+        self.timestamp = timestamp
+        self.rank = rank
+
+        # dictionary mapping from package family to the first-version-after
+        # the given timestamp
+        self._cached_first_after = {}
+        self._cached_sort_key = {}
+
+    def _get_first_after(self, package_family):
+        """Get the first package version that is after the timestamp"""
+        try:
+            first_after = self._cached_first_after[package_family]
+        except KeyError:
+            first_after = self._calc_first_after(package_family)
+            self._cached_first_after[package_family] = first_after
+        return first_after
+
+    def _calc_first_after(self, package_family):
+        descending = sorted(iter_packages(package_family),
+                            key=lambda p: p.version,
+                            reverse=True)
+        first_after = None
+        for i, package in enumerate(descending):
+            if not package.timestamp:
+                continue
+            if package.timestamp > self.timestamp:
+                first_after = package.version
+            else:
+                break
+
+        if not self.rank:
+            return first_after
+
+        # if we have rank, then we need to then go back UP the
+        # versions, until we find one whose trimmed version doesn't
+        # match.
+        # Note that we COULD do this by simply iterating through
+        # an ascending sequence, in which case we wouldn't have to
+        # "switch direction" after finding the first result after
+        # by timestamp... but we're making the assumption that the
+        # timestamp break will be closer to the higher end of the
+        # version, and that we'll therefore have to check fewer
+        # timestamps this way...
+        trimmed_version = package.version.trim(self.rank - 1)
+        first_after = None
+        for after_package in reversed(descending[:i]):
+            if after_package.version.trim(self.rank - 1) != trimmed_version:
+                return after_package.version
+
+        return first_after
+
+    def _calc_sort_key(self, package_name, version):
+        first_after = self._get_first_after(package_name)
+        if first_after is None:
+            # all packages are before T
+            is_before = True
+        else:
+            is_before = int(version < first_after)
+
+        if is_before:
+            return is_before, version
+
+        if self.rank:
+            return (is_before,
+                    _ReversedComparable(version.trim(self.rank - 1)),
+                    version.tokens[self.rank - 1:])
+
+        return is_before, _ReversedComparable(version)
+
+    def sort_key_implementation(self, package_name, version):
+        cache_key = (package_name, str(version))
+        result = self._cached_sort_key.get(cache_key)
+        if result is None:
+            result = self._calc_sort_key(package_name, version)
+            self._cached_sort_key[cache_key] = result
+
+        return result
+
+    def __str__(self):
+        return str((self.timestamp, self.rank))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.timestamp == other.timestamp
+            and self.rank == other.rank
+        )
+
+    def to_pod(self):
+        """
+        Example (in yaml):
+
+        .. code-block:: yaml
+
+           type: soft_timestamp
+           timestamp: 1234567
+           rank: 3
+           packages: ["foo"]
+        """
+        return dict(
+            timestamp=self.timestamp,
+            rank=self.rank,
+            packages=self.packages,
+        )
+
+    @classmethod
+    def from_pod(cls, data):
+        return cls(
+            data["timestamp"],
+            rank=data.get("rank", 0),
+            packages=data.get("packages"),
+        )
+
+
+def register_plugin():
+    return TimestampPackageOrder

--- a/src/rezplugins/package_order/soft_timestamp.py
+++ b/src/rezplugins/package_order/soft_timestamp.py
@@ -48,6 +48,7 @@ class TimestampPackageOrder(PackageOrder):
     Newer versions are consumed in ascending order, except within rank (this is
     why 2.1.1 is consumed before 2.1.0).
     """
+
     name = "soft_timestamp"
 
     def __init__(self, timestamp, rank=0, packages=None):
@@ -78,9 +79,7 @@ class TimestampPackageOrder(PackageOrder):
         return first_after
 
     def _calc_first_after(self, package_family):
-        descending = sorted(iter_packages(package_family),
-                            key=lambda p: p.version,
-                            reverse=True)
+        descending = sorted(iter_packages(package_family), key=lambda p: p.version, reverse=True)
         first_after = None
         for i, package in enumerate(descending):
             if not package.timestamp:
@@ -123,9 +122,7 @@ class TimestampPackageOrder(PackageOrder):
             return is_before, version
 
         if self.rank:
-            return (is_before,
-                    _ReversedComparable(version.trim(self.rank - 1)),
-                    version.tokens[self.rank - 1:])
+            return (is_before, _ReversedComparable(version.trim(self.rank - 1)), version.tokens[self.rank - 1 :])
 
         return is_before, _ReversedComparable(version)
 
@@ -142,11 +139,7 @@ class TimestampPackageOrder(PackageOrder):
         return str((self.timestamp, self.rank))
 
     def __eq__(self, other):
-        return (
-            type(self) is type(other)
-            and self.timestamp == other.timestamp
-            and self.rank == other.rank
-        )
+        return type(self) is type(other) and self.timestamp == other.timestamp and self.rank == other.rank
 
     def to_pod(self):
         """

--- a/src/rezplugins/package_order/soft_timestamp.py
+++ b/src/rezplugins/package_order/soft_timestamp.py
@@ -2,9 +2,18 @@
 # Copyright Contributors to the Rez Project
 
 
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
 from rez.package_order import PackageOrder
 from rez.packages import iter_packages
+from rez.utils.typing import SupportsLessThan
+from rez.version import Version
 from rez.version._version import _ReversedComparable
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class TimestampPackageOrder(PackageOrder):
@@ -51,7 +60,7 @@ class TimestampPackageOrder(PackageOrder):
 
     name = "soft_timestamp"
 
-    def __init__(self, timestamp, rank=0, packages=None):
+    def __init__(self, timestamp: int, rank: int = 0, packages: list[str] | None = None) -> None:
         """Create a reorderer.
 
         Args:
@@ -69,7 +78,7 @@ class TimestampPackageOrder(PackageOrder):
         self._cached_first_after = {}
         self._cached_sort_key = {}
 
-    def _get_first_after(self, package_family):
+    def _get_first_after(self, package_family: str) -> Version | None:
         """Get the first package version that is after the timestamp"""
         try:
             first_after = self._cached_first_after[package_family]
@@ -78,7 +87,7 @@ class TimestampPackageOrder(PackageOrder):
             self._cached_first_after[package_family] = first_after
         return first_after
 
-    def _calc_first_after(self, package_family):
+    def _calc_first_after(self, package_family: str) -> Version | None:
         descending = sorted(iter_packages(package_family), key=lambda p: p.version, reverse=True)
         first_after = None
         for i, package in enumerate(descending):
@@ -110,11 +119,11 @@ class TimestampPackageOrder(PackageOrder):
 
         return first_after
 
-    def _calc_sort_key(self, package_name, version):
+    def _calc_sort_key(self, package_name: str, version: Version) -> SupportsLessThan:
         first_after = self._get_first_after(package_name)
         if first_after is None:
             # all packages are before T
-            is_before = True
+            is_before: bool | int = True
         else:
             is_before = int(version < first_after)
 
@@ -122,11 +131,11 @@ class TimestampPackageOrder(PackageOrder):
             return is_before, version
 
         if self.rank:
-            return (is_before, _ReversedComparable(version.trim(self.rank - 1)), version.tokens[self.rank - 1 :])
+            return (is_before, _ReversedComparable(version.trim(self.rank - 1)), version.tokens[self.rank - 1:])
 
         return is_before, _ReversedComparable(version)
 
-    def sort_key_implementation(self, package_name, version):
+    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
         cache_key = (package_name, str(version))
         result = self._cached_sort_key.get(cache_key)
         if result is None:
@@ -135,13 +144,13 @@ class TimestampPackageOrder(PackageOrder):
 
         return result
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str((self.timestamp, self.rank))
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.timestamp == other.timestamp and self.rank == other.rank
+        return type(other) is type(self) and self.timestamp == other.timestamp and self.rank == other.rank
 
-    def to_pod(self):
+    def to_pod(self) -> dict[str, Any]:
         """
         Example (in yaml):
 
@@ -159,7 +168,7 @@ class TimestampPackageOrder(PackageOrder):
         )
 
     @classmethod
-    def from_pod(cls, data):
+    def from_pod(cls, data: dict[str, Any]) -> Self:
         return cls(
             data["timestamp"],
             rank=data.get("rank", 0),

--- a/src/rezplugins/package_order/sorted.py
+++ b/src/rezplugins/package_order/sorted.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.package_order import PackageOrder
+from rez.version._version import _ReversedComparable
+
+
+class SortedOrder(PackageOrder):
+    """An orderer that sorts based on :attr:`Package.version <rez.packages.Package.version>`.
+    """
+    name = "sorted"
+
+    def __init__(self, descending, packages=None):
+        super().__init__(packages)
+        self.descending = descending
+
+    def sort_key_implementation(self, package_name, version):
+        # Note that the name "descending" can be slightly confusing - it
+        # indicates that the final ordering this Order gives should be
+        # version descending (ie, the default) - however, the sort_key itself
+        # returns its results in "normal" ascending order (because it needs to
+        # be used "alongside" normally-sorted objects like versions).
+        # when the key is passed to sort(), though, it is always invoked with
+        # reverse=True...
+        if self.descending:
+            return version
+        else:
+            return _ReversedComparable(version)
+
+    def __str__(self):
+        return str(self.descending)
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.descending == other.descending
+        )
+
+    def to_pod(self):
+        """
+        Example (in yaml):
+
+        .. code-block:: yaml
+
+           type: sorted
+           descending: true
+           packages: ["foo"]
+        """
+        return {
+            "descending": self.descending,
+            "packages": self.packages,
+        }
+
+    @classmethod
+    def from_pod(cls, data):
+        return cls(
+            data["descending"],
+            packages=data.get("packages"),
+        )
+
+
+def register_plugin():
+    return SortedOrder

--- a/src/rezplugins/package_order/sorted.py
+++ b/src/rezplugins/package_order/sorted.py
@@ -7,8 +7,8 @@ from rez.version._version import _ReversedComparable
 
 
 class SortedOrder(PackageOrder):
-    """An orderer that sorts based on :attr:`Package.version <rez.packages.Package.version>`.
-    """
+    """An orderer that sorts based on :attr:`Package.version <rez.packages.Package.version>`."""
+
     name = "sorted"
 
     def __init__(self, descending, packages=None):
@@ -32,10 +32,7 @@ class SortedOrder(PackageOrder):
         return str(self.descending)
 
     def __eq__(self, other):
-        return (
-            type(self) is type(other)
-            and self.descending == other.descending
-        )
+        return type(self) is type(other) and self.descending == other.descending
 
     def to_pod(self):
         """

--- a/src/rezplugins/package_order/sorted.py
+++ b/src/rezplugins/package_order/sorted.py
@@ -2,8 +2,17 @@
 # Copyright Contributors to the Rez Project
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from rez.package_order import PackageOrder
+from rez.utils.typing import SupportsLessThan
+from rez.version import Version
 from rez.version._version import _ReversedComparable
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class SortedOrder(PackageOrder):
@@ -11,11 +20,11 @@ class SortedOrder(PackageOrder):
 
     name = "sorted"
 
-    def __init__(self, descending, packages=None):
+    def __init__(self, descending: bool, packages: list[str] | None = None) -> None:
         super().__init__(packages)
         self.descending = descending
 
-    def sort_key_implementation(self, package_name, version):
+    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
         # Note that the name "descending" can be slightly confusing - it
         # indicates that the final ordering this Order gives should be
         # version descending (ie, the default) - however, the sort_key itself
@@ -28,13 +37,13 @@ class SortedOrder(PackageOrder):
         else:
             return _ReversedComparable(version)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.descending)
 
     def __eq__(self, other):
         return type(self) is type(other) and self.descending == other.descending
 
-    def to_pod(self):
+    def to_pod(self) -> dict[str, object]:
         """
         Example (in yaml):
 
@@ -50,7 +59,7 @@ class SortedOrder(PackageOrder):
         }
 
     @classmethod
-    def from_pod(cls, data):
+    def from_pod(cls, data: dict[str, object]) -> Self:
         return cls(
             data["descending"],
             packages=data.get("packages"),

--- a/src/rezplugins/package_order/version_split.py
+++ b/src/rezplugins/package_order/version_split.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+from rez.package_order import PackageOrder
+from rez.version import Version
+
+
+class VersionSplitPackageOrder(PackageOrder):
+    """Orders package versions <= a given version first.
+
+    For example, given the versions [5, 4, 3, 2, 1], an orderer initialized
+    with ``version=3`` would give the order [3, 2, 1, 5, 4].
+    """
+    name = "version_split"
+
+    def __init__(self, first_version, packages=None):
+        """Create a reorderer.
+
+        Args:
+            first_version (Version): Start with versions <= this value.
+        """
+        super().__init__(packages)
+        self.first_version = first_version
+
+    def sort_key_implementation(self, package_name, version):
+        priority_key = 1 if version <= self.first_version else 0
+        return priority_key, version
+
+    def __str__(self):
+        return str(self.first_version)
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.first_version == other.first_version
+        )
+
+    def to_pod(self):
+        """
+        Example (in yaml):
+
+        .. code-block:: yaml
+
+           type: version_split
+           first_version: "3.0.0"
+           packages: ["foo"]
+        """
+        return dict(
+            first_version=str(self.first_version),
+            packages=self.packages,
+        )
+
+    @classmethod
+    def from_pod(cls, data):
+        return cls(
+            Version(data["first_version"]),
+            packages=data.get("packages"),
+        )
+
+
+def register_plugin():
+    return VersionSplitPackageOrder

--- a/src/rezplugins/package_order/version_split.py
+++ b/src/rezplugins/package_order/version_split.py
@@ -2,8 +2,16 @@
 # Copyright Contributors to the Rez Project
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from rez.package_order import PackageOrder
+from rez.utils.typing import SupportsLessThan
 from rez.version import Version
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class VersionSplitPackageOrder(PackageOrder):
@@ -15,7 +23,7 @@ class VersionSplitPackageOrder(PackageOrder):
 
     name = "version_split"
 
-    def __init__(self, first_version, packages=None):
+    def __init__(self, first_version: Version, packages: list[str] | None = None) -> None:
         """Create a reorderer.
 
         Args:
@@ -24,17 +32,17 @@ class VersionSplitPackageOrder(PackageOrder):
         super().__init__(packages)
         self.first_version = first_version
 
-    def sort_key_implementation(self, package_name, version):
+    def sort_key_implementation(self, package_name: str, version: Version) -> SupportsLessThan:
         priority_key = 1 if version <= self.first_version else 0
         return priority_key, version
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.first_version)
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.first_version == other.first_version
+        return type(other) is type(self) and self.first_version == other.first_version
 
-    def to_pod(self):
+    def to_pod(self) -> dict[str, object]:
         """
         Example (in yaml):
 
@@ -50,7 +58,7 @@ class VersionSplitPackageOrder(PackageOrder):
         )
 
     @classmethod
-    def from_pod(cls, data):
+    def from_pod(cls, data: dict[str, object]) -> Self:
         return cls(
             Version(data["first_version"]),
             packages=data.get("packages"),

--- a/src/rezplugins/package_order/version_split.py
+++ b/src/rezplugins/package_order/version_split.py
@@ -12,6 +12,7 @@ class VersionSplitPackageOrder(PackageOrder):
     For example, given the versions [5, 4, 3, 2, 1], an orderer initialized
     with ``version=3`` would give the order [3, 2, 1, 5, 4].
     """
+
     name = "version_split"
 
     def __init__(self, first_version, packages=None):
@@ -31,10 +32,7 @@ class VersionSplitPackageOrder(PackageOrder):
         return str(self.first_version)
 
     def __eq__(self, other):
-        return (
-            type(self) is type(other)
-            and self.first_version == other.first_version
-        )
+        return type(self) is type(other) and self.first_version == other.first_version
 
     def to_pod(self):
         """


### PR DESCRIPTION
** WIP, DO NOT REVIEW YET :) **

# Summary

Rebases and fixes #1787 by @cfxegbert 
Moves the 5 built-in package-orderers from `src/rez/package_order.py` to `src/rezplugins/package_order/` as proper rez plugins.
Adds runtime configuration support via `REZ_PACKAGE_ORDERERS_JSON` and cache invalidation, creating a platform for PRs #1706 + #1709 to land in a usable manner with minimal changes.

# What changed (on top of the PR #1787 rebase+fixing)

1. Moves PackageOrderers into plugins.
2. Registers `PackageOrderPluginType` in `plugin_managers.py`
3. Replaces #1787 's function-based backward-compat shims with PEP-562 `__getattr__` lazy aliases, so `isinstance`, `from_pod`, `type(x) is` checks all work against the imported class names, while avoiding a circular import that module-level aliases would cause (plugin files import from package_order.py, which would call `_find_orderer` -> plugin system at load time)
4. Keeps `register_orderer()` and the `_orderers` dict as a means to subclass/apply orderers programmatically.
5. ruff-compatible reformatting of touched files ends up affecting many lines of code generically. It may be easiest to review commit by commit for this reason.

# Runtime configuration of Package Orderers

1. Documents that `REZ_PACKAGE_ORDERERS_JSON` works end-to-end using the existing `_JSON` env-var configuration pathway that then feeds into `config.package_orderers` -> `PackageOrderList.singleton` -> `from_pod()`
2. Adds `PackageOrderList.clear_singleton_cache()` classmethod to invalidate the cached singleton, so runtime config changes can take effect without restarting, or API-based-usage of the feature can be correctly managed.

# Documentation

1. Adds `REZ_PACKAGE_ORDERERS_JSON` usage section to `docs/source/package_orderers.rst`
2. Updates custom orderers section to recommend the plugin approach over `register_orderer()`

# Design Notes

1. The original plan was `SortedOrder = _find_orderer('sorted')` at module level, but this causes a circular import (`package_order.py` -> `_find_orderer()` -> plugin system -> `rezplugins/package_order/sorted.py` -> `from rez.package_order import PackageOrder` -> still importing). The `__getattr__` approach defers resolution to the first attribute access, breaking the cycle.
2. The locked config used by the test framework blocks env-var reads, so the runtime config tests simulate the `REZ_PACKAGE_ORDERERS_JSON` path by parsing JSON and using `config.override()` which is what the `_JSON` path does internally.
3. Needed a lazy class resolution to survive test_plugin_manager's plugin manager reset

# Testing

1. 46 orderer tests + 2 completion tests
2. Pre-flight tests were added _before_ the refactor to catch potential regressions: `from_pod` round-trip, `isinstance` against imported classes, `get_orderer` default fallback
4. New tests: plugin loading of all five built-in orderers, `to_pod` / `from_pod` round-trip through the plugin system, legacy `register_orderer` fallback, runtime config via `config.override` (simulating the `_JSON` path), cache invalidation, and a test-only kwarg-orderer that validates the pattern used in #1706 / #1709 (constructor kwargs configured at runtime).

# Credit

Original refactor by @cfxegbert . Rebased on to current main, conflicts resolved, backward-compat shims fixed, and runtime configuration support added by me.

# Follow-on work (not here)

1. Possibly perform an API-breaking change from usage of `PackageOrder` class names (and other namings/imports/etc) to `PackageOrderer` for making-more-sense?
2. PRs #1706 and #1709 could land as-is or could be migrated into `rezplugins` to join the rest.

Disclosure: This PR was assisted by GLM-5.2 for docstrings, documentation, and test generation.