### PR TITLE
Speed up plugin discovery

### DIFF
--- a/src/rez/plugin_managers.py
+++ b/src/rez/plugin_managers.py
@@ -15,6 +15,8 @@ from rez.utils.logging_ import print_debug, print_warning
 from rez.exceptions import RezPluginError
 from zipimport import zipimporter
 from typing import overload, Any, Literal, TypeVar, TYPE_CHECKING
+from importlib.machinery import FileFinder, all_suffixes
+from functools import lru_cache
 import pkgutil
 import os.path
 import sys
@@ -36,6 +38,25 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
+
+
+def _entry_points_cache_key():
+    """Describe import locations closely enough to detect installations."""
+    result = []
+    for path in sys.path:
+        path = path or os.getcwd()
+        try:
+            mtime = os.stat(path).st_mtime_ns
+        except OSError:
+            mtime = None
+        result.append((path, mtime))
+    return tuple(result)
+
+
+@lru_cache(maxsize=1)
+def _get_entry_points(_cache_key):
+    """Discover installed entry points once for all plugin types."""
+    return entry_points()
 
 
 # modified from pkgutil standard library:
@@ -98,6 +119,83 @@ def extend_path(path, name):
 def uncache_rezplugins_module_paths(instance=None) -> None:
     instance = instance or plugin_manager
     cached_property.uncache(instance, "rezplugins_module_paths")  # type: ignore[attr-defined]
+    _get_entry_points.cache_clear()
+
+
+def _iter_top_level_modules():
+    """Find the top-level modules that could contain a rez plugin package.
+
+    Rez plugins can be shipped inside another Python package. For example, a
+    distribution might install::
+
+        studio_tools/
+            __init__.py
+            rezplugins/
+                __init__.py
+
+    To find packages like ``studio_tools``, rez has to look at each directory
+    on ``sys.path``. ``pkgutil.iter_modules()`` can do that, but its generic
+    filesystem implementation does considerably more work per directory entry
+    than we need here. Plugin discovery calls this while rez is starting, so
+    that extra work is noticeable in repositories with a large Python
+    environment.
+
+    For normal filesystem paths we reproduce the relevant ``pkgutil``
+    behaviour with ``os.scandir()`` and simple import-suffix checks. We still
+    yield ordinary modules such as ``tools.py`` as well as packages such as
+    ``studio_tools`` so that ordering and duplicate handling match
+    ``pkgutil.iter_modules()``; the caller decides which entries can actually
+    contain ``rezplugins``. ZIP files and custom importers are less common and
+    cannot be inspected this way, so they continue to use ``pkgutil``.
+    """
+    yielded = set()
+    suffixes = all_suffixes()
+
+    for path in sys.path:
+        importer = pkgutil.get_importer(path)
+        if isinstance(importer, FileFinder):
+            try:
+                entries = sorted(os.scandir(importer.path), key=lambda x: x.name)
+            except OSError:
+                continue
+
+            for entry in entries:
+                try:
+                    is_dir = entry.is_dir()
+                except OSError:
+                    continue
+
+                if is_dir:
+                    name = entry.name
+                    if '.' in name:
+                        continue
+                    ispkg = any(
+                        os.path.isfile(os.path.join(entry.path, "__init__" + suffix))
+                        for suffix in suffixes
+                    )
+                    if not ispkg:
+                        continue
+                else:
+                    name = next(
+                        (entry.name[:-len(suffix)] for suffix in suffixes
+                         if entry.name.endswith(suffix)),
+                        None,
+                    )
+                    if not name:
+                        continue
+                    ispkg = False
+
+                if name == "__init__" or '.' in name:
+                    continue
+
+                if name not in yielded:
+                    yielded.add(name)
+                    yield importer, name, ispkg
+        else:
+            for importer_, name, ispkg in pkgutil.iter_modules([path]):
+                if name not in yielded:
+                    yielded.add(name)
+                    yield importer_, name, ispkg
 
 
 class RezPluginType(object):
@@ -117,6 +215,7 @@ class RezPluginType(object):
         self.failed_plugins: dict[str, str] = {}
         self.plugin_modules: dict[str, types.ModuleType] = {}
         self.config_data = {}
+        self._loaded_config_paths = set()
         self.load_plugins()
 
     def __repr__(self) -> str:
@@ -195,10 +294,11 @@ class RezPluginType(object):
         if config.debug("plugins"):
             print_debug("searching plugin for entry point %r...", entry_point_name)
 
+        plugin_entry_points = _get_entry_points(_entry_points_cache_key())
         if sys.version_info[:2] >= (3, 8) and sys.version_info[:2] <= (3, 9):
-            discovered_plugins = entry_points().get(entry_point_name, [])
+            discovered_plugins = plugin_entry_points.get(entry_point_name, [])
         else:
-            discovered_plugins = entry_points(group=entry_point_name)
+            discovered_plugins = plugin_entry_points.select(group=entry_point_name)
 
         for plugin in discovered_plugins:
             if config.debug("plugins"):
@@ -228,8 +328,13 @@ class RezPluginType(object):
 
     def load_config_from_plugin(self, plugin):
         plugin_path = os.path.dirname(plugin.__file__)
-        data, _ = _load_config_from_filepaths([os.path.join(plugin_path, "rezconfig")])
+        config_path = os.path.join(plugin_path, "rezconfig")
+        if config_path in self._loaded_config_paths:
+            return
+
+        data, _ = _load_config_from_filepaths([config_path])
         deep_update(self.config_data, data)
+        self._loaded_config_paths.add(config_path)
 
     def register_plugin_module(self, plugin_name, plugin_module, plugin_path):
         module_name = plugin_module.__name__
@@ -356,7 +461,7 @@ class RezPluginManager(object):
     @cached_property
     def rezplugins_module_paths(self):
         paths = []
-        for importer, name, ispkg in pkgutil.iter_modules():
+        for importer, name, ispkg in _iter_top_level_modules():
             if not ispkg:
                 continue
 

--- a/src/rez/tests/test_plugin_manager.py
+++ b/src/rez/tests/test_plugin_manager.py
@@ -8,6 +8,7 @@ test rezplugins manager behaviors
 from rez.tests.util import TestBase, TempdirMixin, restore_sys_path
 from rez.plugin_managers import plugin_manager, uncache_rezplugins_module_paths
 from rez.package_repository import package_repository_manager
+from unittest.mock import patch
 import sys
 import unittest
 
@@ -75,6 +76,28 @@ class TestPluginManagers(TestBase, TempdirMixin):
             baz_cls = plugin_manager.get_plugin_class("command", "baz_cmd")
             self.assertEqual(baz_cls.name(), "baz_cmd")
 
+    def test_discovers_entry_points_once_for_all_plugin_types(self) -> None:
+        """Installed distributions are scanned once across plugin types."""
+        from rez.plugin_managers import entry_points
+
+        with patch("rez.plugin_managers.entry_points", wraps=entry_points) as discover:
+            plugin_manager.get_plugins("shell")
+            plugin_manager.get_plugins("release_vcs")
+
+        discover.assert_called_once_with()
+
+    def test_rediscovers_entry_points_when_sys_path_changes(self) -> None:
+        """Changing import locations invalidates entry-point discovery."""
+        from rez.plugin_managers import entry_points
+
+        with patch("rez.plugin_managers.entry_points", wraps=entry_points) as discover:
+            plugin_manager.get_plugins("shell")
+            with restore_sys_path():
+                sys.path.append(self.data_path("extensions"))
+                plugin_manager.get_plugins("release_vcs")
+
+        self.assertEqual(discover.call_count, 2)
+
     def test_plugin_override_1(self) -> None:
         """Test plugin from plugin_path can override the default"""
         self.update_settings(dict(
@@ -107,6 +130,20 @@ class TestPluginManagers(TestBase, TempdirMixin):
             mem_cls = plugin_manager.get_plugin_class(
                 "package_repository", "memory")
             self.assertEqual("bar", mem_cls.on_test)
+
+    def test_loads_config_once_per_plugin_path(self) -> None:
+        """Each plugin directory's shared config is loaded only once."""
+        from rez.plugin_managers import _load_config_from_filepaths
+
+        with patch(
+            "rez.plugin_managers._load_config_from_filepaths",
+            wraps=_load_config_from_filepaths,
+        ) as load_config:
+            plugin_manager.get_plugins("shell")
+
+        config_paths = [call.args[0][0] for call in load_config.call_args_list]
+        self.assertGreater(len(config_paths), 0)
+        self.assertEqual(len(config_paths), len(set(config_paths)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Leaving as draft until I get the time to polish and fully review the tests and think about potential unexpected side effects.

## Summary

Plugin discovery was spending a surprising amount of time repeatedly scanning Python packages, installed entry-point metadata, and shared plugin configuration.

This changes the discovery path in three places:

- Uses an `os.scandir()` fast path when looking for top-level packages that may contain `rezplugins`.
- Discovers installed entry points once and shares the result across plugin types. The cache is invalidated when `sys.path` or its directory mtimes change.
- Loads `rezconfig` once per plugin directory instead of once per plugin module.

ZIP files and custom importers still fall back to `pkgutil`, so those discovery mechanisms continue to work as before.

## Performance

The benchmark repeatedly resets and loads all seven plugin types for 100 discovery cycles. It excludes the unrelated import optimizations investigated earlier.

| Measurement | Before | After | Improvement |
|---|---:|---:|---:|
| Overall plugin discovery/loading | 1.146 s | 548.2 ms | 2.09× faster |
| Top-level `rezplugins` discovery | 1.203 s | 297 ms | 4.05× faster |
| Entry-point discovery | 850 ms | 249 ms | 3.41× faster |
| Shared plugin config loading | 231 ms | 55 ms | 4.20× faster |

The individual timings are cumulative `cProfile` results over the repeated workload run using hyperfine, so they are not intended to add up to the `hyperfine` wall-clock result.

## Testing

- Added coverage ensuring entry-point metadata is discovered once across plugin types.
- Added coverage ensuring entry points are rediscovered after `sys.path` changes.
- Added coverage ensuring shared plugin configuration is loaded once per plugin path.
- Existing plugin-manager tests pass.
- Verified the optimized scanner returns the same ordered module set as `pkgutil.iter_modules()` in the benchmark environment.

## AI usage

This was mostly generated by an LLM with a lot of babysitting.

Amp-Thread-ID: https://ampcode.com/threads/T-01a0771d-16ef-7787-b60b-eb71b1cc8a4b (sorry in advanced for cursing a bit in that thread... The models were gaslighting me in multiple threads all trying to inline dozens of imports to find performance gains).