### PR TITLE
Improve python docstrings for some core modules

### DIFF
--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -576,14 +576,14 @@ class Config(object, metaclass=LazyAttributeMeta):
     schema_error = ConfigurationError
 
     #: List of filepaths specified during initialization. Note that
-    #: this doesn't corresponds to the actual list of filepaths
+    #: this doesn't correspond to the actual list of filepaths
     #: that participated to create the loaded config.
     filepaths: list[str]
 
     #: Overrides applied to the current config instance.
-    #: Note that is is preferable to use :meth:`override`
+    #: Note that it is preferable to use :meth:`override`
     #: and :meth:`remove_override` to modify the overrides.
-    overrides: dict[str, Any] | None
+    overrides: dict[str, Any]
 
     #: If True, settings overrides in environment variables are ignored.
     locked: bool
@@ -613,7 +613,7 @@ class Config(object, metaclass=LazyAttributeMeta):
         """Get the value of a setting."""
         return getattr(self, key, default)
 
-    def copy(self, overrides: dict[str, Any] = None, locked: bool = False) -> Config:
+    def copy(self, overrides: dict[str, Any] | None = None, locked: bool = False) -> Config:
         """Create a separate copy of this config."""
         other = copy.copy(self)
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -29,6 +29,15 @@ from typing import Any, Protocol, TypeVar, TYPE_CHECKING
 
 T = TypeVar("T")
 
+__all__ = [
+    "Config",
+    "expand_system_vars",
+    "create_config",
+    "get_module_root_config",
+    "config",
+    "Validatable",
+]
+
 
 class Validatable(Protocol):
     def validate(self, data: T) -> T:
@@ -551,16 +560,33 @@ _plugin_config_dict = {
 class Config(object, metaclass=LazyAttributeMeta):
     """Rez configuration settings.
 
-    You should call the `create_config` function, rather than constructing a
-    `Config` object directly.
+    You should call the :func:`create_config` function, rather than constructing a
+    :class:`Config` object directly.
 
-    Config files are merged with other config files to create a `Config`
+    Config files are merged with other config files to create a :class:`Config`
     instance. The 'rezconfig' file in rez acts as the primary - other config
     files update the primary configuration to create the final config. See the
     comments at the top of 'rezconfig' for more details.
     """
+
+    #: :meta private:
     schema = config_schema
+
+    #: :meta private:
     schema_error = ConfigurationError
+
+    #: List of filepaths specified during initialization. Note that
+    #: this doesn't corresponds to the actual list of filepaths
+    #: that participated to create the loaded config.
+    filepaths: list[str]
+
+    #: Overrides applied to the current config instance.
+    #: Note that is is preferable to use :meth:`override`
+    #: and :meth:`remove_override` to modify the overrides.
+    overrides: dict[str, Any] | None
+
+    #: If True, settings overrides in environment variables are ignored.
+    locked: bool
 
     if TYPE_CHECKING:
         # mypy: The use of LazyAttributeMeta means that this class generates hundreds
@@ -569,12 +595,11 @@ class Config(object, metaclass=LazyAttributeMeta):
         def __getattr__(self, item: str) -> Any:
             pass
 
-    def __init__(self, filepaths: list[str], overrides=None, locked: bool = False) -> None:
-        """Create a config.
-
+    def __init__(self, filepaths: list[str], overrides: dict[str, Any] | None = None, locked: bool = False) -> None:
+        """
         Args:
-            filepaths (list of str): List of config files to load.
-            overrides (dict): A dict containing settings that override all
+            filepaths: List of config files to load.
+            overrides: A dict containing settings that override all
                 others. Nested settings are overridden with nested dicts.
             locked: If True, settings overrides in environment variables are
                 ignored.
@@ -584,11 +609,11 @@ class Config(object, metaclass=LazyAttributeMeta):
         self.overrides = overrides or {}
         self.locked = locked
 
-    def get(self, key, default=None):
+    def get(self, key: str, default=None):
         """Get the value of a setting."""
         return getattr(self, key, default)
 
-    def copy(self, overrides=None, locked: bool = False) -> Config:
+    def copy(self, overrides: dict[str, Any] = None, locked: bool = False) -> Config:
         """Create a separate copy of this config."""
         other = copy.copy(self)
 
@@ -600,11 +625,11 @@ class Config(object, metaclass=LazyAttributeMeta):
         other._uncache()
         return other
 
-    def override(self, key: str, value):
+    def override(self, key: str, value: Any):
         """Set a setting to the given value.
 
-        Note that `key` can be in dotted form, eg
-        'plugins.release_hook.emailer.sender'.
+        Note that ``key`` can be in dotted form, eg
+        ``plugins.release_hook.emailer.sender``.
         """
         keys = key.split('.')
         if len(keys) > 1:
@@ -651,13 +676,13 @@ class Config(object, metaclass=LazyAttributeMeta):
         """Get the list of files actually sourced to create the config.
 
         Note:
-            `self.filepaths` refers to the filepaths used to search for the
+            :attr:`Config.filepaths` refers to the filepaths used to search for the
             configs, which does dot necessarily match the files used. For example,
             some files may not exist, while others are chosen as rezconfig.py in
             preference to rezconfig, rezconfig.yaml.
 
         Returns:
-            List of str: The sourced files.
+            The sourced files.
         """
         # Force a config reload
         _ = self._data  # noqa
@@ -674,7 +699,8 @@ class Config(object, metaclass=LazyAttributeMeta):
     def data(self):
         """Returns the entire configuration as a dict.
 
-        Note that this will force all plugins to be loaded.
+        Note:
+            This will force all plugins to be loaded.
         """
         d = {}
         for key in self._data:
@@ -695,7 +721,8 @@ class Config(object, metaclass=LazyAttributeMeta):
             paths.remove(self.local_packages_path)
         return paths
 
-    def get_completions(self, prefix):
+    def get_completions(self, prefix: str):
+        """:meta private:"""
         def _get_plugin_completions(prefix_):
             from rez.utils.data_utils import get_object_completions
             words = get_object_completions(
@@ -910,7 +937,7 @@ class _PluginConfigs(object):
 
 
 def expand_system_vars(data: T) -> T:
-    """Expands any strings within `data` such as '{system.user}'."""
+    """Expands any strings within ``data`` such as ``{system.user}``."""
     def _expanded(value):
         if isinstance(value, str):
             str_value = expandvars(value)
@@ -1051,10 +1078,11 @@ def _load_config_from_filepaths(filepaths: list[str]) -> tuple[dict[str, Any], l
 
 
 def get_module_root_config() -> str:
+    """Get the path to the default config"""
     return os.path.join(module_root_path, "rezconfig.py")
 
 
-# singleton
+#: singleton representing the currently active config
 config = Config._create_main_config()
 
 if os.getenv("REZ_LOG_DEPRECATION_WARNINGS"):

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -279,7 +279,7 @@ class PackageRepository(object):
 
         Args:
             pkg_name: Package name
-            force: If Trur, delete even if not empty.
+            force: If True, delete even if not empty.
 
         Returns:
             True if the family was removed, False if it wasn't found.
@@ -467,7 +467,7 @@ class PackageRepository(object):
 
     def get_resource_from_handle(self, resource_handle: ResourceHandle,
                                  verify_repo: bool = True) -> Resource:
-        """Get a resource from an handle.
+        """Get a resource from a handle.
 
         Args:
             resource_handle: Handle of the resource.

--- a/src/rez/package_repository.py
+++ b/src/rez/package_repository.py
@@ -34,7 +34,7 @@ def create_memory_package_repository(repository_data: dict) -> MemoryPackageRepo
     See rezplugins/package_repository/memory.py for more details.
 
     Args:
-        repository_data (dict): Package repository data.
+        repository_data: Package repository data.
 
     Returns:
         `PackageRepository` object.
@@ -75,7 +75,7 @@ class PackageRepository(object):
     payloads.
     """
 
-    # see `install_variant`.
+    #: see :meth:`install_variant`.
     remove = object()
 
     @classmethod
@@ -87,10 +87,9 @@ class PackageRepository(object):
         """Create a package repository.
 
         Args:
-            location (str): A string specifying the location of the repository.
+            location: A string specifying the location of the repository.
                 This could be a filesystem path, or a database uri, etc.
-            resource_pool (`ResourcePool`): The pool used to manage package
-                resources.
+            resource_pool: The pool used to manage package resources.
         """
         self.location = location
         self.pool = resource_pool
@@ -101,7 +100,7 @@ class PackageRepository(object):
     def register_resource(self, resource_class: type[Resource]) -> None:
         """Register a resource with the repository.
 
-        Your derived repository class should call this method in its __init__ to
+        Your derived repository class should call this method in its ``__init__`` to
         register all the resource types associated with that plugin.
         """
         self.pool.register_resource(resource_class)
@@ -145,7 +144,7 @@ class PackageRepository(object):
         """Get a package family.
 
         Args:
-            name (str): Package name.
+            name: Package name.
 
         Returns:
             `PackageFamilyResource`, or None if not found.
@@ -166,7 +165,7 @@ class PackageRepository(object):
         order.
 
         Args:
-            package_family_resource (`PackageFamilyResource`): Parent family.
+            package_family_resource: Parent family.
 
         Returns:
             `PackageResource` iterator.
@@ -177,7 +176,7 @@ class PackageRepository(object):
         """Iterate over the variants within the given package.
 
         Args:
-            package_resource (`PackageResource`): Parent package.
+            package_resource: Parent package.
 
         Returns:
             `VariantResource` iterator.
@@ -188,8 +187,8 @@ class PackageRepository(object):
         """Get a package.
 
         Args:
-            name (str): Package name.
-            version (`Version`): Package version.
+            name: Package name.
+            version: Package version.
 
         Returns:
             `PackageResourceHelper` or None: Matching package, or None if not found.
@@ -208,7 +207,7 @@ class PackageRepository(object):
         """Get a package given its URI.
 
         Args:
-            uri (str): Package URI
+            uri: Package URI
 
         Returns:
             `PackageResource`, or None if the package is not present in this
@@ -220,7 +219,7 @@ class PackageRepository(object):
         """Get a variant given its URI.
 
         Args:
-            uri (str): Variant URI
+            uri: Variant URI
 
         Returns:
             `VariantResource`, or None if the variant is not present in this
@@ -234,18 +233,16 @@ class PackageRepository(object):
         Ignoring a package makes it invisible to further resolves.
 
         Args:
-            pkg_name (str): Package name
-            pkg_version(`Version`): Package version
-            allow_missing (bool): if True, allow for ignoring a package that
+            pkg_name: Package name
+            pkg_version: Package version
+            allow_missing: if True, allow for ignoring a package that
                 does not exist. This is useful when you want to copy a package
                 to a repo and you don't want it visible until the copy is
                 completed.
 
         Returns:
-            int:
-            * -1: Package not found
-            * 0: Nothing was done, package already ignored
-            * 1: Package was ignored
+            -1 if the package is not found, 0 if nothing was done (package already ignored)
+            or 1 if package was ignored.
         """
         raise NotImplementedError
 
@@ -253,14 +250,12 @@ class PackageRepository(object):
         """Unignore the given package.
 
         Args:
-            pkg_name (str): Package name
-            pkg_version(`Version`): Package version
+            pkg_name: Package name
+            pkg_version: Package version
 
         Returns:
-            int:
-            * -1: Package not found
-            * 0: Nothing was done, package already visible
-            * 1: Package was unignored
+            -1 if the package is not found, 0 if nothing was done (package already visible)
+            or 1 if the package was unignored.
         """
         raise NotImplementedError
 
@@ -271,11 +266,11 @@ class PackageRepository(object):
         ignored.
 
         Args:
-            pkg_name (str): Package name
-            pkg_version(`Version`): Package version
+            pkg_name: Package name
+            pkg_version: Package version
 
         Returns:
-            bool: True if the package was removed, False if it wasn't found.
+            True if the package was removed, False if it wasn't found.
         """
         raise NotImplementedError
 
@@ -283,11 +278,11 @@ class PackageRepository(object):
         """Remove an empty package family.
 
         Args:
-            pkg_name (str): Package name
-            force (bool): If Trur, delete even if not empty.
+            pkg_name: Package name
+            force: If Trur, delete even if not empty.
 
         Returns:
-            bool: True if the family was removed, False if it wasn't found.
+            True if the family was removed, False if it wasn't found.
         """
         raise NotImplementedError
 
@@ -296,13 +291,13 @@ class PackageRepository(object):
         """Remove packages ignored for >= specified number of days.
 
         Args:
-            days (int): Remove packages ignored >= this many days
+            days: Remove packages ignored >= this many days
             dry_run: Dry run mode
-            verbose (bool): Verbose mode
+            verbose: Verbose mode
 
         Returns:
-            int: Number of packages removed. In dry-run mode, returns the
-            number of packages that _would_ be removed.
+            Number of packages removed. In dry-run mode, returns the
+            number of packages that *would* be removed.
         """
         raise NotImplementedError
 
@@ -312,7 +307,7 @@ class PackageRepository(object):
         If any directories are created on disk for the variant to install into,
         this is called before that happens.
 
-        Note that it is the responsibility of the `BuildProcess` to call this
+        Note that it is the responsibility of the :class:`.BuildProcess` to call this
         function at the appropriate time.
         """
         pass
@@ -320,14 +315,14 @@ class PackageRepository(object):
     def on_variant_install_cancelled(self, variant_resource: VariantResource) -> None:
         """Called when a variant installation is cancelled.
 
-        This is called after `pre_variant_install`, but before `install_variant`,
+        This is called after :meth:`pre_variant_install`, but before :meth:`install_variant`,
         which is not expected to be called.
 
         Variant install cancellation usually happens for one of two reasons -
         either the variant installation failed (ie a build error occurred), or
         one or more of the package tests failed, aborting the installation.
 
-        Note that it is the responsibility of the `BuildProcess` to call this
+        Note that it is the responsibility of the :class:`.BuildProcess` to call this
         function at the appropriate time.
         """
         pass
@@ -342,18 +337,18 @@ class PackageRepository(object):
         into this one.
 
         Args:
-            variant_resource (`VariantResource`): Variant to install.
-            dry_run (bool): If True, do not actually install the variant. In this
-                mode, a `Variant` instance is only returned if the equivalent
+            variant_resource: Variant to install.
+            dry_run: If True, do not actually install the variant. In this
+                mode, a :class:`.Variant` instance is only returned if the equivalent
                 variant already exists in this repository; otherwise, None is
                 returned.
-            overrides (dict): Use this to change or add attributes to the
+            overrides: Use this to change or add attributes to the
                 installed variant. To remove attributes, set values to
-                `PackageRepository.remove`.
+                :attr:`remove`.
 
         Returns:
             `VariantResource` object, which is the newly created variant in this
-            repository. If `dry_run` is True, None may be returned.
+            repository. If ``dry_run`` is True, None may be returned.
         """
         raise NotImplementedError
 
@@ -365,11 +360,11 @@ class PackageRepository(object):
         requirements).
 
         Note that even though the implementation is trivial, this function is
-        provided since using `install_variant` to find an existing variant is
+        provided since using :meth:`install_variant` to find an existing variant is
         nonintuitive.
 
         Args:
-            variant_resource (`VariantResource`): Variant to install.
+            variant_resource: Variant to install.
 
         Returns:
             `VariantResource` object, or None if the variant was not found.
@@ -380,7 +375,7 @@ class PackageRepository(object):
         """Get the parent package family of the given package.
 
         Args:
-            package_resource (`PackageResource`): Package.
+            package_resource: Package.
 
         Returns:
             `PackageFamilyResource`.
@@ -391,7 +386,7 @@ class PackageRepository(object):
         """Get the parent package of the given variant.
 
         Args:
-            variant_resource (`VariantResource`): Variant.
+            variant_resource: Variant.
 
         Returns:
             `PackageResource`.
@@ -424,16 +419,16 @@ class PackageRepository(object):
         you will be missing out on.
 
         Returns:
-            int: Epoch time at which a package was changed/added/removed from
-                the given package family. Zero signifies an unknown last package
-                update time.
+            Epoch time at which a package was changed/added/removed from
+            the given package family. Zero signifies an unknown last package
+            update time.
         """
         return 0
 
     def make_resource_handle(self, resource_key: str, **variables: Any) -> ResourceHandle:
-        """Create a `ResourceHandle`
+        """Create a :class:`.ResourceHandle`
 
-        Nearly all `ResourceHandle` creation should go through here, because it
+        Nearly all :class:`.ResourceHandle` creation should go through here, because it
         gives the various resource classes a chance to normalize / standardize
         the resource handles, to improve caching / comparison / etc.
         """
@@ -461,7 +456,7 @@ class PackageRepository(object):
         available, otherwise a new resource object is created and returned.
 
         Args:
-            resource_key (`str`):  Name of the type of `Resources` to find
+            resource_key: Name of the type of :class:`.Resource` to find
             variables: data to identify / store on the resource
 
         Returns:
@@ -472,10 +467,10 @@ class PackageRepository(object):
 
     def get_resource_from_handle(self, resource_handle: ResourceHandle,
                                  verify_repo: bool = True) -> Resource:
-        """Get a resource.
+        """Get a resource from an handle.
 
         Args:
-            resource_handle (`ResourceHandle`): Handle of the resource.
+            resource_handle: Handle of the resource.
 
         Returns:
             `PackageRepositoryResource` instance.
@@ -505,11 +500,11 @@ class PackageRepository(object):
         """Defines where a package's payload should be installed to.
 
         Args:
-            package_name (str): Name of package.
-            package_version (str or `Version`): Package version.
+            package_name: Name of package.
+            package_version: Package version.
 
         Returns:
-            str: Path where package's payload should be installed to.
+            Path where package's payload should be installed to.
         """
         raise NotImplementedError
 
@@ -517,8 +512,8 @@ class PackageRepository(object):
         """Unique identifier implementation.
 
         You may need to provide your own implementation. For example, consider
-        the 'filesystem' repository. A default uri might be 'filesystem@/tmp_pkgs'.
-        However /tmp_pkgs is probably a local path for each user, so this would
+        the 'filesystem' repository. A default uri might be ``filesystem@/tmp_pkgs``.
+        However ``/tmp_pkgs`` is probably a local path for each user, so this would
         not actually uniquely identify the repository - probably the inode number
         needs to be incorporated also.
 
@@ -531,14 +526,14 @@ class PackageRepository(object):
 class PackageRepositoryManager(object):
     """Package repository manager.
 
-    Manages retrieval of resources (packages and variants) from `PackageRepository`
+    Manages retrieval of resources (packages and variants) from :class:`PackageRepository`
     instances, and caches these resources in a resource pool.
     """
     def __init__(self, resource_pool: ResourcePool | None = None) -> None:
         """Create a package repo manager.
 
         Args:
-            resource_pool (`ResourcePool`): Provide your own resource pool. If
+            resource_pool: Provide your own resource pool. If
                 None, a default pool is created based on config settings.
         """
         if resource_pool is None:
@@ -555,10 +550,10 @@ class PackageRepositoryManager(object):
         """Get a package repository.
 
         Args:
-            path (str): Entry from the 'packages_path' config setting. This may
+            path: Entry from the :data:`packages_path` config setting. This may
                 simply be a path (which is managed by the 'filesystem' package
-                repository plugin), or a string in the form "type@location",
-                where 'type' identifies the repository plugin type to use.
+                repository plugin), or a string in the form ``type@location``,
+                where ``type`` identifies the repository plugin type to use.
 
         Returns:
             `PackageRepository` instance.
@@ -591,11 +586,11 @@ class PackageRepositoryManager(object):
         return repository
 
     def are_same(self, path_1: str, path_2: str) -> bool:
-        """Test that `path_1` and `path_2` refer to the same repository.
+        """Test that ``path_1`` and ``path_2`` refer to the same repository.
 
         This is more reliable than testing that the strings match, since slightly
         different strings might refer to the same repository (consider small
-        differences in a filesystem path for example, eg '//svr/foo', '/svr/foo').
+        differences in a filesystem path for example, eg ``//svr/foo``, ``/svr/foo``).
 
         Returns:
             True if the paths refer to the same repository, False otherwise.
@@ -615,10 +610,10 @@ class PackageRepositoryManager(object):
         available, otherwise a new resource object is created and returned.
 
         Args:
-            resource_key (`str`):  Name of the type of `Resources` to find
-            repository_type (`str`): What sort of repository to look for the
+            resource_key:  Name of the type of :class:`.Resource` to find
+            repository_type: What sort of repository to look for the
                 resource in
-            location (`str`): location for the repository
+            location: location for the repository
             variables: data to identify / store on the resource
 
         Returns:
@@ -629,12 +624,11 @@ class PackageRepositoryManager(object):
         resource = repo.get_resource(**variables)
         return resource
 
-    def get_resource_from_handle(self, resource_handle: ResourceHandle
-                                 ) -> Resource:
-        """Get a resource.
+    def get_resource_from_handle(self, resource_handle: ResourceHandle) -> Resource:
+        """Get a resource from an handle.
 
         Args:
-            resource_handle (`ResourceHandle`): Handle of the resource.
+            resource_handle: Handle of the resource.
 
         Returns:
             `PackageRepositoryResource` instance.

--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -44,7 +44,7 @@ T = TypeVar("T")
 def extend_path(path, name):
     """Extend a package's path.
 
-    Intended use is to place the following code in a package's __init__.py:
+    Intended use is to place the following code in a package's __init__.py::
 
         from pkgutil import extend_path
         __path__ = extend_path(__path__, __name__)

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -695,11 +695,11 @@ class ResolvedContext(object):
 
         Args:
             as_dot: If True, get the graph as a dot-language string. Otherwise,
-                a :class:`.digraph` object is returned.
+                a :class:`rez.vendor.pygraph.classes.digraph.digraph` object is returned.
 
         Returns:
-            A string or :class:`.digraph` object, or None if there is no graph
-            associated with the resolve.
+            A string or :class:`rez.vendor.pygraph.classes.digraph.digraph` object, or
+            None if there is no graph associated with the resolve.
         """
         if not self.has_graph:
             return None
@@ -1143,7 +1143,7 @@ class ResolvedContext(object):
         The dependency graph does not show conflicts.
 
         Returns:
-            `pygraph.digraph` object.
+            :class:`rez.vendor.pygraph.classes.digraph.digraph` object.
         """
         from rez.vendor.pygraph.classes.digraph import digraph
 

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -68,7 +68,7 @@ CallableT = TypeVar("CallableT", bound=Callable)
 
 
 class RezToolsVisibility(Enum):
-    """Determines if/how rez cli tools are added back to PATH within a
+    """Determines if/how rez cli tools are added back to $PATH within a
     resolved environment.
     """
     #: Don't expose rez in resolved env
@@ -114,20 +114,20 @@ def get_lock_request(name: str,
                      weak: bool = True) -> PackageRequest | None:
     """Given a package and patch lock, return the equivalent request.
 
-    For example, for object 'foo-1.2.1' and lock type 'lock_3', the equivalent
-    request is '~foo-1.2'. This restricts updates to foo to patch-or-lower
+    For example, for object ``foo-1.2.1`` and lock type ``lock_3``, the equivalent
+    request is ``~foo-1.2``. This restricts updates to foo to patch-or-lower
     version changes only.
 
     For objects not versioned down to a given lock level, the closest possible
-    lock is applied. So 'lock_3' applied to 'foo-1' would give '~foo-1'.
+    lock is applied. So ``lock_3`` applied to ``foo-1`` would give ``~foo-1``.
 
     Args:
-        name (str): Package name.
-        version (Version): Package version.
-        patch_lock (PatchLock): Lock type to apply.
+        name: Package name.
+        version: Package version.
+        patch_lock: Lock type to apply.
 
     Returns:
-        typing.Optional[PackageRequest]: PackageRequest object, or None if there is no equivalent request.
+        PackageRequest object, or None if there is no equivalent request.
     """
     ch = '~' if weak else ''
     if patch_lock == PatchLock.lock:
@@ -161,15 +161,31 @@ class ResolvedContext(object):
     supported shell plugin type, such as bash and tcsh. It can also run a
     command within a configured python namespace, without spawning a child
     shell.
+
+    Creating an instance will resolve the requested package requests.
+
+    An existing environment (context) can be loaded by using either
+    :meth:`load` or :meth:`read_from_buffer`.
+
+    Saving the environment for later reuse can be done using :meth:`save`
+    or :meth:`write_to_buffer`.
     """
+
+    #: :meta private:
     serialize_version = (4, 9)
+    #: :meta private:
     tmpdir_manager = TempDirs(config.context_tmpdir, prefix="rez_context_")
+    #: :meta private:
     context_tracking_payload: dict[str, Any] | None = None
+    #: :meta private:
     context_tracking_lock = threading.Lock()
+    #: :meta private:
     package_cache_present = True
+    #: :meta private:
     local = threading.local()
 
     class Callback(object):
+        """:meta private:"""
         def __init__(self, max_fails: int, time_limit: int,
                      callback: Callable[[SolverState], tuple[SolverCallbackReturn, str]] | None,
                      buf: SupportsWrite | None = None) -> None:
@@ -215,54 +231,63 @@ class ResolvedContext(object):
         """Perform a package resolve, and store the result.
 
         Args:
-            package_requests (list[typing.Union[str, Requirement]]): request
-            verbosity (int): Verbosity level. One of [0,1,2].
-            timestamp (float): Ignore packages released after this epoch time. Packages
+            package_requests: request
+            verbosity: Verbosity level. One of 0, 1 or 2.
+            timestamp: Ignore packages released after this epoch time. Packages
                 released at exactly this time will not be ignored.
-            building (bool): True if we're resolving for a build.
-            testing (bool): True if we're resolving for a test (rez-test).
-            caching (bool): If True, cache(s) may be used to speed the resolve. If
+            building: True if we're resolving for a build.
+            testing: True if we're resolving for a test (rez-test).
+            caching: If True, cache(s) may be used to speed the resolve. If
                 False, caches will not be used. If None, :data:`resolve_caching`
                 is used.
-            package_paths (list[str]): List of paths to search for pkgs, defaults to
+            package_paths: List of paths to search for pkgs, defaults to
                 :data:`packages_path`.
-            package_filter (PackageFilterList): Filter used to exclude certain
+            package_filter: Filter used to exclude certain
                 packages. Defaults to settings from :data:`package_filter`. Use
                 :data:`rez.package_filter.no_filter` to remove all filtering.
-            package_orderers (list[PackageOrder]): Custom package ordering.
+            package_orderers: Custom package ordering.
                 Defaults to settings from :data:`package_orderers`.
-            add_implicit_packages (bool): If True, the implicit package list defined
+            add_implicit_packages: If True, the implicit package list defined
                 by :data:`implicit_packages` is appended to the request.
-            max_fails (int): Abort the resolve if the number of failed steps is
+            max_fails: Abort the resolve if the number of failed steps is
                 greater or equal to this number. If -1, does not abort.
-            time_limit (int): Abort the resolve if it takes longer than this
+            time_limit: Abort the resolve if it takes longer than this
                 many seconds. If -1, there is no time limit.
             callback: See :class:`.Solver`.
             package_load_callback: If not None, this callable will be called
                 prior to each package being loaded. It is passed a single
                 :class:`.Package` object.
-            buf (typing.IO): Where to print verbose output to, defaults
+            buf: Where to print verbose output to, defaults
                 to stdout.
-            suppress_passive (bool): If True, don't print debugging info that
+            suppress_passive: If True, don't print debugging info that
                 has had no effect on the solve. This argument only has an
                 effect if ``verbosity`` > 2.
-            print_stats (bool): If True, print advanced solver stats at the end.
-            package_caching (bool|None): If True, apply package caching settings
+            print_stats: If True, print advanced solver stats at the end.
+            package_caching: If True, apply package caching settings
                 as per the config. If None, enable as determined by config
                 setting :data:`package_cache_during_build`.
-            package_cache_async (bool|None): If True, cache packages asynchronously.
+            package_cache_async: If True, cache packages asynchronously.
                 If None, use the config setting :data:`package_cache_async`
         """
         self.load_path: str | None = None
 
         # resolving settings
+        #: The epoch time of this resolved environment, explicitly set by the user
+        #: with (for example) the :option:`rez-env --time` flag; zero otherwise.
         self.requested_timestamp = timestamp
-        self.timestamp = self.requested_timestamp or int(time.time())
-        self.building = building
-        self.testing = testing
+        #: The epoch time when this environment was resolved; OR, the value of
+        #: :data:`requested_timestamp`, if non-zero.
+        self.timestamp: float = self.requested_timestamp or int(time.time())
+        #: True if we're resolving for a build.
+        self.building: bool = building
+        #: True if we're resolving for a test (rez-test).
+        self.testing: bool = testing
+        #: List of packages that were implicitly added when the context was created.
         self.implicit_packages: list[Requirement] = []
-        self.caching = config.resolve_caching if caching is None else caching
-        self.verbosity = verbosity
+        #: Whether package payload caching is enabled or not.
+        self.caching: bool = config.resolve_caching if caching is None else caching
+        #: Verbosity level of the solver.
+        self.verbosity: int = verbosity
 
         self._package_requests: list[Requirement] = []
         for req in package_requests:
@@ -407,22 +432,15 @@ class ResolvedContext(object):
 
     @property
     def status(self) -> ResolverStatus:
-        """Return the current status of the context.
-
-        Returns:
-            ResolverStatus:
-        """
+        """Status of the context."""
         return self.status_
 
     def requested_packages(self, include_implicit: bool = False) -> list[Requirement]:
         """Get packages in the request.
 
         Args:
-            include_implicit (bool): If True, implicit packages are appended
+            include_implicit: If True, implicit packages are appended
                 to the result.
-
-        Returns:
-            list[Requirement]:
         """
         if include_implicit:
             return self._package_requests + self.implicit_packages
@@ -434,7 +452,7 @@ class ResolvedContext(object):
         """Get packages in the resolve.
 
         Returns:
-            typing.Optional[list[Variant]]: Resolved variant objects, or None if the resolve failed.
+            Resolved variant objects, or None if the resolve failed.
         """
         return self._resolved_packages
 
@@ -443,7 +461,7 @@ class ResolvedContext(object):
         """Get non-conflict ephemerals in the resolve.
 
         Returns:
-            typing.Optional[list[Requirement]]: Requirement objects, or None if the resolve failed.
+            Requirement objects, or None if the resolve failed.
         """
         return self._resolved_ephemerals
 
@@ -488,7 +506,7 @@ class ResolvedContext(object):
         return bool((self.graph_ is not None) or self.graph_string)
 
     def get_resolved_package(self, name: str) -> Variant | None:
-        """Returns a `Variant` object or None if the package is not in the
+        """Returns a :class:`.Variant` object or None if the package is not in the
         resolve.
         """
         pkgs = [x for x in (self._resolved_packages or []) if x.name == name]
@@ -508,14 +526,14 @@ class ResolvedContext(object):
 
         Args:
             package_paths: List of paths to search for pkgs to retarget to.
-            package_names (list of str): Only retarget these packages. If None,
+            package_names: Only retarget these packages. If None,
                 retarget all packages.
-            skip_missing (bool): If True, skip retargeting of variants that
+            skip_missing: If True, skip retargeting of variants that
                 cannot be found in ``package_paths``. By default, a
                 :exc:`.PackageNotFoundError` is raised.
 
         Returns:
-            ResolvedContext: The retargeted context.
+            The retargeted context.
         """
         retargeted_variants: list[Variant | VariantResource] = []
 
@@ -585,14 +603,13 @@ class ResolvedContext(object):
         in the order that they appear in `package_requests`.
 
         Args:
-            package_requests (list[typing.Union[str, PackageRequest]):
-                Overriding requests.
-            package_subtractions (list[str]): Any original request with a
+            package_requests: Overriding requests.
+            package_subtractions: Any original request with a
                 package name in this list is removed, before the new requests
                 are added.
-            strict (bool): If True, the current context's resolve is used as the
+            strict: If True, the current context's resolve is used as the
                 original request list, rather than the request.
-            rank (int): If > 1, package versions can only increase in this rank
+            rank: If > 1, package versions can only increase in this rank
                 and further - for example, rank=3 means that only version patch
                 numbers are allowed to increase, major and minor versions will
                 not change. This is only applied to packages that have not been
@@ -600,7 +617,7 @@ class ResolvedContext(object):
                 ``strict`` is True, rank is ignored.
 
         Returns:
-            list[PackageRequest]: PackageRequests objects that can be used to construct a
+            PackageRequests objects that can be used to construct a
             new :class:`ResolvedContext` object.
         """
         # assemble source request
@@ -678,10 +695,10 @@ class ResolvedContext(object):
 
         Args:
             as_dot: If True, get the graph as a dot-language string. Otherwise,
-                a pygraph.digraph object is returned.
+                a :class:`.digraph` object is returned.
 
         Returns:
-            A string or `pygraph.digraph` object, or None if there is no graph
+            A string or :class:`.digraph` object, or None if there is no graph
             associated with the resolve.
         """
         if not self.has_graph:
@@ -723,7 +740,7 @@ class ResolvedContext(object):
         """Get the context for the current env, if there is one.
 
         Returns:
-            ResolvedContext: Current context, or None if not in a resolved env.
+            Current context, or None if not in a resolved env.
         """
         filepath = os.getenv("REZ_RXT_FILE")
         if not filepath or not os.path.exists(filepath):
@@ -734,7 +751,7 @@ class ResolvedContext(object):
     def is_current(self) -> bool | None:
         """
         Returns:
-            bool: True if this is the currently sourced context, False otherwise.
+            True if this is the currently sourced context, False otherwise.
         """
         if not self.load_path:
             return False
@@ -763,12 +780,12 @@ class ResolvedContext(object):
         except Exception as e:
             cls._load_error(e, identifier_str)
 
-    def get_resolve_diff(self, other: ResolvedContext) -> dict:
+    def get_resolve_diff(self, other: ResolvedContext) -> dict[str, Any]:
         """Get the difference between the resolve in this context and another.
 
         The difference is described from the point of view of the current context
-        - a newer package means that the package in `other` is newer than the
-        package in `self`.
+        - a newer package means that the package in ``other`` is newer than the
+        package in ``self``.
 
         Diffs can only be compared if their package search paths match, an error
         is raised otherwise.
@@ -777,22 +794,22 @@ class ResolvedContext(object):
         of a package is ignored.
 
         Returns:
-            dict: A dict containing:
+            A dict containing
 
-            - 'newer_packages': A dict containing items:
-                - package name (str);
-                - List of `Package` objects. These are the packages up to and
-                  including the newer package in `self`, in ascending order.
-            - 'older_packages': A dict containing:
-                - package name (str);
-                - List of `Package` objects. These are the packages down to and
-                  including the older package in `self`, in descending order.
-            - 'added_packages': Set of `Package` objects present in `self` but
-               not in `other`;
-            - 'removed_packages': Set of `Package` objects present in `other`,
-               but not in `self`.
+            - ``newer_packages``: A dict containing items:
+                - package name (``str``);
+                - List of :class:`.Package` objects. These are the packages up to and
+                  including the newer package in ``self``, in ascending order.
+            - ``older_packages``: A dict containing:
+                - package name (``str``);
+                - List of :class:`.Package` objects. These are the packages down to and
+                  including the older package in ``self``, in descending order.
+            - ``added_packages``: Set of :class:`.Package` objects present in ``self`` but
+               not in ``other``;
+            - ``removed_packages``: Set of :class:`.Package` objects present in ``other``,
+               but not in ``self``.
 
-            If any item ('added_packages' etc) is empty, it is not added to the
+            If any item (``added_packages``, etc) is empty, it is not added to the
             resulting dict. Thus, an empty dict is returned if there is no
             difference between contexts.
         """
@@ -857,13 +874,14 @@ class ResolvedContext(object):
         """Prints a message summarising the contents of the resolved context.
 
         Args:
-            buf (typing.IO): Where to print this info to.
-            verbosity (bool): Verbose mode.
-            source_order (bool): If True, print resolved packages in the order
+            buf: Where to print this info to.
+            verbosity: Verbose mode.
+            source_order: If True, print resolved packages in the order
                 they are sourced, rather than alphabetical order.
-            show_resolved_uris (bool): By default, resolved packages have their
-                'root' property listed, or their 'uri' if 'root' is None. Use
-                this option to list 'uri' regardless.
+            show_resolved_uris: By default, resolved packages have their
+                :attr:`.Variant.root` property listed, or their :attr:`.Variant.uri` if
+                :attr:`.Variant.root` is None. Use this option to list
+                :attr:`.Variant.uri` regardless.
         """
         _pr = Printer(buf)
 
@@ -1018,6 +1036,11 @@ class ResolvedContext(object):
             self.print_tools(buf=buf)
 
     def print_tools(self, buf: SupportsWrite = sys.stdout) -> None:
+        """Print the command line tools in a table.
+
+        Args:
+            buf: Where to print this info to.
+        """
         data = self.get_tools()
         if not data:
             return
@@ -1047,14 +1070,14 @@ class ResolvedContext(object):
         """Print the difference between the resolve of two contexts.
 
         Args:
-            other (ResolvedContext): Context to compare to.
+            other: Context to compare to.
             heading: One of:
 
                 - None: Do not display a heading;
                 - True: Display the filename of each context as a heading, if
                   both contexts have a filepath;
                 - 2-tuple: Use the given two strings as headings - the first is
-                  the heading for `self`, the second for `other`.
+                  the heading for ``self``, the second for ``other``.
         """
         d = self.get_resolve_diff(other)
         if not d:
@@ -1114,8 +1137,8 @@ class ResolvedContext(object):
     def get_dependency_graph(self, as_dot: bool = False) -> digraph | str:
         """Generate the dependency graph.
 
-        The dependency graph is a simpler subset of the resolve graph. It
-        contains package name nodes connected directly to their dependencies.
+        The dependency graph is a simpler subset of the resolve graph (:meth:`graph`).
+        It contains package name nodes connected directly to their dependencies.
         Weak references and conflict requests are not included in the graph.
         The dependency graph does not show conflicts.
 
@@ -1158,7 +1181,11 @@ class ResolvedContext(object):
 
     @_on_success
     def validate(self) -> None:
-        """Validate the context."""
+        """Validate the context.
+
+        Raises:
+            ResolvedContextError: If the context is not valid.
+        """
         try:
             for pkg in self.resolved_packages:
                 pkg.validate_data()
@@ -1167,7 +1194,7 @@ class ResolvedContext(object):
 
     @_on_success
     def get_environ(self, parent_environ: Mapping[str, str] | None = None) -> dict[str, str]:
-        """Get the environ dict resulting from interpreting this context.
+        """Get the environment variables resulting from interpreting this context.
 
         Args:
             parent_environ: Environment to interpret the context within,
@@ -1184,11 +1211,11 @@ class ResolvedContext(object):
 
     @_on_success
     def get_key(self, key: str, request_only: bool = False) -> dict[str, tuple[Variant, Any]]:
-        """Get a data key value for each resolved package.
+        """Get a data key/value for each resolved package.
 
         Args:
-            key (str): String key of property, eg 'tools'.
-            request_only (bool): If True, only return the key from resolved
+            key: String key of property, eg 'tools'.
+            request_only: If True, only return the key from resolved
                 packages that were also present in the request.
 
         Returns:
@@ -1227,10 +1254,10 @@ class ResolvedContext(object):
         does not know which variant's tool is actually exposed.
 
         Args:
-            tool_name(str): Name of the tool to search for.
+            tool_name: Name of the tool to search for.
 
         Returns:
-            Set of `Variant` objects. If no variant provides the tool, an
+            Set of :class:`.Variant` objects. If no variant provides the tool, an
             empty set is returned.
         """
         variants = set()
@@ -1269,11 +1296,11 @@ class ResolvedContext(object):
         """Get the shell code resulting from intepreting this context.
 
         Args:
-            shell (str): Shell type, for eg 'bash'. If None, the current shell
+            shell: Shell type, for eg 'bash'. If None, the current shell
                 type is used.
-            parent_environ (dict): Environment to interpret the context within,
-                defaults to os.environ if None.
-            style (OutputStyle): Style to format shell code in.
+            parent_environ: Environment to interpret the context within,
+                defaults to :data:`os.environ` if None.
+            style: Style to format shell code in.
         """
         executor = self._create_executor(interpreter=create_shell(shell),
                                          parent_environ=parent_environ)
@@ -1286,7 +1313,7 @@ class ResolvedContext(object):
 
     @_on_success
     def get_actions(self, parent_environ: Mapping[str, str] | None = None) -> list[Action]:
-        """Get the list of rex.Action objects resulting from interpreting this
+        """Get the list of rex :class:`.Action` objects resulting from interpreting this
         context. This is provided mainly for testing purposes.
 
         Args:
@@ -1305,12 +1332,13 @@ class ResolvedContext(object):
     def apply(self, parent_environ: Mapping[str, str] | None = None) -> None:
         """Apply the context to the current python session.
 
-        Note that this updates os.environ and possibly sys.path, if
-        `parent_environ` is not provided.
+        Note:
+            This updates :data:`os.environ` and possibly :data:`sys.path`, if
+            ``parent_environ`` is not provided.
 
         Args:
             parent_environ: Environment to interpret the context within,
-                defaults to os.environ if None.
+                defaults to :data:`os.environ` if None.
         """
         interpreter = Python(target_environ=os.environ)
         executor = self._create_executor(interpreter, parent_environ)
@@ -1325,7 +1353,7 @@ class ResolvedContext(object):
         Args:
             cmd: String name of the program to find.
             parent_environ: Environment to interpret the context within,
-                defaults to os.environ if None.
+                defaults to :data:`os.environ` if None.
             fallback: If True, and the program is not found in the context,
                 the current environment will then be searched.
 
@@ -1347,21 +1375,21 @@ class ResolvedContext(object):
         This applies the context to a python environ dict, then runs a
         subprocess in that namespace. This is not a fully configured subshell -
         shell-specific commands such as aliases will not be applied. To execute
-        a command within a subshell instead, use execute_shell().
+        a command within a subshell instead, use :meth:`execute_shell`.
 
         Warning:
             This runs a command in a configured environ dict only, not in a true
-            shell. To do that, call `execute_shell` using the `command` keyword
+            shell. To do that, call :meth:`execute_shell` using the ``command`` keyword
             argument.
 
         Args:
             args: Command arguments, can be a string.
             parent_environ: Environment to interpret the context within,
                 defaults to os.environ if None.
-            Popen_args: Args to pass to subprocess.Popen.
+            Popen_args: Args to pass to :class:`.Popen`.
 
         Returns:
-            A subprocess.Popen object.
+            A :class:`.Popen` object.
 
         Note:
             This does not alter the current python session.
@@ -1386,11 +1414,11 @@ class ResolvedContext(object):
         """Run some rex code in the context.
 
         Note:
-            This is just a convenience form of `execute_shell`.
+            This is just a convenience form of :meth:`execute_shell`.
 
         Args:
-            code (str): Rex code to execute.
-            filename (str): Filename to report if there are syntax errors.
+            code: Rex code to execute.
+            filename: Filename to report if there are syntax errors.
             shell: Shell type, for eg 'bash'. If None, the current shell type
                 is used.
             parent_environ: Environment to run the shell process in, if None
@@ -1398,7 +1426,7 @@ class ResolvedContext(object):
             Popen_args: args to pass to the shell process object constructor.
 
         Returns:
-            subprocess.Popen: Subprocess object for the shell process.
+            Subprocess object for the shell process.
         """
         def _actions_callback(executor: RexExecutor) -> None:
             executor.execute_code(code, filename=filename)
@@ -1444,11 +1472,11 @@ class ResolvedContext(object):
             block: If True, block until the shell is terminated. If False,
                 return immediately. If None, will default to blocking if the
                 shell is interactive.
-            actions_callback: Callback with signature (RexExecutor). This lets
+            actions_callback: Actions callback. This lets
                 the user append custom actions to the context, such as setting
                 extra environment variables. Callback is run prior to context Rex
                 execution.
-            post_actions_callback: Callback with signature (RexExecutor). This lets
+            post_actions_callback: Post-actions callback. This lets
                 the user append custom actions to the context, such as setting
                 extra environment variables. Callback is run after context Rex
                 execution.
@@ -1458,9 +1486,9 @@ class ResolvedContext(object):
                 up the file.
             start_new_session: If True, change the process group of the target
                 process. Note that this may override the Popen_args keyword
-                'preexec_fn'.
+                ``preexec_fn``.
             detached: If True, open a separate terminal. Note that this may
-                override the `pre_command` argument.
+                override the ``pre_command`` argument.
             pre_command: Command to inject before the shell command itself. This
                 is for internal use.
             Popen_args: args to pass to the shell process object constructor.
@@ -1468,9 +1496,9 @@ class ResolvedContext(object):
         Returns:
             If blocking, a 3-tuple of (returncode, stdout, stderr).
                 Note that if you want to get anything other than None for stdout
-                and/or stderr, you need to give stdout=PIPE and/or stderr=PIPE.
+                and/or stderr, you need to give ``stdout=PIPE`` and/or ``stderr=PIPE``.
 
-            If non-blocking, a subprocess.Popen object for the shell process.
+            If non-blocking, a :class:`.Popen` object for the shell process.
         """
         sh = create_shell(shell)
 
@@ -1559,13 +1587,14 @@ class ResolvedContext(object):
     def get_resolve_as_exact_requests(self) -> list[PackageRequest]:
         """Convert to a package request list of exact resolved package versions.
 
-            >>> r = ResolvedContext(['foo']
-            >>> r.get_resolve_as_exact_requests()
-            ['foo==1.2.3', 'bah==1.0.1', 'python==2.7.12']
+        .. code-block:: python
+
+           >>> r = ResolvedContext(['foo']
+           >>> r.get_resolve_as_exact_requests()
+           ['foo==1.2.3', 'bah==1.0.1', 'python==2.7.12']
 
         Returns:
-            List of `PackageRequest`: Context as a list of exact version
-            requests.
+            Context as a list of exact version requests.
         """
         def to_req(variant: Variant) -> PackageRequest:
             return PackageRequest(variant.parent.as_exact_requirement())
@@ -1576,12 +1605,12 @@ class ResolvedContext(object):
         """Convert context to dict containing only builtin types.
 
         Args:
-            fields (list of str): If present, only write these fields into the
+            fields: If present, only write these fields into the
                 dict. This can be used to avoid constructing expensive fields
                 (such as 'graph') for some cases.
 
         Returns:
-            dict: Dictified context.
+            Dictified context.
         """
         data: dict[str, Any] = {}
 
@@ -1673,11 +1702,11 @@ class ResolvedContext(object):
 
     @classmethod
     def from_dict(cls, d: dict, identifier_str: str | None = None) -> ResolvedContext:
-        """Load a `ResolvedContext` from a dict.
+        """Load a :class:`ResolvedContext` from a dict.
 
         Args:
-            d (dict): Dict containing context data.
-            identifier_str (str): String identifying the context, this is only
+            d: Dict containing context data.
+            identifier_str: String identifying the context, this is only
                 used to display in an error string if a serialization version
                 mismatch is detected.
 


### PR DESCRIPTION
This has been on my todo list for a long time and I decided to start while I I'm knee deep in Sphinx.

This PR cleans up the docstrings for 4 modules:
* `rez.config`
* `rez.package_repository`
* `rez.plugin_managers`
* `rez.resolved_context`

Note that this is mostly just cleaning up and adding more cross-references.

No LLM has been used. This is all manual work like in the good old days.