### PR TITLE
Uncached os.listdir() in _get_family() causes much slower resolves on Windows

### DIFF
--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1151,9 +1151,10 @@ class FileSystemPackageRepository(PackageRepository):
         is_valid_package_name(name, raise_error=True)
         if os.path.isdir(os.path.join(self.location, name)):
             # force case-sensitive match on pkg family dir, on case-insensitive platforms
-            if not platform_.has_case_sensitive_filesystem and \
-                    name not in os.listdir(self.location):
-                return None
+            if not platform_.has_case_sensitive_filesystem:
+                dirs = set(dir_name for (dir_name, ext) in self._get_family_dirs() if ext is None)
+                if name not in dirs:
+                    return None
 
             return self.get_resource(
                 FileSystemPackageFamilyResource.key,
@@ -1166,7 +1167,8 @@ class FileSystemPackageRepository(PackageRepository):
                 # force case-sensitive match on pkg filename, on case-insensitive platforms
                 if not platform_.has_case_sensitive_filesystem:
                     ext = os.path.splitext(filepath)[-1]
-                    if (name + ext) not in os.listdir(self.location):
+                    filenames = set("%s.%s" % (filename, extension) for filename, extension in self._get_family_dirs() if extension)
+                    if (name + ext) not in filenames:
                         return None
 
                 return self.get_resource(

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -556,6 +556,14 @@ class FileSystemPackageRepository(PackageRepository):
             )
             self._get_version_dirs = decorator2(self._get_version_dirs)
 
+            decorator3 = memcached(
+                servers=config.memcached_uri if config.cache_listdir else None,
+                min_compress_len=config.memcached_listdir_min_compress_len,
+                key=self._get_dir_listing__key,
+                debug=config.debug_memcache
+            )
+            self._get_dir_listing = decorator3(self._get_dir_listing)
+
     def _uid(self) -> tuple:
         t = ["filesystem", self.location]
         if os.path.exists(self.location):
@@ -1019,6 +1027,7 @@ class FileSystemPackageRepository(PackageRepository):
         if not self.disable_memcache:
             self._get_family_dirs.forget()
             self._get_version_dirs.forget()
+            self._get_dir_listing.forget()
 
         # unfortunately we need to clear file cache across the board
         clear_file_caches()
@@ -1061,6 +1070,18 @@ class FileSystemPackageRepository(PackageRepository):
                     dirs.append((name_, ext_[1:]))
 
         return dirs
+
+    def _get_dir_listing__key(self):
+        if os.path.isdir(self.location):
+            st = os.stat(self.location)
+            return str(("dirlisting", self.location, int(st.st_ino), st.st_mtime))
+        else:
+            return str(("dirlisting", self.location))
+
+    def _get_dir_listing(self):
+        if not os.path.isdir(self.location):
+            return []
+        return os.listdir(self.location)
 
     def _get_version_dirs__key(self, root: str) -> str:
         st = os.stat(root)
@@ -1151,10 +1172,9 @@ class FileSystemPackageRepository(PackageRepository):
         is_valid_package_name(name, raise_error=True)
         if os.path.isdir(os.path.join(self.location, name)):
             # force case-sensitive match on pkg family dir, on case-insensitive platforms
-            if not platform_.has_case_sensitive_filesystem:
-                dirs = set(dir_name for (dir_name, ext) in self._get_family_dirs() if ext is None)
-                if name not in dirs:
-                    return None
+            if not platform_.has_case_sensitive_filesystem and \
+                    name not in self._get_dir_listing():
+                return None
 
             return self.get_resource(
                 FileSystemPackageFamilyResource.key,
@@ -1166,9 +1186,8 @@ class FileSystemPackageRepository(PackageRepository):
             if filepath:
                 # force case-sensitive match on pkg filename, on case-insensitive platforms
                 if not platform_.has_case_sensitive_filesystem:
-                    extension = os.path.splitext(filepath)[-1]
-                    filenames = set("%s.%s" % (fname, ext) for (fname, ext) in self._get_family_dirs() if ext)
-                    if (name + extension) not in filenames:
+                    ext = os.path.splitext(filepath)[-1]
+                    if (name + ext) not in self._get_dir_listing():
                         return None
 
                 return self.get_resource(

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1166,9 +1166,9 @@ class FileSystemPackageRepository(PackageRepository):
             if filepath:
                 # force case-sensitive match on pkg filename, on case-insensitive platforms
                 if not platform_.has_case_sensitive_filesystem:
-                    ext = os.path.splitext(filepath)[-1]
-                    filenames = set("%s.%s" % (filename, extension) for filename, extension in self._get_family_dirs() if extension)
-                    if (name + ext) not in filenames:
+                    extension = os.path.splitext(filepath)[-1]
+                    filenames = set("%s.%s" % (fname, ext) for (fname, ext) in self._get_family_dirs() if ext)
+                    if (name + extension) not in filenames:
                         return None
 
                 return self.get_resource(


### PR DESCRIPTION
Hi all,

I was seeing extremely slow resolve times on Windows, even with memcached showing a 99% hit rate. I caught that `os.listdir()` was being called for every package check. I changed this to use the decorated `_get_familydirs()` and noticed that resolve times were now instant. I'm new to Rez so I don't know if this is the correct way to handle this, but it seems to be working now as intended.

Thanks!
Mandeep