### PR TITLE
Add Sphinx domains for intersphinx consumers

### DIFF
--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -5,8 +5,8 @@ import argparse
 import rez.cli._main
 import rez.cli._util
 import rez.rezconfig
-from rez.utils.docs import PkgDefDomain as BasePkgDefDomain
-from rez.utils.docs import RexDomain as BaseRexDomain
+from rez.utils.sphinxext import PkgDefDomain as BasePkgDefDomain
+from rez.utils.sphinxext import RexDomain as BaseRexDomain
 import docutils.nodes
 import sphinx.util.nodes
 import sphinx.application

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -5,6 +5,8 @@ import argparse
 import rez.cli._main
 import rez.cli._util
 import rez.rezconfig
+from rez.utils.docs import PkgDefDomain as BasePkgDefDomain
+from rez.utils.docs import RexDomain as BaseRexDomain
 import docutils.nodes
 import sphinx.util.nodes
 import sphinx.application
@@ -138,18 +140,12 @@ class BareNamePythonDomain(sphinx.domains.python.PythonDomain):
 
 
 
-class RexDomain(BareNamePythonDomain):
+class RexDomain(BareNamePythonDomain, BaseRexDomain):
     """Domain for rex (Rez EXecution language) objects used in commands() functions."""
 
-    name = "rex"
-    label = "Rex"
 
-
-class PkgDefDomain(BareNamePythonDomain):
+class PkgDefDomain(BareNamePythonDomain, BasePkgDefDomain):
     """Domain for package definition attributes in package.py files."""
-
-    name = "pkgdef"
-    label = "Package Definition"
 
 
 def convert_rez_config_to_rst() -> list[str]:

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -9,3 +9,4 @@ This section contains various user guides.
 
    update_to_3
    developing_your_own_plugin
+   linking_to_rez_documentation

--- a/docs/source/guides/linking_to_rez_documentation.rst
+++ b/docs/source/guides/linking_to_rez_documentation.rst
@@ -4,7 +4,7 @@ Linking to rez documentation
 
 Sphinx projects can use `intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
 to link to objects in the rez documentation. Rez provides the
-``rez.utils.docs`` Sphinx extension for its two custom domains:
+``rez.utils.sphinxext`` Sphinx extension for its two custom domains:
 
 ``pkgdef``
    Package definition attributes and functions documented in
@@ -27,7 +27,7 @@ Add the rez extension and intersphinx mapping to your Sphinx ``conf.py`` file:
 
    extensions = [
        "sphinx.ext.intersphinx",
-       "rez.utils.docs",
+       "rez.utils.sphinxext",
    ]
 
    intersphinx_mapping = {
@@ -60,7 +60,7 @@ Rez intentionally keeps this integration small and does not install or pin a
 Sphinx version. Documentation projects can select and manage the Sphinx version
 appropriate for their own builds.
 
-We aim to keep ``rez.utils.docs`` compatible across Sphinx and rez releases, but
+We aim to keep ``rez.utils.sphinxext`` compatible across Sphinx and rez releases, but
 not every combination is guaranteed. Changes to Sphinx's domain or intersphinx
 APIs may require an updated rez extension. For reproducible documentation
 builds, projects should pin their documentation dependencies and treat

--- a/docs/source/guides/linking_to_rez_documentation.rst
+++ b/docs/source/guides/linking_to_rez_documentation.rst
@@ -1,0 +1,67 @@
+============================
+Linking to rez documentation
+============================
+
+Sphinx projects can use `intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
+to link to objects in the rez documentation. Rez provides the
+``rez.utils.docs`` Sphinx extension for its two custom domains:
+
+``pkgdef``
+   Package definition attributes and functions documented in
+   :doc:`../package_definition`.
+
+``rex``
+   Objects available to package commands documented in
+   :doc:`../package_commands`.
+
+Configuration
+=============
+
+Install rez and Sphinx in the environment that builds your documentation. Rez
+does not install or pin Sphinx, so your project can select the appropriate Sphinx
+version.
+
+Add the rez extension and intersphinx mapping to your Sphinx ``conf.py`` file:
+
+.. code-block:: python
+
+   extensions = [
+       "sphinx.ext.intersphinx",
+       "rez.utils.docs",
+   ]
+
+   intersphinx_mapping = {
+       "rez": ("https://docs.rez-project.io/en/stable/", None),
+   }
+
+If your project already defines ``extensions`` or ``intersphinx_mapping``, add
+these entries to the existing values instead of replacing them.
+
+Creating links
+==============
+
+Use an explicit external reference to select the rez inventory, domain, and
+object type:
+
+.. code-block:: rst
+
+   :external+rez:pkgdef:attr:`requires`
+   :external+rez:pkgdef:func:`commands`
+   :external+rez:rex:attr:`this.root`
+   :external+rez:rex:func:`alias`
+
+The ``external+rez`` prefix selects the ``rez`` entry in
+``intersphinx_mapping``. The next two components select the domain and role.
+
+Compatibility
+=============
+
+Rez intentionally keeps this integration small and does not install or pin a
+Sphinx version. Documentation projects can select and manage the Sphinx version
+appropriate for their own builds.
+
+We aim to keep ``rez.utils.docs`` compatible across Sphinx and rez releases, but
+not every combination is guaranteed. Changes to Sphinx's domain or intersphinx
+APIs may require an updated rez extension. For reproducible documentation
+builds, projects should pin their documentation dependencies and treat
+unresolved references as errors.

--- a/src/rez/utils/docs.py
+++ b/src/rez/utils/docs.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""Lightweight Sphinx domains for referencing objects in Rez's documentation.
+
+Rez's own documentation adds its directive implementations in ``rez_sphinxext``.
+Consumers only need these domain names and the inherited Python roles for
+intersphinx resolution.
+"""
+
+from sphinx.domains.python import PythonDomain
+
+__all__ = ["setup"]
+
+
+class RexDomain(PythonDomain):
+    """Domain for Rex objects used in ``commands()`` functions."""
+
+    name = "rex"
+    label = "Rex"
+
+
+class PkgDefDomain(PythonDomain):
+    """Domain for attributes in Rez package definition files."""
+
+    name = "pkgdef"
+    label = "Package Definition"
+
+
+def setup(app):
+    """Register Rez's Sphinx domains."""
+    app.add_domain(RexDomain)
+    app.add_domain(PkgDefDomain)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/rez/utils/sphinxext.py
+++ b/src/rez/utils/sphinxext.py
@@ -9,6 +9,8 @@ Consumers only need these domain names and the inherited Python roles for
 intersphinx resolution.
 """
 
+from rez.utils import _rez_version
+
 from sphinx.domains.python import PythonDomain
 
 __all__ = ["setup"]
@@ -34,6 +36,7 @@ def setup(app):
     app.add_domain(PkgDefDomain)
 
     return {
+        "version": _rez_version,
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }


### PR DESCRIPTION
I introduced two new Sphinx domains in 3.4.0 without realizing that it's impossible to reference non-standard domains in other sphinx projects.

This PR creates a new Sphinx extension that our users can use to more easily reference our new domains using intersphinx.

Amp-Thread-ID: https://ampcode.com/threads/T-019fdefd-f7a9-75c8-8d27-ddb0ca62d6fe