### PR TITLE
fix(package_cache): skip malformed variant json in get_variants

### DIFF
--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -667,8 +667,14 @@ class PackageCache(object):
 
                     for name in safe_listdir(path3):
                         if name.endswith(".json"):
-                            with open(os.path.join(path3, name)) as f:
-                                data = json.loads(f.read())
+                            try:
+                                with open(os.path.join(path3, name)) as f:
+                                    data = json.loads(f.read())
+                            except (OSError, ValueError):
+                                # variant json is unreadable or corrupt (eg
+                                # truncated by a full disk); skip it rather
+                                # than break every cache query
+                                continue
 
                             handle = data["handle"]
                             variant = get_variant(handle)

--- a/src/rez/tests/test_package_cache.py
+++ b/src/rez/tests/test_package_cache.py
@@ -130,6 +130,25 @@ class TestPackageCache(TestBase, TempdirMixin):
         with self.assertRaises(PackageCacheError):
             pkgcache.add_variant(variant)
 
+    def test_get_variants_ignores_malformed_json(self) -> None:
+        """Test that a corrupt variant json file doesn't break cache queries."""
+        pkgcache = self._pkgcache()
+
+        package = get_package("versioned", "3.0")
+        variant = next(package.iter_variants())
+        pkgcache.add_variant(variant)
+
+        self.assertEqual(len(pkgcache.get_variants()), 1)
+
+        # simulate a variant json truncated by a full disk
+        for root, _, names in os.walk(pkgcache.path):
+            for name in names:
+                if name.endswith(".json"):
+                    with open(os.path.join(root, name), "w"):
+                        pass
+
+        self.assertEqual(pkgcache.get_variants(), [])
+
     def test_external_logging_config(self):
         """Test that external logging is respected if configured."""
         config_file_path = canonical_path(self.data_path("config", "logging_config_test.conf"))


### PR DESCRIPTION
Closes #2016

A variant json file truncated by a full cache disk made `json.loads` raise straight out of `PackageCache.get_variants()`, so every `rez-pkg-cache` command that enumerates the cache crashed with a `JSONDecodeError` — including `--clean`, which is what you'd run to recover from exactly that situation.

Corrupt/unreadable variant json files are now skipped, matching how the pending-file loops in the same class already handle them. New test writes an empty variant json and asserts `get_variants()` returns cleanly; it fails with the reported `JSONDecodeError` without the fix.
