### PR TITLE
Lint rezconfig.py for common mistakes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -96,9 +99,18 @@ jobs:
 
     - name: Run tests
       id: tests
-      run: rez-selftest -v -- --cov=rez --cov=rezplugins --cov-report=xml:coverage.xml
+      shell: bash
       env:
         _REZ_ENSURE_TEST_SHELLS: ${{ matrix.shells }}
+        REZCONFIG_BASELINE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}
+      run: |
+        baseline_args=()
+        if [[ -n "$REZCONFIG_BASELINE" && "$REZCONFIG_BASELINE" != "0000000000000000000000000000000000000000" ]]; then
+          baseline_args=(--rezconfig-baseline "$REZCONFIG_BASELINE")
+        fi
+
+        rez-selftest "${baseline_args[@]}" \
+          -v -- --cov=rez --cov=rezplugins --cov-report=xml:coverage.xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -5,6 +5,7 @@ import argparse
 import rez.cli._main
 import rez.cli._util
 import rez.rezconfig
+import rez.utils.docs
 import docutils.nodes
 import sphinx.util.nodes
 import sphinx.application
@@ -154,118 +155,63 @@ class PkgDefDomain(BareNamePythonDomain):
 
 def convert_rez_config_to_rst() -> list[str]:
     with open(rez.rezconfig.__file__) as fd:
-        txt = fd.read()
+        documented_settings = rez.utils.docs.parse_documented_settings(fd.read())
 
-        lines = txt.split('\n')
+    settings = {}
+    for setting in documented_settings:
+        if setting.section not in settings:
+            settings[setting.section] = {
+                'desc': setting.section_description,
+                'settings': {}
+            }
+        settings[setting.section]['settings'][setting.name] = (
+            setting.value_lines,
+            setting.comment_lines,
+        )
 
-        start = None
-        end = None
-        for i, line in enumerate(lines):
-            if "__DOC_START__" in line:
-                start = i
-            elif "__DOC_END__" in line:
-                end = i
+    # generate rst text
+    # rst = ['.. currentmodule:: config']
+    rst = []
 
-        lines = lines[start:end + 1]
-        assign_regex = re.compile("^([a-z0-9_]+) =")
-        settings = {}
+    for section in settings:
+        rst.append('')
+        rst.append(".. _config-{}:".format(section.replace(' ', '-').lower()))
+        rst.append("")
+        rst.append(section)
+        rst.append("-" * len(section))
+        rst.append('')
 
-        section_header = re.compile(r"^\#{10,}")
+        # This seems benign (storing each line individually), but it's actually extremely
+        # important. The docutils ViewList class absolutely requires to have only one line per
+        # entry. If we don't do that, the docutils parser won't parse the sublines,
+        # and we'll get "garbage" (ie unformatted lines) in the output.
+        for line in settings[section]['desc'].strip().split('\n'):
+            rst.append(line)
+        rst.append('')
 
-        section_title = None
-        section_description = None
-        end_of_section = 0
-
-        # parse out settings sections, settings and their comment
-        for i, line in enumerate(lines):
-
-            if section_header.match(line) and i != end_of_section:
-                section_title = lines[i + 1].split('#', 1)[-1].strip()
-                section_description = ''
-                description_linenumber = i + 2
-                end_of_section = description_linenumber
-
-                while not section_header.match(lines[description_linenumber]):
-                    section_description += lines[description_linenumber].split('#', 1)[-1].strip() + '\n'
-                    description_linenumber += 1
-                    end_of_section = description_linenumber
-
-            m = assign_regex.match(line)
-            if not m:
-                continue
-
-            start_defn = i
-            end_defn = i
-            while lines[end_defn].strip() and not lines[end_defn].startswith('#'):
-                end_defn += 1
-
-            value_lines = lines[start_defn:end_defn]
-            value_lines[0] = value_lines[0].split("=")[-1].strip()
-
-            end_comment = i
-            while not lines[end_comment].startswith('#'):
-                end_comment -= 1
-
-            start_comment = end_comment
-            while lines[start_comment].startswith('#'):
-                start_comment -= 1
-            start_comment += 1
-
-            comments = lines[start_comment:end_comment + 1]
-            comment_lines = [x[2:] for x in comments]  # drop leading '# '
-
-            varname = m.groups()[0]
-            if section_title in settings:
-                settings[section_title]['settings'][varname] = (value_lines, comment_lines)
+        for varname, (value_lines, comment_lines) in sorted(settings[section]['settings'].items()):
+            rst.append(".. py:data:: {0}".format(varname))
+            if len(value_lines) == 1:
+                rst.append("   :value: {0}".format(value_lines[0]))
             else:
-                settings[section_title] = {
-                    'desc': section_description,
-                    'settings': {varname: (value_lines, comment_lines)}
-                }
+                rst.append('')
+                rst.append('   Default:')
+                rst.append('')
+                rst.append('   .. code-block:: python')
+                rst.append('')
+                for line in value_lines:
+                    rst.append(f'      {line}')
 
-        # generate rst text
-        # rst = ['.. currentmodule:: config']
-        rst = []
-
-        for section in settings:
             rst.append('')
-            rst.append(".. _config-{}:".format(section.replace(' ', '-').lower()))
-            rst.append("")
-            rst.append(section)
-            rst.append("-" * len(section))
+            for line in comment_lines:
+                rst.append(f'   {line}')
             rst.append('')
 
-            # This seems benign (storing each line individually), but it's actually extremely
-            # important. The docutils ViewList class absolutely requires to have only one line per
-            # entry. If we don't do that, the docutils parser won't parse the sublines,
-            # and we'll get "garbage" (ie unformatted lines) in the output.
-            for line in settings[section]['desc'].strip().split('\n'):
-                rst.append(line)
+            envvar = f'REZ_{varname.upper()}'
+            rst.append(f'   .. envvar:: {envvar}')
             rst.append('')
-
-            for varname, (value_lines, comment_lines) in sorted(settings[section]['settings'].items()):
-                rst.append(".. py:data:: {0}".format(varname))
-                if len(value_lines) == 1:
-                    rst.append("   :value: {0}".format(value_lines[0]))
-                else:
-                    rst.append('')
-                    rst.append('   Default:')
-                    rst.append('')
-                    rst.append('   .. code-block:: python')
-                    rst.append('')
-                    for line in value_lines:
-                        rst.append(f'      {line}')
-
-                rst.append('')
-                for line in comment_lines:
-                    rst.append(f'   {line}')
-                rst.append('')
-
-                envvar = f'REZ_{varname.upper()}'
-                rst.append(f'   .. envvar:: {envvar}')
-                rst.append('')
-                rst.append(f'      The ``{envvar}`` environment variable can also be used to configure this.')
-                rst.append('')
+            rst.append(f'      The ``{envvar}`` environment variable can also be used to configure this.')
+            rst.append('')
 
     return rst
 
@@ -292,6 +238,7 @@ class RezConfigDirective(sphinx.util.docutils.SphinxDirective):
         # Add rezconfig as a dependency to the current document. The document
         # will be rebuilt if rezconfig changes.
         self.env.note_dependency(rez.rezconfig.__file__)
+        self.env.note_dependency(rez.utils.docs.__file__)
         self.env.note_dependency(__file__)
 
         path, lineNumber = self.get_source_info()

--- a/src/rez/cli/selftest.py
+++ b/src/rez/cli/selftest.py
@@ -43,6 +43,10 @@ def setup_parser(parser, completions: bool = False):
     parser.add_argument(
         "--keep-tmpdirs", action="store_true", help="Keep temporary directories."
     )
+    parser.add_argument(
+        "--rezconfig-baseline", metavar="REV",
+        help="Git revision used to find newly added documented settings"
+    )
 
     # make an Action that will append the appropriate test to the "--test" arg
     class AddTestModuleAction(argparse.Action):
@@ -86,6 +90,9 @@ def command(opts, parser, extra_arg_groups=None) -> None:
 
     if opts.keep_tmpdirs:
         os.environ["REZ_KEEP_TMPDIRS"] = "1"
+
+    if opts.rezconfig_baseline:
+        os.environ["__REZ_SELFTEST_REZCONFIG_BASELINE"] = opts.rezconfig_baseline
 
     if not opts.module_tests and not opts.tests:
         module_tests = all_module_tests

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -11,89 +11,14 @@ from rez.exceptions import ConfigurationError
 from rez.config import Config, get_module_root_config, _replace_config, _Deprecation
 from rez.system import system
 from rez.utils.data_utils import RO_AttrDictWrapper
-from rez.utils.docs import parse_documented_settings
 from rez.packages import get_developer_package
 from rez.deprecations import RezDeprecationWarning, warn
 import os
 import os.path
-import re
 import subprocess
 import functools
 import shutil
-from typing import Optional
 import unittest.mock
-
-
-_REZCONFIG_BASELINE_ENV = "__REZ_SELFTEST_REZCONFIG_BASELINE"
-_VERSIONADDED_RE = re.compile(
-    r"^\s*\.\.\s+versionadded::\s+\S+\s*$"
-)
-
-
-def _new_settings_without_versionadded(baseline_source, current_source):
-    baseline_settings = {
-        setting.name: setting
-        for setting in parse_documented_settings(baseline_source)
-    }
-    current_settings = {
-        setting.name: setting
-        for setting in parse_documented_settings(current_source)
-    }
-    new_settings = set(current_settings) - set(baseline_settings)
-    return [
-        name for name in sorted(
-            new_settings,
-            key=lambda name: current_settings[name].lineno,
-        )
-        if not any(
-            _VERSIONADDED_RE.match(line)
-            for line in current_settings[name].comment_lines
-        )
-    ]
-
-
-def _git_output(*args):
-    return subprocess.check_output(
-        ["git"] + list(args),
-        stderr=subprocess.STDOUT,
-        text=True,
-    ).strip()
-
-
-def _rezconfig_baseline(
-    repo_root: str,
-    requested_baseline: Optional[str],
-) -> str:
-    """Return the Git revision used to detect newly added settings.
-
-    CI supplies an explicit event revision so pull requests and pushes are
-    compared with the exact commit that preceded them. For local runs, compare
-    the default branch with its parent, and compare feature branches with their
-    merge base against origin's default branch.
-
-    A detached HEAD is normal in CI and has no branch name. If it points at the
-    default branch tip, treat it as the default branch; otherwise use the merge
-    base behavior. Unexpected Git failures are intentionally allowed to
-    propagate to the caller.
-    """
-    if requested_baseline:
-        return requested_baseline
-
-    # Resolve origin's default branch symbolically rather than assuming a name
-    # such as "main" or "master".
-    default_ref = _git_output(
-        "-C", repo_root, "symbolic-ref", "refs/remotes/origin/HEAD"
-    )
-    default_branch = default_ref.replace("refs/remotes/origin/", "", 1)
-    default_commit = _git_output("-C", repo_root, "rev-parse", default_ref)
-    head_commit = _git_output("-C", repo_root, "rev-parse", "HEAD")
-    # Unlike `git symbolic-ref`, this succeeds with an empty result for a
-    # detached HEAD, so a legitimate checkout is not handled as an error.
-    branch = _git_output("-C", repo_root, "branch", "--show-current")
-
-    if branch == default_branch or (not branch and head_commit == default_commit):
-        return "HEAD^"
-    return _git_output("-C", repo_root, "merge-base", "HEAD", default_ref)
 
 
 class TestConfig(TestBase):
@@ -464,99 +389,6 @@ class TestDeprecations(TestBase, TempdirMixin):
         with self.assertWarns(DeprecationWarning) as warning:
             warn('Warning Message', DeprecationWarning, pre_formatted=False)
         self.assertEqual(str(warning.warning), 'Warning Message')
-
-
-class TestRezConfigVersionAdded(unittest.TestCase):
-    def test_new_documented_settings_have_versionadded(self) -> None:
-        requested_baseline = os.getenv(_REZCONFIG_BASELINE_ENV)
-        try:
-            repo_root = _git_output("rev-parse", "--show-toplevel")
-            baseline = _rezconfig_baseline(repo_root, requested_baseline)
-            path = "src/rez/rezconfig.py"
-            with open(os.path.join(repo_root, path), encoding="utf-8") as stream:
-                current_source = stream.read()
-            baseline_source = _git_output(
-                "-C", repo_root, "show", "%s:%s" % (baseline, path)
-            )
-        except (OSError, subprocess.CalledProcessError) as exc:
-            reason = "Git repository or usable rezconfig history is unavailable"
-            if requested_baseline:
-                self.fail("%s for baseline %r: %s" % (
-                    reason, requested_baseline, exc
-                ))
-            self.skipTest("%s: %s" % (reason, exc))
-
-        missing = _new_settings_without_versionadded(
-            baseline_source, current_source
-        )
-        self.assertFalse(
-            missing,
-            "New documented rezconfig settings must include a preceding "
-            "'# .. versionadded:: <version>' directive: %s"
-            % ", ".join(missing),
-        )
-
-    def test_collects_top_level_documented_settings(self) -> None:
-        source = """\
-# __DOC_START__
-first = 1
-if True:
-    nested = 2
-annotated: int = 3
-# __DOC_END__
-outside = 4
-"""
-        self.assertEqual(
-            {
-                setting.name: setting.lineno
-                for setting in parse_documented_settings(source)
-            },
-            {"first": 2, "annotated": 5},
-        )
-
-    def test_requires_documentation_sentinels(self) -> None:
-        with self.assertRaisesRegex(ValueError, "sentinels were not found"):
-            parse_documented_settings("setting = 1\n")
-
-    def test_compares_setting_names(self) -> None:
-        baseline = """\
-# __DOC_START__
-existing = 1
-# __DOC_END__
-"""
-        current = """\
-# __DOC_START__
-existing = 2
-# Documentation for the new setting.
-#
-# .. versionadded:: 3.3.0
-added = 1
-# __DOC_END__
-"""
-        self.assertEqual(
-            _new_settings_without_versionadded(baseline, current),
-            [],
-        )
-
-    def test_directive_must_be_in_immediately_preceding_comment_block(self) -> None:
-        baseline = """\
-# __DOC_START__
-existing = 1
-# __DOC_END__
-"""
-        current = """\
-# __DOC_START__
-existing = 1
-# .. versionadded:: 3.3.0
-
-# Documentation without a directive.
-missing = 2
-# __DOC_END__
-"""
-        self.assertEqual(
-            _new_settings_without_versionadded(baseline, current),
-            ["missing"],
-        )
 
 
 if __name__ == "__main__":

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -11,14 +11,89 @@ from rez.exceptions import ConfigurationError
 from rez.config import Config, get_module_root_config, _replace_config, _Deprecation
 from rez.system import system
 from rez.utils.data_utils import RO_AttrDictWrapper
+from rez.utils.docs import parse_documented_settings
 from rez.packages import get_developer_package
 from rez.deprecations import RezDeprecationWarning, warn
 import os
 import os.path
+import re
 import subprocess
 import functools
 import shutil
+from typing import Optional
 import unittest.mock
+
+
+_REZCONFIG_BASELINE_ENV = "__REZ_SELFTEST_REZCONFIG_BASELINE"
+_VERSIONADDED_RE = re.compile(
+    r"^\s*\.\.\s+versionadded::\s+\S+\s*$"
+)
+
+
+def _new_settings_without_versionadded(baseline_source, current_source):
+    baseline_settings = {
+        setting.name: setting
+        for setting in parse_documented_settings(baseline_source)
+    }
+    current_settings = {
+        setting.name: setting
+        for setting in parse_documented_settings(current_source)
+    }
+    new_settings = set(current_settings) - set(baseline_settings)
+    return [
+        name for name in sorted(
+            new_settings,
+            key=lambda name: current_settings[name].lineno,
+        )
+        if not any(
+            _VERSIONADDED_RE.match(line)
+            for line in current_settings[name].comment_lines
+        )
+    ]
+
+
+def _git_output(*args):
+    return subprocess.check_output(
+        ["git"] + list(args),
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).strip()
+
+
+def _rezconfig_baseline(
+    repo_root: str,
+    requested_baseline: Optional[str],
+) -> str:
+    """Return the Git revision used to detect newly added settings.
+
+    CI supplies an explicit event revision so pull requests and pushes are
+    compared with the exact commit that preceded them. For local runs, compare
+    the default branch with its parent, and compare feature branches with their
+    merge base against origin's default branch.
+
+    A detached HEAD is normal in CI and has no branch name. If it points at the
+    default branch tip, treat it as the default branch; otherwise use the merge
+    base behavior. Unexpected Git failures are intentionally allowed to
+    propagate to the caller.
+    """
+    if requested_baseline:
+        return requested_baseline
+
+    # Resolve origin's default branch symbolically rather than assuming a name
+    # such as "main" or "master".
+    default_ref = _git_output(
+        "-C", repo_root, "symbolic-ref", "refs/remotes/origin/HEAD"
+    )
+    default_branch = default_ref.replace("refs/remotes/origin/", "", 1)
+    default_commit = _git_output("-C", repo_root, "rev-parse", default_ref)
+    head_commit = _git_output("-C", repo_root, "rev-parse", "HEAD")
+    # Unlike `git symbolic-ref`, this succeeds with an empty result for a
+    # detached HEAD, so a legitimate checkout is not handled as an error.
+    branch = _git_output("-C", repo_root, "branch", "--show-current")
+
+    if branch == default_branch or (not branch and head_commit == default_commit):
+        return "HEAD^"
+    return _git_output("-C", repo_root, "merge-base", "HEAD", default_ref)
 
 
 class TestConfig(TestBase):
@@ -389,6 +464,99 @@ class TestDeprecations(TestBase, TempdirMixin):
         with self.assertWarns(DeprecationWarning) as warning:
             warn('Warning Message', DeprecationWarning, pre_formatted=False)
         self.assertEqual(str(warning.warning), 'Warning Message')
+
+
+class TestRezConfigVersionAdded(unittest.TestCase):
+    def test_new_documented_settings_have_versionadded(self) -> None:
+        requested_baseline = os.getenv(_REZCONFIG_BASELINE_ENV)
+        try:
+            repo_root = _git_output("rev-parse", "--show-toplevel")
+            baseline = _rezconfig_baseline(repo_root, requested_baseline)
+            path = "src/rez/rezconfig.py"
+            with open(os.path.join(repo_root, path), encoding="utf-8") as stream:
+                current_source = stream.read()
+            baseline_source = _git_output(
+                "-C", repo_root, "show", "%s:%s" % (baseline, path)
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            reason = "Git repository or usable rezconfig history is unavailable"
+            if requested_baseline:
+                self.fail("%s for baseline %r: %s" % (
+                    reason, requested_baseline, exc
+                ))
+            self.skipTest("%s: %s" % (reason, exc))
+
+        missing = _new_settings_without_versionadded(
+            baseline_source, current_source
+        )
+        self.assertFalse(
+            missing,
+            "New documented rezconfig settings must include a preceding "
+            "'# .. versionadded:: <version>' directive: %s"
+            % ", ".join(missing),
+        )
+
+    def test_collects_top_level_documented_settings(self) -> None:
+        source = """\
+# __DOC_START__
+first = 1
+if True:
+    nested = 2
+annotated: int = 3
+# __DOC_END__
+outside = 4
+"""
+        self.assertEqual(
+            {
+                setting.name: setting.lineno
+                for setting in parse_documented_settings(source)
+            },
+            {"first": 2, "annotated": 5},
+        )
+
+    def test_requires_documentation_sentinels(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sentinels were not found"):
+            parse_documented_settings("setting = 1\n")
+
+    def test_compares_setting_names(self) -> None:
+        baseline = """\
+# __DOC_START__
+existing = 1
+# __DOC_END__
+"""
+        current = """\
+# __DOC_START__
+existing = 2
+# Documentation for the new setting.
+#
+# .. versionadded:: 3.3.0
+added = 1
+# __DOC_END__
+"""
+        self.assertEqual(
+            _new_settings_without_versionadded(baseline, current),
+            [],
+        )
+
+    def test_directive_must_be_in_immediately_preceding_comment_block(self) -> None:
+        baseline = """\
+# __DOC_START__
+existing = 1
+# __DOC_END__
+"""
+        current = """\
+# __DOC_START__
+existing = 1
+# .. versionadded:: 3.3.0
+
+# Documentation without a directive.
+missing = 2
+# __DOC_END__
+"""
+        self.assertEqual(
+            _new_settings_without_versionadded(baseline, current),
+            ["missing"],
+        )
 
 
 if __name__ == "__main__":

--- a/src/rez/tests/test_rezconfig.py
+++ b/src/rez/tests/test_rezconfig.py
@@ -190,4 +190,3 @@ class TestRezConfigDocumentation(unittest.TestCase):
                     "\n".join("- %s" % name for name in missing),
                 )
             )
-

--- a/src/rez/tests/test_rezconfig.py
+++ b/src/rez/tests/test_rezconfig.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+"""Tests for requirements specific to the default rezconfig."""
+
+from __future__ import annotations
+
+import os
+import os.path
+import re
+import shutil
+import subprocess
+from typing import Optional
+import unittest
+
+from rez import rezconfig
+from rez.utils.docs import parse_documented_settings
+
+
+_REZCONFIG_BASELINE_ENV = "__REZ_SELFTEST_REZCONFIG_BASELINE"
+_VERSIONADDED_RE = re.compile(
+    r"^\s*\.\.\s+versionadded::\s+\S+\s*$"
+)
+
+
+def _new_settings_without_versionadded(baseline_source, current_source):
+    baseline_settings = {
+        setting.name: setting
+        for setting in parse_documented_settings(baseline_source)
+    }
+    current_settings = {
+        setting.name: setting
+        for setting in parse_documented_settings(current_source)
+    }
+    new_settings = set(current_settings) - set(baseline_settings)
+    return [
+        name for name in sorted(
+            new_settings,
+            key=lambda name: current_settings[name].lineno,
+        )
+        if not any(
+            _VERSIONADDED_RE.match(line)
+            for line in current_settings[name].comment_lines
+        )
+    ]
+
+
+def _git_output(*args):
+    return subprocess.check_output(
+        ["git"] + list(args),
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).strip()
+
+
+def _rezconfig_baseline(
+    repo_root: str,
+    requested_baseline: Optional[str],
+) -> str:
+    """Return the Git revision used to detect newly added settings.
+
+    CI supplies an explicit event revision so pull requests and pushes are
+    compared with the exact commit that preceded them. For local runs, compare
+    the default branch with its parent, and compare feature branches with their
+    merge base against origin's default branch.
+
+    A detached HEAD is normal in CI and has no branch name. If it points at the
+    default branch tip, treat it as the default branch; otherwise use the merge
+    base behavior. Unexpected Git failures are intentionally allowed to
+    propagate to the caller.
+    """
+    if requested_baseline:
+        return requested_baseline
+
+    # Resolve origin's default branch symbolically rather than assuming a name
+    # such as "main" or "master".
+    default_ref = _git_output(
+        "-C", repo_root, "symbolic-ref", "refs/remotes/origin/HEAD"
+    )
+    default_branch = default_ref.replace("refs/remotes/origin/", "", 1)
+    default_commit = _git_output("-C", repo_root, "rev-parse", default_ref)
+    head_commit = _git_output("-C", repo_root, "rev-parse", "HEAD")
+    # Unlike `git symbolic-ref`, this succeeds with an empty result for a
+    # detached HEAD, so a legitimate checkout is not handled as an error.
+    branch = _git_output("-C", repo_root, "branch", "--show-current")
+
+    if branch == default_branch or (not branch and head_commit == default_commit):
+        return "HEAD^"
+    return _git_output("-C", repo_root, "merge-base", "HEAD", default_ref)
+
+
+class TestRezConfigDocumentation(unittest.TestCase):
+    """Validate that the rezconfig file follow the project's conventions.
+
+    The goal is to catch common mistakes when modifying the rezconfig file.
+    That file is use as the default settings but it's also used to generate
+    the settings documentation and it must follow some rules.
+    """
+
+    def test_documented_settings_belong_to_a_section(self) -> None:
+        """Ensure that all settings are declared in a section"""
+
+        with open(rezconfig.__file__, encoding="utf-8") as stream:
+            settings = parse_documented_settings(stream.read())
+
+        sectionless = [
+            setting.name for setting in settings if setting.section is None
+        ]
+        if sectionless:
+            count = len(sectionless)
+            self.fail(
+                "Found %d %s in rezconfig outside a documentation section:"
+                "\n\n%s\n\nDocumented rezconfig settings must be placed "
+                "under a section that follows the style of existing sections."
+                % (
+                    count,
+                    "setting" if count == 1 else "settings",
+                    "\n".join("- %s" % name for name in sectionless),
+                )
+            )
+
+    def test_documented_settings_have_docs(self) -> None:
+        """Ensure that all settings have documentation"""
+
+        with open(rezconfig.__file__, encoding="utf-8") as stream:
+            settings = parse_documented_settings(stream.read())
+
+        missing = [
+            setting.name
+            for setting in settings
+            if not any(
+                line.strip() and not _VERSIONADDED_RE.match(line)
+                for line in setting.comment_lines
+            )
+        ]
+        if missing:
+            count = len(missing)
+            self.fail(
+                "Found %d %s in rezconfig that %s missing documentation:"
+                "\n\n%s\n\nDocumented rezconfig settings must include a "
+                "preceding documentation comment that must follow the style "
+                "of existing settings."
+                % (
+                    count,
+                    "setting" if count == 1 else "settings",
+                    "is" if count == 1 else "are",
+                    "\n".join("- %s" % name for name in missing),
+                )
+            )
+
+    def test_new_documented_settings_have_versionadded(self) -> None:
+        """Ensure that new settings have a versionadded sphinx directive"""
+
+        if shutil.which("git") is None:
+            self.skipTest("Git executable is unavailable")
+
+        requested_baseline = os.getenv(_REZCONFIG_BASELINE_ENV)
+        try:
+            repo_root = _git_output("rev-parse", "--show-toplevel")
+            baseline = _rezconfig_baseline(repo_root, requested_baseline)
+            path = os.path.relpath(rezconfig.__file__, repo_root).replace(os.sep, "/")
+            with open(rezconfig.__file__, encoding="utf-8") as stream:
+                current_source = stream.read()
+            baseline_source = _git_output(
+                "-C", repo_root, "show", "%s:%s" % (baseline, path)
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            reason = "Git repository or usable rezconfig history is unavailable"
+            if requested_baseline:
+                self.fail("%s for baseline %r: %s" % (
+                    reason, requested_baseline, exc
+                ))
+            self.skipTest("%s: %s" % (reason, exc))
+
+        missing = _new_settings_without_versionadded(
+            baseline_source, current_source
+        )
+        if missing:
+            count = len(missing)
+            self.fail(
+                "Found %d new %s added to rezconfig that %s missing a "
+                "versionadded directive:\n\n%s\n\nNew documented rezconfig "
+                "settings must include a preceding "
+                "'# .. versionadded:: <version>' directive."
+                % (
+                    count,
+                    "setting" if count == 1 else "settings",
+                    "is" if count == 1 else "are",
+                    "\n".join("- %s" % name for name in missing),
+                )
+            )
+

--- a/src/rez/tests/test_rezconfig.py
+++ b/src/rez/tests/test_rezconfig.py
@@ -14,11 +14,15 @@ import subprocess
 from typing import Optional
 import unittest
 
-from rez import rezconfig
 from rez.utils.docs import parse_documented_settings
 
 
 _REZCONFIG_BASELINE_ENV = "__REZ_SELFTEST_REZCONFIG_BASELINE"
+_REZCONFIG_GIT_PATH = "src/rez/rezconfig.py"
+_REZCONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "rezconfig.py",
+)
 _VERSIONADDED_RE = re.compile(
     r"^\s*\.\.\s+versionadded::\s+\S+\s*$"
 )
@@ -101,7 +105,7 @@ class TestRezConfigDocumentation(unittest.TestCase):
     def test_documented_settings_belong_to_a_section(self) -> None:
         """Ensure that all settings are declared in a section"""
 
-        with open(rezconfig.__file__, encoding="utf-8") as stream:
+        with open(_REZCONFIG_PATH, encoding="utf-8") as stream:
             settings = parse_documented_settings(stream.read())
 
         sectionless = [
@@ -123,7 +127,7 @@ class TestRezConfigDocumentation(unittest.TestCase):
     def test_documented_settings_have_docs(self) -> None:
         """Ensure that all settings have documentation"""
 
-        with open(rezconfig.__file__, encoding="utf-8") as stream:
+        with open(_REZCONFIG_PATH, encoding="utf-8") as stream:
             settings = parse_documented_settings(stream.read())
 
         missing = [
@@ -159,11 +163,11 @@ class TestRezConfigDocumentation(unittest.TestCase):
         try:
             repo_root = _git_output("rev-parse", "--show-toplevel")
             baseline = _rezconfig_baseline(repo_root, requested_baseline)
-            path = os.path.relpath(rezconfig.__file__, repo_root).replace(os.sep, "/")
-            with open(rezconfig.__file__, encoding="utf-8") as stream:
+            with open(_REZCONFIG_PATH, encoding="utf-8") as stream:
                 current_source = stream.read()
             baseline_source = _git_output(
-                "-C", repo_root, "show", "%s:%s" % (baseline, path)
+                "-C", repo_root, "show",
+                "%s:%s" % (baseline, _REZCONFIG_GIT_PATH),
             )
         except (OSError, subprocess.CalledProcessError) as exc:
             reason = "Git repository or usable rezconfig history is unavailable"

--- a/src/rez/tests/test_rezconfig.py
+++ b/src/rez/tests/test_rezconfig.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Rez Project
 
+
 """Tests for requirements specific to the default rezconfig."""
 
 from __future__ import annotations

--- a/src/rez/tests/test_utils_docs.py
+++ b/src/rez/tests/test_utils_docs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Rez Project
 
+
 """Unit tests for :mod:`rez.utils.docs`."""
 
 import unittest

--- a/src/rez/tests/test_utils_docs.py
+++ b/src/rez/tests/test_utils_docs.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+"""Unit tests for :mod:`rez.utils.docs`."""
+
+import unittest
+
+from rez.tests.test_rezconfig import _new_settings_without_versionadded
+from rez.utils.docs import parse_documented_settings
+
+
+class TestUtilsDocs(unittest.TestCase):
+    def test_collects_top_level_documented_settings(self) -> None:
+        source = """\
+# __DOC_START__
+first = 1
+if True:
+    nested = 2
+annotated: int = 3
+# __DOC_END__
+outside = 4
+"""
+        self.assertEqual(
+            {
+                setting.name: setting.lineno
+                for setting in parse_documented_settings(source)
+            },
+            {"first": 2, "annotated": 5},
+        )
+
+    def test_requires_documentation_sentinels(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sentinels were not found"):
+            parse_documented_settings("setting = 1\n")
+
+    def test_compares_setting_names(self) -> None:
+        baseline = """\
+# __DOC_START__
+existing = 1
+# __DOC_END__
+"""
+        current = """\
+# __DOC_START__
+existing = 2
+# Documentation for the new setting.
+#
+# .. versionadded:: 3.3.0
+added = 1
+# __DOC_END__
+"""
+        self.assertEqual(
+            _new_settings_without_versionadded(baseline, current),
+            [],
+        )
+
+    def test_directive_must_be_in_immediately_preceding_comment_block(self) -> None:
+        baseline = """\
+# __DOC_START__
+existing = 1
+# __DOC_END__
+"""
+        current = """\
+# __DOC_START__
+existing = 1
+# .. versionadded:: 3.3.0
+
+# Documentation without a directive.
+missing = 2
+# __DOC_END__
+"""
+        self.assertEqual(
+            _new_settings_without_versionadded(baseline, current),
+            ["missing"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/rez/utils/docs.py
+++ b/src/rez/utils/docs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the Rez Project
 
+
 from __future__ import annotations
 
 import ast

--- a/src/rez/utils/docs.py
+++ b/src/rez/utils/docs.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class DocumentedSetting:
+    name: str
+    lineno: int
+    value_lines: List[str]
+    comment_lines: List[str]
+    section: Optional[str]
+    section_description: str
+
+
+def parse_documented_settings(source: str) -> List[DocumentedSetting]:
+    """Parse documented top-level settings from a rezconfig source file."""
+    lines = source.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if "__DOC_START__" in line),
+        None,
+    )
+    end = next(
+        (i for i, line in enumerate(lines) if "__DOC_END__" in line),
+        None,
+    )
+    if start is None or end is None or start >= end:
+        raise ValueError("rezconfig documentation sentinels were not found")
+
+    assignments = {}
+    for node in ast.parse(source).body:
+        line_index = node.lineno - 1
+        if not start < line_index < end:
+            continue
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+
+        names = [target.id for target in targets if isinstance(target, ast.Name)]
+        if names:
+            assignments[line_index] = (names, node.end_lineno or node.lineno)
+
+    settings = []
+    section = None
+    section_description = ""
+    section_header = None
+    i = start + 1
+    while i < end:
+        line = lines[i]
+        if line.startswith("##########") and i != section_header:
+            if i + 1 >= end:
+                raise ValueError("rezconfig documentation section has no title")
+            section = lines[i + 1].split("#", 1)[-1].strip()
+            description_lines = []
+            description_line = i + 2
+            while (
+                description_line < end
+                and not lines[description_line].startswith("##########")
+            ):
+                description_lines.append(
+                    lines[description_line].split("#", 1)[-1].strip()
+                )
+                description_line += 1
+            section_description = "\n".join(description_lines)
+            section_header = description_line
+
+        assignment = assignments.get(i)
+        if assignment:
+            names, end_lineno = assignment
+            value_lines = lines[i:end_lineno]
+            value_lines[0] = value_lines[0].split("=")[-1].strip()
+
+            comment_start = i
+            while comment_start > start + 1 and lines[comment_start - 1].startswith("#"):
+                comment_start -= 1
+            comment_lines = [
+                comment[2:] if comment.startswith("# ") else comment[1:]
+                for comment in lines[comment_start:i]
+            ]
+
+            for name in names:
+                settings.append(DocumentedSetting(
+                    name=name,
+                    lineno=i + 1,
+                    value_lines=value_lines,
+                    comment_lines=comment_lines,
+                    section=section,
+                    section_description=section_description,
+                ))
+        i += 1
+
+    return settings


### PR DESCRIPTION
A common mistake make by most people (including me) when editing the rezconfig.py is is to either forget to add documentation or to add a `.. versionadded` sphinx directive.

This PR adds a custom linter that can detect both of the problems. It can also detect if a setting is added outside a section.

To achieve that, I refactored the code to extract the docs that was in the sphinx extension into its own module.

The linting happens inside the tests. That's the "cleanest" option I found that allows to catch these problems locally and in CI.


Note that this PR is mostly AI generated using Amp: https://ampcode.com/threads/T-019fbef7-632f-767e-ad1c-68582e67859f