### PR TITLE
Fix AttributeError in Wrapper.print_package_versions

### DIFF
--- a/src/rez/tests/test_suites.py
+++ b/src/rez/tests/test_suites.py
@@ -9,6 +9,7 @@ from rez.tests.util import TestBase, TempdirMixin, \
     per_available_shell, install_dependent
 from rez.resolved_context import ResolvedContext
 from rez.suite import Suite
+from rez.wrapper import Wrapper
 from rez.config import config
 from rez.system import system
 import subprocess
@@ -140,6 +141,18 @@ class TestRezSuites(TestBase, TempdirMixin):
         self.assertEqual(s.get_tool_context("bahbah"), "bah")
 
         self._test_serialization(s)
+
+    def test_print_package_versions(self) -> None:
+        """Test that a wrapper can print the versions of its package."""
+        c_foo = ResolvedContext(["foo"])
+        s = Suite()
+        s.add_context("foo", c_foo)
+
+        suite_path = os.path.join(self.root, uuid.uuid4().hex)
+        s.save(suite_path)
+
+        w = Wrapper(os.path.join(suite_path, "bin", "fooer"))
+        self.assertEqual(w.print_package_versions(), 0)
 
     @per_available_shell()
     @install_dependent()

--- a/src/rez/wrapper.py
+++ b/src/rez/wrapper.py
@@ -248,7 +248,7 @@ class Wrapper(object):
                         col = local if pkg.is_local else None
 
                     label = "(local)" if pkg.is_local else ""
-                    rows.append((name, pkg.path, label))
+                    rows.append((name, pkg.uri, label))
                     colors.append(col)
 
                 _pr = Printer()


### PR DESCRIPTION
Closes #2046

`print_package_versions` builds its rows from `pkg.path`, but `Package` has no `path` attribute — the package's location is exposed as `uri` (as rez-view, rez-help and rez-cp already use), so `++versions` on any suite tool raised `AttributeError: Package instance has no attribute 'path'` instead of printing the table.

Added `test_print_package_versions`, which fails with the reported AttributeError before the change and passes after.
