### PR TITLE
Fix most sphinx warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 .vscode/
 .venv/
 docs/source/api/
+docs/source/apivendor/
 docs/source/commands/
 __tests_pkg_repo/
 .idea/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -n
+SPHINXOPTS    ?= -n -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,4 +25,5 @@ livehtml:
 clean:
 	rm -rf _build
 	rm -rf source/api
+	rm -rf source/apivendor
 	rm -rf source/commands

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -51,3 +51,12 @@ Python API
    rez.utils
    rez.version
    rez.wrapper
+   rezplugins.package_repository.memory
+
+.. autosummary::
+   :toctree: apivendor
+   :recursive:
+
+   rez.vendor.pygraph.classes
+   rez.vendor.packaging.version.InvalidVersion
+   rez.vendor.schema.schema

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,12 +46,34 @@ extensions = [
 templates_path = ['_templates']
 
 nitpick_ignore = [
-    # TODO: Remove once we unvendor enum.
+    # Our API isn't very clean... We expose private things via public
+    # interfaces...
     ("py:class", "rez.solver._Common"),
     ("py:class", "_thread._local"),
     ("py:class", "rez.utils.platform_._UnixPlatform"),
     ("py:class", "rez.version._util._Common"),
     ("py:class", "rez.version._version._Comparable"),
+    ("py:class", "rez.solver._ResolvePhase"),
+    ("py:class", "rez.config._PluginConfigs"),
+    ("py:class", "rez.version._version._LowerBound"),
+    ("py:class", "rez.version._version._UpperBound"),
+    ("py:class", "rez.version._version._Bound"),
+    ("py:class", "_ContainsVersionIterator"),
+    ("py:class", "rez.version._version._ReversedComparable"),
+    ("py:class", "_ReversedComparable"),
+    ("py:class", "rez.solver._PackageVariantList"),
+    ("py:class", "rez.solver._PackageVariantSlice"),
+    ("py:class", "rez.utils.memcached.Client._Miss"),
+    ("py:class", "argparse._ArgumentGroup"),
+    # Remove once we find a way to support TypeVar correctly.
+    ("py:class", "rez.config.T"),
+    ("py:obj", "rez.utils.sourcecode.T"),
+    ("py:class", "rez.utils.sourcecode.T"),
+    ("py:class", "rez.utils.sourcecode.CallabeT"),
+    ("py:class", "rez.utils.data_utils.T"),
+    ("py:obj", "rez.utils.data_utils.T"),
+    ("py:class", "rez.utils.memcached.CallableT"),
+    ("py:class", "rez.packages.PackageT"),
 ]
 
 nitpick_ignore_regex = [
@@ -134,6 +156,29 @@ googleanalytics_id = "G-G11PX36QZS"
 
 # -- Custom -----------------------------------------------------------------
 
+def skip_inherited_mapping_member(
+    app: sphinx.application.Sphinx,
+    what: str,
+    name: str,
+    obj: object,
+    skip: bool,
+    options: object,
+) -> bool | None:
+    """
+    Do not document implementation methods inherited by mapping classes.
+    This is annoying, but without this, inherited-members
+    causes a lot of unnecessary warnings coming from the stdlib.
+    """
+    owner = getattr(obj, '__objclass__', None)
+    if what == 'class' and (
+        owner is dict
+        or getattr(obj, '__module__', None) in ("collections", "collections.abc")
+    ):
+        return True
+
+    return None
+
+
 def handle_ref_warning(
     app: sphinx.application.Sphinx,
     domain: sphinx.domains.Domain,
@@ -160,6 +205,7 @@ def handle_ref_warning(
 
 
 def setup(app: sphinx.application.Sphinx) -> dict[str, bool | str]:
+    app.connect('autodoc-skip-member', skip_inherited_mapping_member)
     app.connect('warn-missing-reference', handle_ref_warning)
 
     return {

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -662,5 +662,5 @@ class PackageRepositoryManager(object):
         return repo
 
 
-# singleton
+#: singleton
 package_repository_manager = PackageRepositoryManager()

--- a/src/rez/rex.py
+++ b/src/rez/rex.py
@@ -12,7 +12,7 @@ from fnmatch import fnmatch
 from enum import Enum
 from contextlib import contextmanager
 from string import Formatter
-from collections.abc import MutableMapping
+from collections.abc import KeysView, MutableMapping
 from typing import Any, Iterable, Mapping
 
 from rez.system import system
@@ -1114,7 +1114,8 @@ class EnvironmentDict(MutableMapping):
         self._var_cache = dict((k, EnvironmentVariable(k, self))
                                for k in manager.parent_environ.keys())
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
+        """Return the environment variable names."""
         return self._var_cache.keys()
 
     def __repr__(self) -> str:

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -213,12 +213,10 @@ def resolve_variant_indices(
         num_variants: Total number of variants in the package.
 
     Returns:
-        A 2-tuple of:
-        - resolved (set[int]): Canonical non-negative indices.
-        - invalid (list[int]): Any indices outside [-num_variants, num_variants-1],
-          sorted for deterministic error messages. Empty when all indices are valid.
-          When num_variants is 0 the package has no explicit variants; the
-          input is returned unchanged and invalid is always empty.
+        tuple[set[int], list[int]]: The resolved and invalid indices. Invalid
+        indices are sorted for deterministic error messages. When
+        ``num_variants`` is 0, the input is returned unchanged and the invalid
+        indices are always empty.
     """
     if num_variants <= 0:
         return set(variants), []

--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -76,8 +76,8 @@ def pip_to_rez_version(dist_version, allow_legacy: bool = True):
         str: Rez-compatible equivalent version string.
 
     Raises:
-        InvalidVersion: When legacy mode is not allowed and a PEP440
-            incompatible version is detected.
+        rez.vendor.packaging.version.InvalidVersion: When legacy mode is
+            not allowed and a PEP440 incompatible version is detected.
 
     .. _PEP 440 (all possible matches):
         https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
@@ -522,8 +522,8 @@ def convert_distlib_to_setuptools(installed_dist):
     """Get the setuptools equivalent of a distlib installed dist.
 
     Args:
-        installed_dist (`distlib.database.InstalledDistribution`: Distribution
-            to convert.
+        installed_dist (``distlib.database.InstalledDistribution``):
+            Distribution to convert.
 
     Returns:
         `Distribution`: Equivalent importlib/setuptools dist object.

--- a/src/rezplugins/package_repository/memory.py
+++ b/src/rezplugins/package_repository/memory.py
@@ -124,7 +124,7 @@ class MemoryPackageRepository(PackageRepository):
                "1.0.0": {
                    "name":         "foo",
                    "version":      "1.0.0",
-                   "description":  "does foo-like things.",
+                   "description":  "does foo-like things."
                }
            },
 

--- a/src/rezplugins/package_repository/memory.py
+++ b/src/rezplugins/package_repository/memory.py
@@ -117,26 +117,28 @@ class MemoryPackageRepository(PackageRepository):
 
     Packages are stored in a dict, organised like so:
 
-        {
-            "foo": {
-                "1.0.0": {
-                    "name":         "foo",
-                    "version":      "1.0.0",
-                    "description":  "does foo-like things.",
-                }
-            },
+    .. code-block:: json
 
-            "bah": {
-                "_NO_VERSION": {
-                    "name":         "bah",
-                    "description":  "does bah-like things.",
-                    "requires":     ["python-2.6", "foo-1+"]
-                }
-            }
-        }
+       {
+           "foo": {
+               "1.0.0": {
+                   "name":         "foo",
+                   "version":      "1.0.0",
+                   "description":  "does foo-like things.",
+               }
+           },
 
-        This example repository contains one versioned package 'foo', and one
-        unversioned package 'bah'.
+           "bah": {
+               "_NO_VERSION": {
+                   "name":         "bah",
+                   "description":  "does bah-like things.",
+                   "requires":     ["python-2.6", "foo-1+"]
+               }
+           }
+       }
+
+    This example repository contains one versioned package 'foo', and one
+    unversioned package 'bah'.
     """
     @classmethod
     def name(cls) -> str:
@@ -146,7 +148,7 @@ class MemoryPackageRepository(PackageRepository):
     def create_repository(cls, repository_data) -> MemoryPackageRepository:
         """Create a standalone, in-memory repository.
 
-        Using this function bypasses the `package_repository_manager` singleton.
+        Using this function bypasses the :data:`~rez.package_repository.package_repository_manager` singleton.
         This is usually desired however, since in-memory repositories are for
         temporarily storing programmatically created packages, which we do not
         want to cache and that do not persist.


### PR DESCRIPTION
This PR fixes most Sphinx warnings. This this, I was able to remove 115 warnings. There are only two warnings left:

```
<unknown>:1: WARNING: more than one target found for cross-reference 'Command': rez.command.Command, rez.rex.Command [ref.python]
<unknown>:1: WARNING: py:class reference target not found: ModuleType [ref.class]
```

These two warnings are bugs in Sphinx. The `autodoc` extension was recently rewritten and it seems to have a few bugs. The warnings don't affect the builds though, so it's all good.

AI disclosure: This started out with an LLM, but I ended up abandoning all its suggestion and instead I did all the changes manually, all by myself. So everything in this PR is coming from my brain.