### PR TITLE
fix(ephemerals): don't cache empty ephemerals

### DIFF
--- a/src/rez/packages.py
+++ b/src/rez/packages.py
@@ -9,6 +9,7 @@ from rez.package_resources import PackageFamilyResource, PackageResource, \
     VariantResource, package_family_schema, package_schema, variant_schema, \
     package_release_keys, late_requires_schema
 from rez.package_serialise import dump_package_data
+from rez.rex_bindings import EphemeralsBinding
 from rez.utils import reraise
 from rez.utils.sourcecode import SourceCode
 from rez.utils.data_utils import cached_property
@@ -182,9 +183,11 @@ class PackageBaseResourceWrapper(PackageRepositoryResourceWrapper):
 
         if self.context is None:
             g["in_context"] = lambda: False
+            g["ephemerals"] = EphemeralsBinding([])
         else:
             g["in_context"] = lambda: True
             g["context"] = self.context
+            g["ephemerals"] = EphemeralsBinding(self.context.resolved_ephemerals or [])
 
             # 'request', 'system' etc
             bindings = self.context._get_pre_resolve_bindings()

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -2049,7 +2049,6 @@ class ResolvedContext(object):
                 "testing": self.testing,
                 "request": RequirementsBinding(self._package_requests),
                 "implicits": RequirementsBinding(self.implicit_packages),
-                "ephemerals": EphemeralsBinding(self.resolved_ephemerals or []),
                 "intersects": intersects
             }
 
@@ -2135,6 +2134,7 @@ class ResolvedContext(object):
             executor.bind(k, v)
 
         executor.bind("resolve", VariantsBinding(variant_bindings))
+        executor.bind("ephemerals", EphemeralsBinding(self.resolved_ephemerals or []))
 
         #
         # -- apply each resolved package to the execution context

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -8,16 +8,19 @@ test resolved contexts
 from rez.tests.util import restore_os_environ, restore_sys_path, TempdirMixin, \
     TestBase
 from rez.resolved_context import ResolvedContext
+from rez.resolver import ResolverStatus
 from rez.bundle_context import bundle_context
 from rez.bind import hello_world
 from rez.utils.platform_ import platform_
 from rez.utils.filesystem import is_subdirectory
+from rez.version import Requirement
 import unittest
 import subprocess
 import platform
 import shutil
 import os.path
 import os
+import textwrap
 
 
 class TestContext(TestBase, TempdirMixin):
@@ -306,6 +309,70 @@ class TestContext(TestBase, TempdirMixin):
                 continue
             # check types here, as not all type instances are comparable
             self.assertIs(type(v), type(r2.__dict__.get(k)))
+
+    def test_ephemerals_update_during_resolution(self):
+        packages_path = os.path.join(self.root, "ephemeral_packages")
+        package_version = os.path.join(packages_path, "package", "1.0.0")
+        package_definition = os.path.join(package_version, "package.py")
+
+        package_contents = textwrap.dedent("""
+            name = "package"
+            version = "1.0.0"
+
+            def commands():
+                if "myeph" in ephemerals:
+                    env.EPH_SEEN_IN_COMMANDS = "1"
+                else:
+                    env.EPH_SEEN_IN_COMMANDS = "0"
+        """)
+
+        os.makedirs(package_version)
+
+        with open(package_definition, "w") as fh:
+            fh.write(package_contents)
+
+        r = ResolvedContext(["package", ".myeph-1"], package_paths=[packages_path])
+        self.assertEqual(r.status, ResolverStatus.solved)
+
+        self.assertEqual(r.resolved_ephemerals, [Requirement(".myeph-1")])
+
+        environ = r.get_environ()
+        self.assertEqual(environ.get("EPH_SEEN_IN_COMMANDS"), "1")
+
+    def test_ephemerals_update_during_resolution_with_late_function(self):
+        packages_path = os.path.join(self.root, "ephemeral_packages_with_late_function")
+        package_version = os.path.join(packages_path, "package", "1.0.0")
+        package_definition = os.path.join(package_version, "package.py")
+
+        package_contents = textwrap.dedent("""
+            name = "package"
+            version = "1.0.0"
+
+            # This late function will trigger the ephemeral binding before the end of
+            # the resolution.
+            @late()
+            def requires():
+                return []
+
+            def commands():
+                if "myeph" in ephemerals:
+                    env.EPH_SEEN_IN_COMMANDS = "1"
+                else:
+                    env.EPH_SEEN_IN_COMMANDS = "0"
+        """)
+
+        os.makedirs(package_version)
+
+        with open(package_definition, "w") as fh:
+            fh.write(package_contents)
+
+        r = ResolvedContext(["package", ".myeph-1"], package_paths=[packages_path])
+        self.assertEqual(r.status, ResolverStatus.solved)
+
+        self.assertEqual(r.resolved_ephemerals, [Requirement(".myeph-1")])
+
+        environ = r.get_environ()
+        self.assertEqual(environ.get("EPH_SEEN_IN_COMMANDS"), "1")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #2173 

Ephemerals were initially exposed to package commands as an `ephemerals` binding.

Since dcf77a26761627c02a671848943bf3d7c2d7df5c, they are also exposed to late-bound functions using the same strategy: reusing the existing list of resolved ephemerals.

The issue lies in the difference in timing between late-bound functions and package commands:

- Package commands are executed after the context have been resolved, so we get a properly resolved list of ephemerals
- Late-bound functions are executed _during_ a solve, which means we don't have access to the resolved ephemerals yet

The previous implementation did not crash when accessing `ephemerals` in late-bound functions: instead, it defaulted to an empty list.

This behavior leads to a second issue: ephemerals were added and **cached** as part of the list of pre-resolve bindings.

This can lead to the following scenario:

- A package late-bound function accesses the `ephemerals` binding
- Since the context is not resolve yet, no resolved ephemerals is found and an empty list is returned and cached
- Later, in the package commands, we also access `ephemerals`
- The cached empty list is returned, meaning that most queries will likely fail

This commit addresses these issues the following way:

- Move `ephemerals` out of pre-resolve bindings for commands, so that they are always retrieved from the resolved context
- For late-bound functions, use resolved ephemerals only if a context is available