### PR TITLE
Improve configuration environment variable docs

### DIFF
--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -4,6 +4,7 @@ import argparse
 
 import rez.cli._main
 import rez.cli._util
+import rez.config
 import rez.rezconfig
 import docutils.nodes
 import sphinx.util.nodes
@@ -262,9 +263,49 @@ def convert_rez_config_to_rst() -> list[str]:
                 rst.append('')
 
                 envvar = f'REZ_{varname.upper()}'
-                rst.append(f'   .. envvar:: {envvar}')
+                setting_type = rez.config.config_schema._schema.get(varname)
+
+                if varname == 'plugins':
+                    # Plugins don't have a schema like the normal settings
+                    # have, so let's not document environment variables since
+                    # they effectively don't support them.
+                    assert setting_type is None
+                    continue
+
+                assert setting_type is not None
+
+                json_envvar = f'{envvar}_JSON'
+                if not setting_type.env_var_json_only:
+                    rst.append(f'   .. envvar:: {envvar}')
+                rst.append(f'   .. envvar:: {json_envvar}')
                 rst.append('')
-                rst.append(f'      The ``{envvar}`` environment variable can also be used to configure this.')
+
+                if setting_type.env_var_json_only:
+                    rst.append(
+                        f'      The non-JSON ``{envvar}`` environment variable is not supported. '
+                        f'Use ``{json_envvar}`` to configure this setting via an environment variable.'
+                    )
+                    rst.append('')
+                    continue
+
+                rst.append(
+                    f'      The ``{envvar}`` and ``{json_envvar}`` environment variables can also '
+                    'be used to configure this. The latter expects a JSON-encoded value.'
+                )
+                if issubclass(setting_type, rez.config.PathList):
+                    rst.append(
+                        f'      Values in ``{envvar}`` must be separated with ``:`` on Unix-like '
+                        'systems and ``;`` on Windows.'
+                    )
+                elif issubclass(setting_type, rez.config.StrList):
+                    rst.append(
+                        f'      Values in ``{envvar}`` can be separated by commas or whitespace.'
+                    )
+                elif issubclass(setting_type, rez.config.Dict):
+                    rst.append(
+                        f'      Dictionary values in ``{envvar}`` must use the format '
+                        '``k1:v1,k2:v2,...kN:vN``.'
+                    )
                 rst.append('')
 
     return rst

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -279,19 +279,23 @@ def convert_rez_config_to_rst() -> list[str]:
                     rst.append(f'   .. envvar:: {envvar}')
                 rst.append(f'   .. envvar:: {json_envvar}')
                 rst.append('')
+                envvars = [json_envvar]
+                if not setting_type.env_var_json_only:
+                    envvars.insert(0, envvar)
+                rst.append(
+                    '      :ref:`Environment variables '
+                    '<config-environment-variable-overrides>`: '
+                    + ', '.join(f'``{name}``' for name in envvars)
+                )
+                rst.append('')
 
                 if setting_type.env_var_json_only:
                     rst.append(
-                        f'      The non-JSON ``{envvar}`` environment variable is not supported. '
-                        f'Use ``{json_envvar}`` to configure this setting via an environment variable.'
+                        f'      The non-JSON ``{envvar}`` environment variable is not supported.'
                     )
                     rst.append('')
                     continue
 
-                rst.append(
-                    f'      The ``{envvar}`` and ``{json_envvar}`` environment variables can also '
-                    'be used to configure this. The latter expects a JSON-encoded value.'
-                )
                 if issubclass(setting_type, rez.config.PathList):
                     rst.append(
                         f'      Values in ``{envvar}`` must be separated with ``:`` on Unix-like '

--- a/docs/rez_sphinxext.py
+++ b/docs/rez_sphinxext.py
@@ -275,39 +275,32 @@ def convert_rez_config_to_rst() -> list[str]:
                 assert setting_type is not None
 
                 json_envvar = f'{envvar}_JSON'
-                if not setting_type.env_var_json_only:
-                    rst.append(f'   .. envvar:: {envvar}')
-                rst.append(f'   .. envvar:: {json_envvar}')
+                rst.append('   Environment variables:')
                 rst.append('')
-                envvars = [json_envvar]
                 if not setting_type.env_var_json_only:
-                    envvars.insert(0, envvar)
-                rst.append(
-                    '      :ref:`Environment variables '
-                    '<config-environment-variable-overrides>`: '
-                    + ', '.join(f'``{name}``' for name in envvars)
-                )
+                    rst.append(f'      .. envvar:: {envvar}')
+                rst.append(f'      .. envvar:: {json_envvar}')
                 rst.append('')
 
                 if setting_type.env_var_json_only:
                     rst.append(
-                        f'      The non-JSON ``{envvar}`` environment variable is not supported.'
+                        f'         The non-JSON ``{envvar}`` environment variable is not supported.'
                     )
                     rst.append('')
                     continue
 
                 if issubclass(setting_type, rez.config.PathList):
                     rst.append(
-                        f'      Values in ``{envvar}`` must be separated with ``:`` on Unix-like '
+                        f'         Values in ``{envvar}`` must be separated with ``:`` on Unix-like '
                         'systems and ``;`` on Windows.'
                     )
                 elif issubclass(setting_type, rez.config.StrList):
                     rst.append(
-                        f'      Values in ``{envvar}`` can be separated by commas or whitespace.'
+                        f'         Values in ``{envvar}`` can be separated by commas or whitespace.'
                     )
                 elif issubclass(setting_type, rez.config.Dict):
                     rst.append(
-                        f'      Dictionary values in ``{envvar}`` must use the format '
+                        f'         Dictionary values in ``{envvar}`` must use the format '
                         '``k1:v1,k2:v2,...kN:vN``.'
                     )
                 rst.append('')

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -12,9 +12,11 @@ Settings are determined in the following way:
   :envvar:`REZ_CONFIG_FILE` environment variable. This can also be a path-like variable, to read from
   multiple configuration files;
 - The setting is further overridden if it is present in ``$HOME/.rezconfig`` or ``$HOME/.rezconfig.py``;
+- The setting is overridden again if the environment variable :envvar:`REZ_XXX_JSON` is present, where ``XXX``
+  is the uppercase version of the setting key. Its value must be JSON-encoded;
 - The setting is overridden again if the environment variable :envvar:`REZ_XXX` is present, where ``XXX`` is
   the uppercase version of the setting key. For example, :data:`.image_viewer` will be overridden by
-  :envvar:`REZ_IMAGE_VIEWER`.
+  :envvar:`REZ_IMAGE_VIEWER`. This form takes precedence if both environment variables are present;
 - This is a special case applied only during a package build or release. In this case, if the
   package definition file contains a "config" section, settings in this section will override all
   others. See :ref:`configuring-rez-package-overrides`.

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -219,6 +219,8 @@ operation of rez.
 
    Path to a rez configuration file.
 
+.. _config-environment-variable-overrides:
+
 .. envvar:: REZ_XXX
 
    For any given rez config entry (see ``rezconfig.py``),
@@ -235,6 +237,7 @@ operation of rez.
    Same as :envvar:`REZ_XXX`, except that the format
    is a JSON string. This means that some more complex settings can be overridden,
    that aren't supported in the non-JSON case (:data:`package_filter` is an example).
+   If both forms are present, :envvar:`REZ_XXX` takes precedence.
 
 .. envvar:: REZ_DISABLE_HOME_CONFIG
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -115,8 +115,9 @@ class Setting(object):
                     )
                 if self.env_var_json_only:
                     raise ConfigurationError(
-                        "$%s is not supported for this setting; use $%s_JSON instead."
-                        % (self._env_var_name, self._env_var_name)
+                        "The setting %r doesn't support the environment variable $%s, "
+                        "use $%s_JSON instead."
+                        % (self.key, self._env_var_name, self._env_var_name)
                     )
                 return self._parse_env_var(value)
 

--- a/src/rez/config.py
+++ b/src/rez/config.py
@@ -67,6 +67,10 @@ class Setting(object):
     """
     schema: Validatable = Schema(object)
 
+    # Only set to True in subclasses when the non-JSON
+    # env var cannot be used by users.
+    env_var_json_only = False
+
     def __init__(self, config, key) -> None:
         self.config = config
         self.key = key
@@ -96,7 +100,8 @@ class Setting(object):
 
         if not self.config.locked:
 
-            # next, env-var
+            # next, env-var. Note that all settings support _JSON
+            # but not all support the non-JSON variant.
             value = os.getenv(self._env_var_name)
             if value is not None:
                 if self.key in _deprecated_settings:
@@ -107,6 +112,11 @@ class Setting(object):
                         rez.deprecations.RezDeprecationWarning,
                         pre_formatted=True,
                         filename=self._env_var_name,
+                    )
+                if self.env_var_json_only:
+                    raise ConfigurationError(
+                        "$%s is not supported for this setting; use $%s_JSON instead."
+                        % (self._env_var_name, self._env_var_name)
                     )
                 return self._parse_env_var(value)
 
@@ -180,6 +190,7 @@ class PipInstallRemaps(Setting):
     KEYS = ["record_path", "pip_install", "rez_install"]
 
     schema = Schema([{key: And(str, len) for key in KEYS}])
+    env_var_json_only = True
 
     def validate(self, data: list) -> list:
         """Extended to substitute regex-escaped path tokens."""
@@ -302,6 +313,7 @@ class OptionalDictOrDictList(Setting):
     schema = Or(And(None, Use(lambda x: [])),
                 And(dict, Use(lambda x: [x])),
                 [dict])
+    env_var_json_only = True
 
 
 class SuiteVisibility_(Str):

--- a/src/rez/rezconfig.py
+++ b/src/rez/rezconfig.py
@@ -14,13 +14,15 @@ precedence):
    files are supported, separated by os.pathsep;
 3) The setting is further overriden if it is present in $HOME/.rezconfig,
   UNLESS $REZ_DISABLE_HOME_CONFIG is 1;
-4) The setting is overridden again if the environment variable $REZ_XXX is
+4) The setting can also be overridden by the environment variable
+   $REZ_XXX_JSON, and in this case the string is expected to be a JSON-encoded
+   value;
+5) The setting is overridden again if the environment variable $REZ_XXX is
    present, where XXX is the uppercase version of the setting key. For example,
    "image_viewer" will be overriden by $REZ_IMAGE_VIEWER. List values can be
    separated either with "," or blank space. Dict values are in the form
-   "k1:v1,k2:v2,kn:vn";
-5) The setting can also be overriden by the environment variable $REZ_XXX_JSON,
-   and in this case the string is expected to be a JSON-encoded value;
+   "k1:v1,k2:v2,kn:vn". This form takes precedence if both environment
+   variables are present;
 6) This is a special case applied only during a package build or release. In
    this case, if the package definition file contains a "config" section,
    settings in this section will override all others.

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -309,8 +309,9 @@ class TestConfig(TestBase):
 
                 self.assertEqual(
                     str(error.exception),
-                    "$%s is not supported for this setting; use $%s_JSON instead."
-                    % (env_var, env_var),
+                    "The setting %r doesn't support the environment variable $%s, "
+                    "use $%s_JSON instead."
+                    % (key, env_var, env_var),
                 )
 
 

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -314,6 +314,15 @@ class TestConfig(TestBase):
                     % (key, env_var, env_var),
                 )
 
+    def test_10_environment_variable_precedence(self) -> None:
+        """Test that the plain environment variable takes precedence."""
+        with restore_os_environ():
+            os.environ["REZ_IMAGE_VIEWER"] = "plain"
+            os.environ["REZ_IMAGE_VIEWER_JSON"] = '"json"'
+            config = Config([self.root_config_file], locked=False)
+
+            self.assertEqual(config.image_viewer, "plain")
+
 
 class TestDeprecations(TestBase, TempdirMixin):
     @classmethod

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -8,7 +8,7 @@ test configuration settings
 import unittest
 from rez.tests.util import TestBase, TempdirMixin, restore_os_environ
 from rez.exceptions import ConfigurationError
-from rez.config import Config, get_module_root_config, _replace_config, _Deprecation
+from rez.config import Config, get_module_root_config, _replace_config, _Deprecation, Setting
 from rez.system import system
 from rez.utils.data_utils import RO_AttrDictWrapper
 from rez.packages import get_developer_package
@@ -315,13 +315,44 @@ class TestConfig(TestBase):
                 )
 
     def test_10_environment_variable_precedence(self) -> None:
-        """Test that the plain environment variable takes precedence."""
+        """Test that the plain environment variable takes precedence over the JSON variant."""
         with restore_os_environ():
             os.environ["REZ_IMAGE_VIEWER"] = "plain"
             os.environ["REZ_IMAGE_VIEWER_JSON"] = '"json"'
             config = Config([self.root_config_file], locked=False)
 
             self.assertEqual(config.image_viewer, "plain")
+
+    def test_11_all_settings_declare_environment_variable_support(self) -> None:
+        """Test that env_var_json_only and _parse_env_var are aligned and agree.
+
+        This should guard against accidental misuse of the feature.
+        """
+        def get_sublcasses(obj: type):
+            subclasses = obj.__subclasses__()
+            for subclass in subclasses:
+                subclasses.extend(get_sublcasses(subclass))
+
+            return subclasses
+
+        for setting_type in get_sublcasses(Setting):
+            with self.subTest(key=setting_type.__name__):
+                if setting_type.env_var_json_only:
+                    self.assertTrue(
+                        setting_type._parse_env_var is Setting._parse_env_var,
+                        msg=(
+                            f"{setting_type.__name__!r}.env_var_json_only is True. The class "
+                            "must not implement the _parse_env_var method."
+                        ),
+                    )
+                else:
+                    self.assertTrue(
+                        setting_type._parse_env_var is not Setting._parse_env_var,
+                        msg=(
+                            f"{setting_type.__name__!r}.env_var_json_only is False. The class "
+                            "must implement the _parse_env_var method."
+                        )
+                    )
 
 
 class TestDeprecations(TestBase, TempdirMixin):

--- a/src/rez/tests/test_config.py
+++ b/src/rez/tests/test_config.py
@@ -296,6 +296,23 @@ class TestConfig(TestBase):
                 print(error.stdout)
                 raise
 
+    def test_9_json_only_environment_variable(self) -> None:
+        """Test the error when a JSON-only setting uses its plain env var."""
+        for key in ("package_orderers", "pip_install_remaps"):
+            with self.subTest(key=key), restore_os_environ():
+                env_var = "REZ_%s" % key.upper()
+                os.environ[env_var] = "invalid"
+                config = Config([self.root_config_file], locked=False)
+
+                with self.assertRaises(ConfigurationError) as error:
+                    getattr(config, key)
+
+                self.assertEqual(
+                    str(error.exception),
+                    "$%s is not supported for this setting; use $%s_JSON instead."
+                    % (env_var, env_var),
+                )
+
 
 class TestDeprecations(TestBase, TempdirMixin):
     @classmethod


### PR DESCRIPTION
We've had a gap for years now in regards to config settings environment variables. I partly filled that gap when I introduced https://rez.readthedocs.io/en/stable/environment.html and the automatic documentation of env vars in settings (https://rez.readthedocs.io/en/stable/configuring_rez.html#envvar-REZ_CONTEXT_TMPDIR), but there was still a major missing piece.

Some of our settings can only be configured via an environment variable suffixed with `_JSON`.

This PR properly documents those and also documents that all settings be set via `REZ_XXX_JSON`. I also took the occasion to document the format of some env vars too.

With this, I think we can finally say that all our settings and env vars are properly documented. At least I think, until someone comes in to tell me that we missed something :smile:

Lastly, I also fixed an old bug that was triggered when a user was setting a setting via an env var but without the JSON suffix for a setting that only supports JSON. Rez was raising a fat from helpful `NotImplementedError`. With the fix, rez raises an actionable exception.

AI usage: I started with an LLM and then reworked the results a bit and continued to iterate with it after.

Amp-Thread-ID: https://ampcode.com/threads/T-01a02b3d-dd38-7533-abe8-4844dadda902