### PR TITLE
Document REZ_(PKG)_ORIG_ROOT

### DIFF
--- a/docs/source/caching.rst
+++ b/docs/source/caching.rst
@@ -150,8 +150,8 @@ as shown below:
    platform-linux      /home/ajohns/package_cache/platform/linux/9d4d/a                                  (cached)
    python-3.7.4        /home/ajohns/package_cache/python/3.7.4/ce1c/a                                    (cached)
 
-For reference, cached packages also have their original payload location stored to
-an environment variable like so:
+For reference, the original payload location for each cached package is stored in
+:envvar:`REZ_(PKG)_ORIG_ROOT`:
 
 .. code-block:: console
 

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -88,6 +88,14 @@ dots replaced with underscore.
 
    The root directory of the package installation (actually,the variant), eg ``/packages/utils/1.0.0/python-2.7``.
 
+.. envvar:: REZ_(PKG)_ORIG_ROOT
+
+   The original root directory of the package installation (actually, the
+   variant), before package caching retargets :envvar:`REZ_(PKG)_ROOT` to the
+   cached payload. It is only set when the package is cached.
+
+   .. seealso:: Documentation on :ref:`package caching <package-caching>`.
+
 .. envvar:: REZ_(PKG)_VERSION
 
    The version of the package.


### PR DESCRIPTION
It looks like I forgot to document the `REZ_(PKG)_ORIG_ROOT` environment variable when I created the environment variables page.

Amp-Thread-ID: https://ampcode.com/threads/T-019fd984-bbd8-750e-8a0e-7f10d664a703