### PR TITLE
Updating package maker to create packages safely

### DIFF
--- a/src/rez/package_maker.py
+++ b/src/rez/package_maker.py
@@ -196,6 +196,8 @@ def make_package(name: str, path: str,
         The 'installed_variants' attribute on the `PackageMaker` instance will
         be appended with variant(s) created by this function, if any.
     """
+    from rez.package_repository import package_repository_manager
+
     maker = PackageMaker(name)
     yield maker
 
@@ -222,18 +224,28 @@ def make_package(name: str, path: str,
     with retain_cwd():
         # install the package variant(s) into the filesystem package repo at `path`
         for variant in src_variants:
-            variant_ = variant.install(path)
+            repository = package_repository_manager.get_repository(path)
 
-            base = variant_.base
+            base = repository.get_package_payload_path(
+                package_name=variant.name,
+                package_version=variant.version
+            )
+            repository.pre_variant_install(variant.resource)
+
             if make_base and base:
                 os.makedirs(base, exist_ok=True)
                 os.chdir(base)
-                make_base(variant_, base)
+                make_base(variant, base)
 
-            root = variant_.root
+            if variant.index is None:
+                root = base
+            else:
+                root = os.path.join(base, variant._non_shortlinked_subpath)
+
             if make_root and root:
                 os.makedirs(root, exist_ok=True)
                 os.chdir(root)
-                make_root(variant_, root)
+                make_root(variant, root)
 
+            variant_ = variant.install(path)
             maker.installed_variants.append(variant_)

--- a/src/rez/tests/test_package_maker.py
+++ b/src/rez/tests/test_package_maker.py
@@ -1,0 +1,52 @@
+import os
+
+from rez.tests.util import TestBase, TempdirMixin
+from rez.package_maker import make_package
+
+
+class TestPackages(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls) -> None:
+        TempdirMixin.setUpClass()
+
+        cls.settings = dict()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        TempdirMixin.tearDownClass()
+
+    def test_make_package(self):
+
+        def make_root(variant, root):
+            assert os.path.isdir(root)
+            assert variant.resource.repository_type == 'memory'
+
+            with open(os.path.join(root, 'payload.txt'),'w'):
+                pass
+
+        with make_package('test_package1', self.root, make_root=make_root) as pkg:
+            pkg.version = '1.0.0'
+
+        assert os.path.isfile(os.path.join(self.root, 'test_package1', '1.0.0', 'package.py'))
+        assert os.path.isfile(os.path.join(self.root, 'test_package1', '1.0.0', 'payload.txt'))
+
+    def test_make_package_with_variant(self):
+
+        def make_root(variant, root):
+            with open(os.path.join(root, 'payload.txt'),'w'):
+                pass
+
+        with make_package('test_package2', self.root, make_root=make_root) as pkg:
+            pkg.version = '1.0.1'
+            pkg.variants = [['python-3']]
+
+        payload_path = os.path.join(self.root, 'test_package2', '1.0.1', 'python-3', 'payload.txt')
+        assert os.path.isfile(payload_path)
+
+    def test_make_package_build_token(self):
+        def make_base(variant, base):
+            assert os.path.isdir(base)
+            assert os.path.isfile(os.path.join(os.path.dirname(base), '.building2.0.1'))
+
+        with make_package('test_package3', self.root, make_base=make_base) as pkg:
+            pkg.version = '2.0.1'

--- a/src/rez/tests/test_package_maker.py
+++ b/src/rez/tests/test_package_maker.py
@@ -16,7 +16,7 @@ class TestPackages(TestBase, TempdirMixin):
         TempdirMixin.tearDownClass()
 
     def test_make_package(self):
-
+        '''Test make_package makes a package in structure we expect'''
         def make_root(variant, root):
             assert os.path.isdir(root)
             assert variant.resource.repository_type == 'memory'
@@ -31,7 +31,7 @@ class TestPackages(TestBase, TempdirMixin):
         assert os.path.isfile(os.path.join(self.root, 'test_package1', '1.0.0', 'payload.txt'))
 
     def test_make_package_with_variant(self):
-
+        '''Test make_package makes a package with variants sub path'''
         def make_root(variant, root):
             with open(os.path.join(root, 'payload.txt'),'w'):
                 pass
@@ -44,6 +44,7 @@ class TestPackages(TestBase, TempdirMixin):
         assert os.path.isfile(payload_path)
 
     def test_make_package_build_token(self):
+        '''Test make_package has a build prefix token while building payload'''
         def make_base(variant, base):
             assert os.path.isdir(base)
             assert os.path.isfile(os.path.join(os.path.dirname(base), '.building2.0.1'))

--- a/src/rez/tests/test_package_maker.py
+++ b/src/rez/tests/test_package_maker.py
@@ -28,7 +28,7 @@ class TestPackages(TestBase, TempdirMixin):
             assert os.path.isdir(root)
             assert variant.resource.repository_type == 'memory'
 
-            with open(os.path.join(root, 'payload.txt'),'w'):
+            with open(os.path.join(root, 'payload.txt'), 'w'):
                 pass
 
         with make_package('test_package1', self.root, make_root=make_root) as pkg:
@@ -40,7 +40,7 @@ class TestPackages(TestBase, TempdirMixin):
     def test_make_package_with_variant(self):
         '''Test make_package makes a package with variants sub path'''
         def make_root(variant, root):
-            with open(os.path.join(root, 'payload.txt'),'w'):
+            with open(os.path.join(root, 'payload.txt'), 'w'):
                 pass
 
         with make_package('test_package2', self.root, make_root=make_root) as pkg:

--- a/src/rez/tests/test_package_maker.py
+++ b/src/rez/tests/test_package_maker.py
@@ -1,3 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+Test package maker.
+"""
 import os
 
 from rez.tests.util import TestBase, TempdirMixin


### PR DESCRIPTION
- package_maker would not create .building prefix when build payload
- changed to use pre_variant_install from repository to get build_prefix
- Variant is installed now after make_base and make_root calls
- using get_package_payload_path to generate base path
- Note: the variant passed to make_base and make_root is now a memory repo variant